### PR TITLE
feat(auth): Redis 기반 이메일 인증 플로우 구현 및 회원가입 연동

### DIFF
--- a/back/build.gradle
+++ b/back/build.gradle
@@ -25,6 +25,7 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
@@ -37,6 +38,11 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    //Jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/back/src/main/java/com/qmate/api/AuthController.java
+++ b/back/src/main/java/com/qmate/api/AuthController.java
@@ -1,9 +1,12 @@
 package com.qmate.api;
 
+import com.qmate.domain.auth.EmailVerificationService;
+import com.qmate.domain.auth.model.request.EmailVerificationSendRequest;
 import com.qmate.domain.user.UserService;
 import com.qmate.domain.user.model.request.RegisterRequest;
 import com.qmate.domain.user.model.response.RegisterResponse;
 import jakarta.validation.Valid;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -16,13 +19,19 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/auth")
 @RequiredArgsConstructor
 public class AuthController {
+
   private final UserService userService;
+  private final EmailVerificationService emailVerificationService;
 
   @PostMapping("/register")
-  public ResponseEntity<RegisterResponse> registerResponseResponseEntity(@RequestBody @Valid RegisterRequest req){
+  public ResponseEntity<RegisterResponse> register(@Valid @RequestBody RegisterRequest req){
+    //ok 토큰 소비
+    if (!emailVerificationService.consumeOkToken(req.getEmailVerifiedToken(), "signup", req.getEmail())) {
+      throw new IllegalStateException("이메일 인증이 확인되지 않음.");
+    }
+    //가입
     Long id = userService.register(req);
     return ResponseEntity.status(HttpStatus.CREATED)
         .body(new RegisterResponse(id.toString(), true));
   }
-
 }

--- a/back/src/main/java/com/qmate/api/EmailVerificationController.java
+++ b/back/src/main/java/com/qmate/api/EmailVerificationController.java
@@ -1,0 +1,46 @@
+package com.qmate.api;
+
+import com.qmate.domain.auth.EmailVerificationService;
+import com.qmate.domain.auth.model.request.EmailVerificationSendRequest;
+import com.qmate.domain.auth.model.response.EmailConfirmResponse;
+import com.qmate.domain.auth.model.response.EmailResentResponse;
+import com.qmate.domain.auth.model.request.EmailVerificationConfirmRequest;
+import com.qmate.domain.auth.model.response.EmailSentResponse;
+import jakarta.validation.Valid;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/auth/email-verifications")
+@RequiredArgsConstructor
+public class EmailVerificationController {
+  private final EmailVerificationService emailVerificationService;
+
+  @PostMapping
+  public ResponseEntity<EmailSentResponse> send(@Valid @RequestBody EmailVerificationSendRequest req) {
+    emailVerificationService.sendCode(req.getEmail(), req.getPurpose());
+    return ResponseEntity.ok(new EmailSentResponse(true));
+  }
+
+  @PostMapping("/resend")
+  public ResponseEntity<?> resend(@Valid @RequestBody EmailVerificationSendRequest req) {
+    try {
+      emailVerificationService.sendCode(req.getEmail(), req.getPurpose());
+      return ResponseEntity.ok(new EmailResentResponse(true));
+    } catch (IllegalStateException e) { // RESEND_COOLDOWN
+      return ResponseEntity.status(429).body(Map.of("error","RESEND_COOLDOWN"));
+    }
+  }
+
+  @PostMapping("/verify")
+  public ResponseEntity<?> verify(@Valid @RequestBody EmailVerificationConfirmRequest req) {
+    try {
+      String token = emailVerificationService.verifyAndIssueToken(req.getEmail(), req.getPurpose(), req.getCode());
+      return ResponseEntity.ok(new EmailConfirmResponse(true, token));
+    } catch (IllegalArgumentException e) {
+      return ResponseEntity.badRequest().body(new EmailConfirmResponse(false, null));
+    }
+  }
+}

--- a/back/src/main/java/com/qmate/domain/auth/EmailVerificationService.java
+++ b/back/src/main/java/com/qmate/domain/auth/EmailVerificationService.java
@@ -1,0 +1,102 @@
+package com.qmate.domain.auth;
+
+import com.qmate.domain.mail.MailSender;
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+@Service
+@RequiredArgsConstructor
+public class EmailVerificationService {
+  private final StringRedisTemplate redis;
+  private final MailSender mail;
+  private static final SecureRandom RND = new SecureRandom();
+
+  private static final Duration CODE_TTL = Duration.ofMinutes(10);//인증코드 유효기간 10분
+  private static final Duration RESEND_COOLDOWN = Duration.ofSeconds(15);//재전송 쿨다운 15초
+  private static final Duration OK_TOKEN_TTL = Duration.ofMinutes(3);//OK token 유효기간 3분
+  private static final int MAX_ATTEMPTS = 5;//최대 시도 횟수 5회
+
+  //Redis 키 규칙 메서드
+  private String codeKey(String p, String e){
+    return "EV:"+p+":"+e;
+  }
+  private String attemptKey(String p, String e){
+    return "EV_ATTEMPT:"+p+":"+e;
+  }
+  private String resendKey(String p, String e){
+    return "EV_RESEND:"+p+":"+e;
+  }
+  private String okTokenKey(String token){
+    return "EV_OK_TOKEN:"+token;
+  }
+
+  public void sendCode(String email, String purpose) {
+    if (Boolean.TRUE.equals(redis.hasKey(resendKey(purpose, email)))) {
+      throw new IllegalStateException("RESEND_COOLDOWN");
+    }
+    String code = String.format("%06d", RND.nextInt(1_000_000));//0~999,999 범위 난수 생성 후 6자리 0패딩 문자열로 포맷
+    redis.opsForValue().set(codeKey(purpose, email), code, CODE_TTL);
+    redis.opsForValue().set(attemptKey(purpose, email), "0", CODE_TTL);
+    redis.opsForValue().set(resendKey(purpose, email), "1", RESEND_COOLDOWN);
+
+    mail.send(email, "[Qmate] 이메일 인증코드",
+        "인증코드: " + code + "\n유효시간: " + CODE_TTL.toMinutes() + "분\n목적: " + purpose);
+  }
+
+  public String verifyAndIssueToken(String email, String purpose, String inputCode) {
+    String stored = redis.opsForValue().get(codeKey(purpose, email));
+    if (!StringUtils.hasText(stored)) throw new IllegalArgumentException("만료 또는 유효하지 않음");
+
+    long attempts = increment(attemptKey(purpose, email), CODE_TTL);
+    if (attempts > MAX_ATTEMPTS) {
+      deleteAll(purpose, email);
+      throw new IllegalArgumentException("시도 한도 초과");
+    }
+
+    if (!stored.equals(inputCode)) throw new IllegalArgumentException("만료 또는 유효하지 않음");
+
+    //성공-----------------
+    deleteAll(purpose, email);
+
+    // 가입 직전 확인용 토큰(짧은 TTL)
+    String token = UUID.randomUUID().toString();
+    redis.opsForValue().set(okTokenKey(token), purpose+":"+email, OK_TOKEN_TTL);
+    return token;
+  }
+
+  public boolean consumeOkToken(String okToken, String expectedPurpose, String expectedEmail) {
+    String tokenKey = okTokenKey(okToken);
+    String storedTokenBinding = redis.opsForValue().get(tokenKey);
+    if (storedTokenBinding == null) return false;
+
+    String normalizedEmail = normalizeEmail(expectedEmail);
+    String expectedTokenBinding = expectedPurpose + ":" + normalizedEmail;
+
+    boolean isMatch = expectedTokenBinding.equals(storedTokenBinding);
+    if (isMatch) {
+      redis.delete(tokenKey);
+    }
+    return isMatch;
+  }
+
+  private String normalizeEmail(String email) {
+    return (email == null)? null : email.trim().toLowerCase();
+  }
+
+  private long increment(String key, Duration ttl) {
+    Long v = redis.opsForValue().increment(key);
+    if (v != null && v == 1L) redis.expire(key, ttl);
+    return v == null ? 0L : v;
+  }
+
+  private void deleteAll(String purpose, String email) {
+    redis.delete(codeKey(purpose, email));
+    redis.delete(attemptKey(purpose, email));
+    redis.delete(resendKey(purpose, email));
+  }
+}

--- a/back/src/main/java/com/qmate/domain/auth/model/request/EmailVerificationConfirmRequest.java
+++ b/back/src/main/java/com/qmate/domain/auth/model/request/EmailVerificationConfirmRequest.java
@@ -1,0 +1,22 @@
+package com.qmate.domain.auth.model.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class EmailVerificationConfirmRequest {
+  @Email @NotBlank
+  private String email;
+
+  @NotBlank @Size(min = 6, max = 6)
+  private String code;
+
+  @NotBlank
+  private String purpose;
+}

--- a/back/src/main/java/com/qmate/domain/auth/model/request/EmailVerificationSendRequest.java
+++ b/back/src/main/java/com/qmate/domain/auth/model/request/EmailVerificationSendRequest.java
@@ -1,0 +1,18 @@
+package com.qmate.domain.auth.model.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class EmailVerificationSendRequest {
+  @Email @NotBlank
+  private String email;
+
+  @NotBlank
+  private String purpose;
+}

--- a/back/src/main/java/com/qmate/domain/auth/model/response/EmailConfirmResponse.java
+++ b/back/src/main/java/com/qmate/domain/auth/model/response/EmailConfirmResponse.java
@@ -1,0 +1,14 @@
+package com.qmate.domain.auth.model.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class EmailConfirmResponse {
+  private final boolean verified;
+
+  @JsonProperty("email_verified_token")
+  private final String emailVerifiedToken;// 검증 성공 시 짧은 TTL로 발급
+}

--- a/back/src/main/java/com/qmate/domain/auth/model/response/EmailResentResponse.java
+++ b/back/src/main/java/com/qmate/domain/auth/model/response/EmailResentResponse.java
@@ -1,0 +1,10 @@
+package com.qmate.domain.auth.model.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class EmailResentResponse {
+  private final boolean resent;
+}

--- a/back/src/main/java/com/qmate/domain/auth/model/response/EmailSentResponse.java
+++ b/back/src/main/java/com/qmate/domain/auth/model/response/EmailSentResponse.java
@@ -1,0 +1,10 @@
+package com.qmate.domain.auth.model.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class EmailSentResponse {
+  private final boolean sent;
+}

--- a/back/src/main/java/com/qmate/domain/mail/MailSender.java
+++ b/back/src/main/java/com/qmate/domain/mail/MailSender.java
@@ -1,0 +1,5 @@
+package com.qmate.domain.mail;
+
+public interface MailSender {
+  void send(String to, String subject, String body);
+}

--- a/back/src/main/java/com/qmate/domain/mail/SmtpMailSender.java
+++ b/back/src/main/java/com/qmate/domain/mail/SmtpMailSender.java
@@ -1,0 +1,21 @@
+package com.qmate.domain.mail;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SmtpMailSender implements MailSender{
+  private final JavaMailSender mailSender;
+
+  @Override
+  public void send(String to, String subject, String body) {
+    SimpleMailMessage msg = new SimpleMailMessage();
+    msg.setTo(to);
+    msg.setSubject(subject);
+    msg.setText(body);
+    mailSender.send(msg);
+  }
+}

--- a/back/src/main/java/com/qmate/domain/user/model/request/RegisterRequest.java
+++ b/back/src/main/java/com/qmate/domain/user/model/request/RegisterRequest.java
@@ -24,4 +24,7 @@ public class RegisterRequest {
 
   @NotNull
   private LocalDate birthDate;
+
+  @NotBlank
+  private String emailVerifiedToken; //verify 성공 후 받은 토큰
 }

--- a/back/src/main/resources/application-local.yml
+++ b/back/src/main/resources/application-local.yml
@@ -4,17 +4,39 @@ spring:
       on-profile: local
 
   datasource:
-    driver-class-name: org.mariadb.jdbc.Driver
-    url: jdbc:mariadb://localhost:3306/qmate?useUnicode=true&characterEncoding=utf8&serverTimezone=Asia/Seoul
+    url: jdbc:mariadb://localhost:3306/qmate
     username: root
     password: qwer1234!@#$
-
+    driver-class-name: org.mariadb.jdbc.Driver
+  data:
+    redis:
+      host: 127.0.0.1
+      port: 6379
+      connect-timeout: 2s
+      timeout: 2s
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: kimsuasch@gmail.com
+    password: xksj eqev dqrb keva
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
   jpa:
     hibernate:
-      ddl-auto: update  # 개발 중에는 update, 배포 전에는 validate
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true
         show_sql: true
+
+app:
+  email-verification:
+    jwt-secret: "random0jwt0secret0keyaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa!!!!!!!!!11111111!@#$"
+    ttl-minutes: 10
+
 server:
   port: 8080


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 이메일 인증 흐름 부재 → 코드 발송/검증/토큰 발급 단계 없음
- 회원가입이 이메일 검증 없이 진행됨 (위변조/스팸 가입 위험)
- 재전송 쿨다운/시도 횟수 제한/TTL 관리 없음 → 과도한 발송/코드 혼선 가능

**TO-BE**

-  Redis 기반 이메일 인증 플로우 완성

> 코드 발송: EV:{purpose}:{email}(TTL 10m)
> 시도 횟수: EV_ATTEMPT:{purpose}:{email}(TTL 10m, MAX 5)
> 재전송 쿨다운: EV_RESEND:{purpose}:{email}(TTL 15s)
> 검증 성공 시 OK 토큰 발급: EV_OK_TOKEN:{uuid}(TTL 3m, 일회성 소비)

- POST /auth/email-verifications → { sent: true }
- POST /auth/email-verifications/resend → { resent: true }(쿨다운 시 429)
- POST /auth/email-verifications/verify → { verified: true, email_verified_token: "<uuid>" }
- POST /auth/register → OK 토큰 consume 후 가입 처리 { user_id, registered: true }
- 컨트롤러 역할 분리: EmailVerificationController(발송/재전송/검증) · AuthController(회원가입)
- RegisterRequest에 emailVerifiedToken 추가(BREAKING)
- 메일 전송 구현: SmtpMailSender(JavaMailSender) 적용

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- API 테스트 : postman으로 api 정상 작동 테스트 완료