### PR TITLE
feat: 글로벌 예외 처리 프레임워크 구축

### DIFF
--- a/back/src/main/java/com/qmate/exception/BusinessGlobalException.java
+++ b/back/src/main/java/com/qmate/exception/BusinessGlobalException.java
@@ -1,0 +1,16 @@
+package com.qmate.exception;
+
+import lombok.Getter;
+
+@Getter
+public abstract class BusinessGlobalException extends RuntimeException{
+
+  private final ErrorCode errorCode;
+
+  public BusinessGlobalException(ErrorCode errorCode){
+    super(errorCode.getMessage());
+    this.errorCode = errorCode;
+  }
+
+
+}

--- a/back/src/main/java/com/qmate/exception/ErrorCode.java
+++ b/back/src/main/java/com/qmate/exception/ErrorCode.java
@@ -1,0 +1,25 @@
+package com.qmate.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+
+  //일반적인 오류
+  INVALID_INPUT(HttpStatus.BAD_REQUEST, "INVALID_INPUT","잘못된 입력입니다."),
+  UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED", "인증에 실패했습니다."),
+  FORBIDDEN(HttpStatus.FORBIDDEN, "FORBIDDEN", "접근 권한이 없습니다."),
+  RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "RESOURCE_NOT_FOUND", "요청한 자원을 찾을 수 없습니다."),
+  INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR", "서버 내부 오류가 발생했습니다."),
+
+  //매칭 관련 오류
+  INVITE_CODE_EXPIRED(HttpStatus.NOT_FOUND, "INVITE_CODE_EXPIRED", "초대 코드가 만료되었거나 유효하지 않습니다."),
+  ALREADY_IN_MATCH(HttpStatus.CONFLICT, "ALREADY_IN_MATCH", "이미 매칭에 속해 있습니다.");
+
+  private final HttpStatus httpStatus;  //HTTP 상태 코드
+  private final String code;  //비즈니스 에러 코드
+  private final String message; //사용자에게 보여줄 기본 메시지
+}

--- a/back/src/main/java/com/qmate/exception/ErrorResponse.java
+++ b/back/src/main/java/com/qmate/exception/ErrorResponse.java
@@ -1,0 +1,28 @@
+package com.qmate.exception;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ErrorResponse {
+  private final String errorCode;
+  private final String message;
+  private final List<FieldErrorDetail> errors;
+
+  // Validation 에러를 위한 내부 클래스
+  @Getter
+  @AllArgsConstructor
+  public static class FieldErrorDetail{
+    private final String field;
+    private final String defaultMessage;
+  }
+
+  //일반 에러 처리를 위한 생성자 오버로딩
+  public ErrorResponse(String errorCode, String message){
+    this(errorCode,message,null);
+  }
+
+
+}

--- a/back/src/main/java/com/qmate/exception/GlobalExceptionHandler.java
+++ b/back/src/main/java/com/qmate/exception/GlobalExceptionHandler.java
@@ -1,0 +1,96 @@
+package com.qmate.exception;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authorization.AuthorizationDeniedException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+  // 비즈니스 로직에서 던지는 커스텀 예외는 여기서 처리
+  @ExceptionHandler(BusinessGlobalException.class)
+  public ResponseEntity<ErrorResponse> handleBusinessException(BusinessGlobalException ex) {
+    return new ResponseEntity<>(
+        new ErrorResponse(ex.getErrorCode().getCode(), ex.getMessage()),
+        ex.getErrorCode().getHttpStatus()
+    );
+  }
+
+  //유효성 검사 실패 예외를 처리하는 핸들러
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<ErrorResponse> handleValidationException(
+      MethodArgumentNotValidException ex) {
+    log.warn("유효성 검사 실패: {}", ex.getMessage());
+
+    // FieldError를 추출하여 상세 에러 목록을 만듭니다.
+    List<ErrorResponse.FieldErrorDetail> errors = ex.getBindingResult()
+        .getFieldErrors()
+        .stream()
+        .map(fieldError -> new ErrorResponse.FieldErrorDetail(fieldError.getField(),
+            fieldError.getDefaultMessage()))
+        .toList();
+    // 400 BAD_REQUEST와 함께 상세 에러 목록을 반환
+    return ResponseEntity.badRequest().body(new ErrorResponse(
+        ErrorCode.INVALID_INPUT.getCode(),
+        ErrorCode.INVALID_INPUT.getMessage(),
+        errors
+    ));
+
+  }
+
+  //인증 실패 예외를 처리하는 핸들러(401)
+  @ExceptionHandler(AuthenticationException.class)
+  public ResponseEntity<ErrorResponse> handleAuthenticationException(AuthenticationException ex) {
+    log.warn("인증 실패: {}", ex.getMessage());
+    return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new ErrorResponse(
+        ErrorCode.UNAUTHORIZED.getCode(),
+        ErrorCode.UNAUTHORIZED.getMessage(),
+        null
+    ));
+  }
+
+  // 접근 권한 관련 예외를 처리하는 핸들러
+  @ExceptionHandler(AuthorizationDeniedException.class)
+  public ResponseEntity<ErrorResponse> handleAuthorizationDeniedException(
+      AuthorizationDeniedException ex) {
+    log.warn("권한이 없는 접근 시도: {}", ex.getMessage());
+
+    // 403 FORBIDDEN 상태를 반환
+    return ResponseEntity.status(HttpStatus.FORBIDDEN).body(new ErrorResponse(
+        ErrorCode.FORBIDDEN.getCode(),
+        ErrorCode.FORBIDDEN.getMessage(),
+        null
+    ));
+  }
+
+  //자주 발생하는 일반 예외들 처리(400,404)
+  @ExceptionHandler({IllegalArgumentException.class, NoSuchElementException.class})
+  public ResponseEntity<ErrorResponse> handleArgumentException(Exception ex) {
+    log.warn("유효하지 않은 인자: {}", ex.getMessage());
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorResponse(
+        ErrorCode.INVALID_INPUT.getCode(),
+        ex.getMessage(),
+        null
+    ));
+  }
+
+  // 예상치 못한 모든 예외를 처리 500 에러
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<ErrorResponse> handleGeneralException(Exception ex) {
+    log.error("알 수 없는 에러 발생", ex);
+    ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
+    return new ResponseEntity<>(
+        new ErrorResponse(errorCode.getCode(), errorCode.getMessage()),
+        errorCode.getHttpStatus()
+    );
+  }
+
+}

--- a/back/src/main/java/com/qmate/exception/custom/AlreadyInMatchException.java
+++ b/back/src/main/java/com/qmate/exception/custom/AlreadyInMatchException.java
@@ -1,0 +1,12 @@
+package com.qmate.exception.custom;
+
+import com.qmate.exception.BusinessGlobalException;
+import com.qmate.exception.ErrorCode;
+
+//이미 매칭 참여 예외
+public class AlreadyInMatchException extends BusinessGlobalException {
+  public AlreadyInMatchException(){
+    super(ErrorCode.ALREADY_IN_MATCH);
+  }
+
+}

--- a/back/src/main/java/com/qmate/exception/custom/InviteCodeExpiredException.java
+++ b/back/src/main/java/com/qmate/exception/custom/InviteCodeExpiredException.java
@@ -1,0 +1,12 @@
+package com.qmate.exception.custom;
+
+import com.qmate.exception.BusinessGlobalException;
+import com.qmate.exception.ErrorCode;
+
+//초대코드 만료 또는 유효하지 않음 예외
+public class InviteCodeExpiredException extends BusinessGlobalException {
+  public InviteCodeExpiredException(){
+    super(ErrorCode.INVITE_CODE_EXPIRED);
+  }
+
+}

--- a/back/src/main/java/com/qmate/exception/custom/MatchNotFoundException.java
+++ b/back/src/main/java/com/qmate/exception/custom/MatchNotFoundException.java
@@ -1,0 +1,12 @@
+package com.qmate.exception.custom;
+
+import com.qmate.exception.BusinessGlobalException;
+import com.qmate.exception.ErrorCode;
+
+//매칭을 찾을 수 없음 예외.
+public class MatchNotFoundException extends BusinessGlobalException {
+  public MatchNotFoundException(){
+    super(ErrorCode.RESOURCE_NOT_FOUND);
+  }
+
+}


### PR DESCRIPTION
변경사항
AS-IS (현재)

프로젝트 전반의 예외 처리 시스템이 구축되어 있지 않아, 예외 발생 시 기본 오류 메시지가 노출될 수 있었습니다.


TO-BE (변경 후)

글로벌 예외 처리 프레임워크 구축: GlobalExceptionHandler를 도입하여 모든 예외를 중앙에서 처리하도록 설계했습니다.

비즈니스 예외 분리: BusinessGlobalException을 상속받는 커스텀 예외들을 정의하여, 비즈니스 로직에서 발생하는 오류를 명확하게 구분할 수 있게 되었습니다.

표준화된 에러 응답: 모든 예외 발생 시 ErrorCode를 활용한 400, 404, 409 등 명확한 HTTP 상태 코드와 에러 메시지를 포함하는 통일된 JSON 응답을 반환하도록 개선했습니다.


다음 작업
매칭 엔티티 및 레포지토리 구현 후, 예외 처리 프레임워크를 적용하여 매칭 생성/참여 로직을 개발할 예정입니다.