### PR TITLE
feat: 답변 제출 기능 구현

### DIFF
--- a/back/build.gradle
+++ b/back/build.gradle
@@ -54,6 +54,8 @@ dependencies {
     testImplementation 'org.mockito:mockito-junit-jupiter:5.12.0'
     testImplementation 'org.mockito:mockito-inline:5.2.0'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
 }
 
 tasks.named('test') {

--- a/back/src/main/java/com/qmate/api/questioninstance/AnswerController.java
+++ b/back/src/main/java/com/qmate/api/questioninstance/AnswerController.java
@@ -1,0 +1,37 @@
+package com.qmate.api.questioninstance;
+
+import com.qmate.domain.questioninstance.model.request.AnswerContentRequest;
+import com.qmate.domain.questioninstance.model.response.AnswerCreateResponse;
+import com.qmate.domain.questioninstance.service.AnswerService;
+import jakarta.validation.Valid;
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class AnswerController {
+
+  private final AnswerService answerService;
+
+  @PostMapping(value = "/question-instances/{questionInstanceId}/answers")
+  public ResponseEntity<AnswerCreateResponse> create(
+      @PathVariable Long questionInstanceId,
+      // TODO: @AuthenticationPrincipal CustomUserDetails principal
+      @Valid @RequestBody AnswerContentRequest request
+  ) {
+    Long userId = 1L; // TODO: principal.getUserId();
+
+    AnswerCreateResponse response = answerService.create(questionInstanceId, userId, request);
+
+    // Location: 생성으로 인해 최신 상태가 된 QI 상세 리소스
+    URI location = URI.create("/api/question-instances/" + questionInstanceId);
+    return ResponseEntity.created(location).body(response);
+  }
+}

--- a/back/src/main/java/com/qmate/common/constants/question/QuestionInstanceConstants.java
+++ b/back/src/main/java/com/qmate/common/constants/question/QuestionInstanceConstants.java
@@ -1,5 +1,0 @@
-package com.qmate.common.constants.question;
-
-public class QuestionInstanceConstants {
-
-}

--- a/back/src/main/java/com/qmate/common/constants/questioninstance/AnswerConstants.java
+++ b/back/src/main/java/com/qmate/common/constants/questioninstance/AnswerConstants.java
@@ -1,0 +1,9 @@
+package com.qmate.common.constants.questioninstance;
+
+public class AnswerConstants {
+  public static final int MAX_CONTENT_LENGTH = 100;
+
+  // 유효성 검사 메시지
+  public static final String CONTENT_NOT_BLANK_MESSAGE = "내용은 필수입니다.";
+  public static final String CONTENT_SIZE_MESSAGE = "내용은 최대 " + MAX_CONTENT_LENGTH + "자까지 입력할 수 있습니다.";
+}

--- a/back/src/main/java/com/qmate/domain/questioninstance/entity/InstanceStatus.java
+++ b/back/src/main/java/com/qmate/domain/questioninstance/entity/InstanceStatus.java
@@ -1,5 +1,6 @@
 package com.qmate.domain.questioninstance.entity;
 
+// TODO QuestionInstanceStatus로 리팩토링 필요
 public enum InstanceStatus {
   PENDING, COMPLETED, EXPIRED
 }

--- a/back/src/main/java/com/qmate/domain/questioninstance/mapper/AnswerMapper.java
+++ b/back/src/main/java/com/qmate/domain/questioninstance/mapper/AnswerMapper.java
@@ -1,0 +1,36 @@
+package com.qmate.domain.questioninstance.mapper;
+
+import com.qmate.domain.questioninstance.entity.Answer;
+import com.qmate.domain.questioninstance.entity.QuestionInstance;
+import com.qmate.domain.questioninstance.model.request.AnswerContentRequest;
+import com.qmate.domain.questioninstance.model.response.AnswerCreateResponse;
+import com.qmate.domain.user.User;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+public class AnswerMapper {
+
+  public static Answer toEntity(QuestionInstance qi, User user, AnswerContentRequest req) {
+    String normalized = normalize(req.getContent());
+    return Answer.builder()
+        .questionInstance(qi)
+        .user(user)
+        .content(normalized)
+        .build();
+  }
+
+  public static AnswerCreateResponse toResponse(Answer a) {
+    return AnswerCreateResponse.builder()
+        .answerId(a.getId())
+        .questionInstanceId(a.getQuestionInstance().getId())
+        .userId(a.getUser().getId())
+        .content(a.getContent())
+        .submittedAt(a.getSubmittedAt())
+        .build();
+  }
+
+  private static String normalize(String raw) {
+    if (raw == null) return null;
+    return raw.trim().replace("\r\n", "\n");
+  }
+}

--- a/back/src/main/java/com/qmate/domain/questioninstance/model/request/AnswerContentRequest.java
+++ b/back/src/main/java/com/qmate/domain/questioninstance/model/request/AnswerContentRequest.java
@@ -1,0 +1,19 @@
+package com.qmate.domain.questioninstance.model.request;
+
+import com.qmate.common.constants.questioninstance.AnswerConstants;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AnswerContentRequest {
+
+  @NotBlank(message = AnswerConstants.CONTENT_NOT_BLANK_MESSAGE)
+  @Size(max = AnswerConstants.MAX_CONTENT_LENGTH, message = AnswerConstants.CONTENT_SIZE_MESSAGE)
+  private String content;
+}

--- a/back/src/main/java/com/qmate/domain/questioninstance/model/response/AnswerCreateResponse.java
+++ b/back/src/main/java/com/qmate/domain/questioninstance/model/response/AnswerCreateResponse.java
@@ -1,0 +1,20 @@
+package com.qmate.domain.questioninstance.model.response;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class AnswerCreateResponse {
+
+  private Long answerId;
+  private Long questionInstanceId;
+  private Long userId;
+  private String content;
+  private LocalDateTime submittedAt;
+}

--- a/back/src/main/java/com/qmate/domain/questioninstance/repository/AnswerRepository.java
+++ b/back/src/main/java/com/qmate/domain/questioninstance/repository/AnswerRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface AnswerRepository extends JpaRepository<Answer, Long> {
 
   Optional<Answer> findByQuestionInstance_IdAndUser_Id(Long questionInstanceId, Long userId);
+
+  long countByQuestionInstance_Id(Long questionInstanceId);
 }

--- a/back/src/main/java/com/qmate/domain/questioninstance/service/AnswerService.java
+++ b/back/src/main/java/com/qmate/domain/questioninstance/service/AnswerService.java
@@ -1,0 +1,78 @@
+package com.qmate.domain.questioninstance.service;
+
+import com.qmate.domain.questioninstance.entity.Answer;
+import com.qmate.domain.questioninstance.entity.InstanceStatus;
+import com.qmate.domain.questioninstance.entity.QuestionInstance;
+import com.qmate.domain.questioninstance.mapper.AnswerMapper;
+import com.qmate.domain.questioninstance.model.request.AnswerContentRequest;
+import com.qmate.domain.questioninstance.model.response.AnswerCreateResponse;
+import com.qmate.domain.questioninstance.repository.AnswerRepository;
+import com.qmate.domain.questioninstance.repository.QuestionInstanceRepository;
+import com.qmate.domain.user.User;
+import com.qmate.domain.user.UserRepository;
+import com.qmate.exception.custom.UserNotFoundException;
+import com.qmate.exception.custom.questioninstance.AnswerAlreadyExistsException;
+import com.qmate.exception.custom.questioninstance.AnswerCannotModifyException;
+import com.qmate.exception.custom.questioninstance.QuestionInstanceForbiddenException;
+import com.qmate.exception.custom.questioninstance.QuestionInstanceNotFoundException;
+import java.time.LocalDateTime;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.apache.coyote.BadRequestException;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.crossstore.ChangeSetPersister.NotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AnswerService {
+
+  private final QuestionInstanceRepository questionInstanceRepository;
+  private final UserRepository userRepository;
+  private final AnswerRepository answerRepository;
+
+  @Transactional
+  public AnswerCreateResponse create(Long questionInstanceId, Long userId, AnswerContentRequest req) {
+
+    // 1) 로드
+    QuestionInstance qi = questionInstanceRepository.findById(questionInstanceId)
+        .orElseThrow(QuestionInstanceNotFoundException::new);
+
+    User user = userRepository.findById(userId)
+        .orElseThrow(UserNotFoundException::new);
+
+    // 2) 권한 검증: 같은 매치인지 확인
+    Long qiMatchId = qi.getMatch().getMatchId();
+    Long userCurrentMatchId = user.getCurrentMatchId();
+    if (qiMatchId == null || !qiMatchId.equals(userCurrentMatchId)) {
+      throw new QuestionInstanceForbiddenException();
+    }
+
+    // 3) 상태 검증
+    InstanceStatus status = qi.getStatus();
+    // PENDING만 통과
+    if (status != InstanceStatus.PENDING) {
+      throw new AnswerCannotModifyException();
+    }
+
+    // 4) 저장 (+ 유니크 충돌을 409로 매핑)
+    Answer saved;
+    try {
+      Answer entity = AnswerMapper.toEntity(qi, user, req);
+      saved = answerRepository.save(entity);
+    } catch (DataIntegrityViolationException e) {
+      // (question_instance_id, user_id) 유니크 인덱스 충돌
+      throw new AnswerAlreadyExistsException();
+    }
+
+    // 5) 두 사람 모두 답하면 QI 완료 전이
+    if (answerRepository.countByQuestionInstance_Id(questionInstanceId) >= 2L) {
+      qi.markCompleted(LocalDateTime.now());
+      // TODO 알림 발송
+    }
+
+    // 6) 응답 매핑
+    return AnswerMapper.toResponse(saved);
+  }
+}

--- a/back/src/main/java/com/qmate/exception/custom/questioninstance/AnswerAlreadyExistsException.java
+++ b/back/src/main/java/com/qmate/exception/custom/questioninstance/AnswerAlreadyExistsException.java
@@ -1,0 +1,11 @@
+package com.qmate.exception.custom.questioninstance;
+
+import com.qmate.exception.BusinessGlobalException;
+import com.qmate.exception.errorcode.AnswerErrorCode;
+
+public class AnswerAlreadyExistsException extends BusinessGlobalException {
+
+  public AnswerAlreadyExistsException() {
+    super(AnswerErrorCode.answerAlreadyExists());
+  }
+}

--- a/back/src/main/java/com/qmate/exception/custom/questioninstance/AnswerCannotModifyException.java
+++ b/back/src/main/java/com/qmate/exception/custom/questioninstance/AnswerCannotModifyException.java
@@ -1,0 +1,12 @@
+package com.qmate.exception.custom.questioninstance;
+
+import com.qmate.exception.BusinessGlobalException;
+import com.qmate.exception.errorcode.AnswerErrorCode;
+
+public class AnswerCannotModifyException extends BusinessGlobalException {
+
+  public AnswerCannotModifyException() {
+    super(AnswerErrorCode.answerCannotModify());
+  }
+
+}

--- a/back/src/main/java/com/qmate/exception/errorcode/AnswerErrorCode.java
+++ b/back/src/main/java/com/qmate/exception/errorcode/AnswerErrorCode.java
@@ -20,7 +20,7 @@ public class AnswerErrorCode extends ErrorCode {
   }
 
   public static ErrorCode answerCannotModify() {
-    return new AnswerErrorCode(HttpStatus.BAD_REQUEST, "ANSWER_003", ANSWER_CANNOT_MODIFY);
+    return new AnswerErrorCode(HttpStatus.LOCKED, "ANSWER_003", ANSWER_CANNOT_MODIFY);
   }
 
   protected AnswerErrorCode(HttpStatus httpStatus, String code, String message) {

--- a/back/src/main/java/com/qmate/exception/errorcode/AnswerErrorCode.java
+++ b/back/src/main/java/com/qmate/exception/errorcode/AnswerErrorCode.java
@@ -1,0 +1,29 @@
+package com.qmate.exception.errorcode;
+
+import com.qmate.exception.ErrorCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class AnswerErrorCode extends ErrorCode {
+
+  private static final String ANSWER_NOT_FOUND = "답변을 찾을 수 없습니다.";
+  public static final String ANSWER_ALREADY_EXISTS = "이미 답변이 존재합니다.";
+  public static final String ANSWER_CANNOT_MODIFY = "답변을 작성/수정할 수 없는 상태입니다.";
+
+  public static ErrorCode answerNotFound() {
+    return new AnswerErrorCode(HttpStatus.NOT_FOUND, "ANSWER_001", ANSWER_NOT_FOUND);
+  }
+
+  public static ErrorCode answerAlreadyExists() {
+    return new AnswerErrorCode(HttpStatus.CONFLICT, "ANSWER_002", ANSWER_ALREADY_EXISTS);
+  }
+
+  public static ErrorCode answerCannotModify() {
+    return new AnswerErrorCode(HttpStatus.BAD_REQUEST, "ANSWER_003", ANSWER_CANNOT_MODIFY);
+  }
+
+  protected AnswerErrorCode(HttpStatus httpStatus, String code, String message) {
+    super(httpStatus, code, message);
+  }
+}

--- a/back/src/test/java/com/qmate/questioninstance/AnswerControllerTest.java
+++ b/back/src/test/java/com/qmate/questioninstance/AnswerControllerTest.java
@@ -1,0 +1,153 @@
+package com.qmate.questioninstance;
+
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.anyLong;
+import static org.mockito.BDDMockito.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.qmate.api.questioninstance.AnswerController;
+import com.qmate.domain.questioninstance.model.request.AnswerContentRequest;
+import com.qmate.domain.questioninstance.model.response.AnswerCreateResponse;
+import com.qmate.domain.questioninstance.service.AnswerService;
+import com.qmate.exception.custom.questioninstance.AnswerAlreadyExistsException;
+import com.qmate.exception.custom.questioninstance.AnswerCannotModifyException;
+import com.qmate.exception.custom.questioninstance.QuestionInstanceForbiddenException;
+import com.qmate.exception.custom.questioninstance.QuestionInstanceNotFoundException;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = AnswerController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class AnswerControllerTest {
+
+  @Autowired MockMvc mockMvc;
+  @Autowired ObjectMapper objectMapper;
+
+  @MockitoBean
+  AnswerService answerService;
+
+  @Test
+  @DisplayName("201 Created: Location은 QI 단건, 바디는 생성 결과")
+  void create_201() throws Exception {
+    // given
+    Long qiId = 123L;
+    var req = new AnswerContentRequest("최대 100자");
+    // userId는 컨트롤러 내부 구현(현재는 1L, 이후 principal)과 무관하게 anyLong()로 대응
+    var res = new AnswerCreateResponse(
+        456L, qiId, 99L, "최대 100자",
+        LocalDateTime.parse("2025-09-11T12:20:00")
+    );
+
+    given(answerService.create(eq(qiId), anyLong(), any(AnswerContentRequest.class)))
+        .willReturn(res);
+
+    // expect
+    mockMvc.perform(post("/api/question-instances/{qiId}/answers", qiId)
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(req)))
+        .andExpect(status().isCreated())
+        .andExpect(header().string("Location", "/api/question-instances/" + qiId))
+        .andExpect(jsonPath("$.answerId").value(456))
+        .andExpect(jsonPath("$.questionInstanceId").value(123))
+        .andExpect(jsonPath("$.userId").value(99))
+        .andExpect(jsonPath("$.content").value("최대 100자"))
+        .andExpect(jsonPath("$.submittedAt").value("2025-09-11T12:20:00"));
+  }
+
+  @Test
+  @DisplayName("400 Bad Request: 본문 검증 실패(@NotBlank)")
+  void create_400_validation() throws Exception {
+    // given
+    var bad = new AnswerContentRequest(""); // @NotBlank 위반
+
+    // expect
+    mockMvc.perform(post("/api/question-instances/{qiId}/answers", 1L)
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(bad)))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName("403 Forbidden: 매치 불일치")
+  void create_403_forbidden() throws Exception {
+    // given
+    Long qiId = 10L;
+    var req = new AnswerContentRequest("ok");
+    willThrow(new QuestionInstanceForbiddenException())
+        .given(answerService).create(eq(qiId), anyLong(), any(AnswerContentRequest.class));
+
+    // expect
+    mockMvc.perform(post("/api/question-instances/{qiId}/answers", qiId)
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(req)))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @DisplayName("423 Locked: QI 상태가 완료/만료라 수정 불가")
+  void create_423_locked() throws Exception {
+    // given
+    Long qiId = 11L;
+    var req = new AnswerContentRequest("ok");
+    willThrow(new AnswerCannotModifyException())
+        .given(answerService).create(eq(qiId), anyLong(), any(AnswerContentRequest.class));
+
+    // expect
+    mockMvc.perform(post("/api/question-instances/{qiId}/answers", qiId)
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(req)))
+        .andExpect(status().isLocked());
+  }
+
+  @Test
+  @DisplayName("409 Conflict: 동일 QI에 본인 답변 기등록")
+  void create_409_conflict_duplicate() throws Exception {
+    // given
+    Long qiId = 12L;
+    var req = new AnswerContentRequest("ok");
+    willThrow(new AnswerAlreadyExistsException())
+        .given(answerService).create(eq(qiId), anyLong(), any(AnswerContentRequest.class));
+
+    // expect
+    mockMvc.perform(post("/api/question-instances/{qiId}/answers", qiId)
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(req)))
+        .andExpect(status().isConflict());
+  }
+
+  @Test
+  @DisplayName("404 Not Found: QI가 없음")
+  void create_404_qiNotFound() throws Exception {
+    // given
+    Long qiId = 404L;
+    var req = new AnswerContentRequest("ok");
+    willThrow(new QuestionInstanceNotFoundException())
+        .given(answerService).create(eq(qiId), anyLong(), any(AnswerContentRequest.class));
+
+    // expect
+    mockMvc.perform(post("/api/question-instances/{qiId}/answers", qiId)
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(req)))
+        .andExpect(status().isNotFound());
+  }
+}

--- a/back/src/test/java/com/qmate/questioninstance/AnswerMapperTest.java
+++ b/back/src/test/java/com/qmate/questioninstance/AnswerMapperTest.java
@@ -1,0 +1,49 @@
+package com.qmate.questioninstance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.qmate.domain.questioninstance.entity.Answer;
+import com.qmate.domain.questioninstance.entity.QuestionInstance;
+import com.qmate.domain.questioninstance.mapper.AnswerMapper;
+import com.qmate.domain.questioninstance.model.request.AnswerContentRequest;
+import com.qmate.domain.questioninstance.model.response.AnswerCreateResponse;
+import com.qmate.domain.user.User;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+
+class AnswerMapperTest {
+
+  @Test
+  void toEntity_트리밍_개행정규화() {
+    QuestionInstance qi = QuestionInstance.builder().id(123L).build();
+    User user = User.builder().id(99L).build();
+
+    AnswerContentRequest req = new AnswerContentRequest("  안녕\r\n하세요  ");
+    Answer a = AnswerMapper.toEntity(qi, user, req);
+
+    assertThat(a.getQuestionInstance()).isSameAs(qi);
+    assertThat(a.getUser()).isSameAs(user);
+    assertThat(a.getContent()).isEqualTo("안녕\n하세요");
+  }
+
+  @Test
+  void toResponse_엔티티에서필드매핑() {
+    QuestionInstance qi = QuestionInstance.builder().id(123L).build();
+    User user = User.builder().id(99L).build();
+    Answer a = Answer.builder()
+        .id(456L)
+        .questionInstance(qi)
+        .user(user)
+        .content("hello")
+        .submittedAt(LocalDateTime.parse("2025-09-11T12:20:00"))
+        .build();
+
+    AnswerCreateResponse res = AnswerMapper.toResponse(a);
+
+    assertThat(res.getAnswerId()).isEqualTo(456L);
+    assertThat(res.getQuestionInstanceId()).isEqualTo(123L);
+    assertThat(res.getUserId()).isEqualTo(99L);
+    assertThat(res.getContent()).isEqualTo("hello");
+    assertThat(res.getSubmittedAt()).isEqualTo("2025-09-11T12:20:00");
+  }
+}

--- a/back/src/test/java/com/qmate/questioninstance/AnswerServiceCreateTest.java
+++ b/back/src/test/java/com/qmate/questioninstance/AnswerServiceCreateTest.java
@@ -1,0 +1,163 @@
+package com.qmate.questioninstance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.BDDAssertions.thenThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.qmate.domain.match.Match;
+import com.qmate.domain.questioninstance.entity.Answer;
+import com.qmate.domain.questioninstance.entity.InstanceStatus;
+import com.qmate.domain.questioninstance.entity.QuestionInstance;
+import com.qmate.domain.questioninstance.model.request.AnswerContentRequest;
+import com.qmate.domain.questioninstance.repository.AnswerRepository;
+import com.qmate.domain.questioninstance.repository.QuestionInstanceRepository;
+import com.qmate.domain.questioninstance.service.AnswerService;
+import com.qmate.domain.user.User;
+import com.qmate.domain.user.UserRepository;
+import com.qmate.exception.custom.UserNotFoundException;
+import com.qmate.exception.custom.questioninstance.AnswerAlreadyExistsException;
+import com.qmate.exception.custom.questioninstance.AnswerCannotModifyException;
+import com.qmate.exception.custom.questioninstance.QuestionInstanceForbiddenException;
+import com.qmate.exception.custom.questioninstance.QuestionInstanceNotFoundException;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+
+@ExtendWith(MockitoExtension.class)
+class AnswerServiceCreateTest {
+  @Mock
+  QuestionInstanceRepository qiRepo;
+  @Mock
+  UserRepository userRepo;
+  @Mock
+  AnswerRepository answerRepo;
+
+  @InjectMocks
+  AnswerService sut;
+
+  private QuestionInstance qi(Long qiId, Long matchId, InstanceStatus status) {
+    return QuestionInstance.builder()
+        .id(qiId)
+        .status(status)
+        .match(Match.builder().matchId(matchId).build())
+        .build();
+  }
+
+  @Test
+  @DisplayName("정상: 저장 후 두 사람 답변이면 QI 완료 전이")
+  void create_정상_201() {
+    // given
+    Long qiId = 123L; Long userId = 99L; Long matchId = 7L;
+    var req = new AnswerContentRequest("  안녕\r\n하세요  ");
+    var user = User.builder().id(userId).currentMatchId(matchId).build();
+    var qi = qi(qiId, matchId, InstanceStatus.PENDING);
+
+    given(qiRepo.findById(qiId)).willReturn(Optional.of(qi));
+    given(userRepo.findById(userId)).willReturn(Optional.of(user));
+
+    // 저장 시 id/시간 세팅된 엔티티 리턴
+    var saved = Answer.builder()
+        .id(456L).questionInstance(qi).user(user)
+        .content("안녕\n하세요").submittedAt(LocalDateTime.parse("2025-09-11T12:20:00")).build();
+    given(answerRepo.save(any(Answer.class))).willReturn(saved);
+    given(answerRepo.countByQuestionInstance_Id(qiId)).willReturn(2L);
+
+    // when
+    var res = sut.create(qiId, userId, req);
+
+    // then
+    assertThat(res.getAnswerId()).isEqualTo(456L);
+    assertThat(res.getQuestionInstanceId()).isEqualTo(123L);
+    assertThat(res.getUserId()).isEqualTo(99L);
+    assertThat(res.getContent()).isEqualTo("안녕\n하세요");
+    assertThat(res.getSubmittedAt()).isEqualTo("2025-09-11T12:20:00");
+
+    // 완료 전이 호출 확인(마커 메서드가 내부 상태만 바꾸면 상태만 검증)
+    assertThat(qi.getStatus()).isEqualTo(InstanceStatus.COMPLETED);
+  }
+
+  @Test
+  void create_권한불일치_403() {
+    Long qiId = 1L; Long userId = 2L;
+    var req = new AnswerContentRequest("a");
+    var qi = qi(qiId, 100L, InstanceStatus.PENDING);
+    var user = User.builder().id(userId).currentMatchId(200L).build();
+
+    given(qiRepo.findById(qiId)).willReturn(Optional.of(qi));
+    given(userRepo.findById(userId)).willReturn(Optional.of(user));
+
+    assertThatThrownBy(() -> sut.create(qiId, userId, req))
+        .isInstanceOf(QuestionInstanceForbiddenException.class);
+  }
+
+  @Test
+  @DisplayName("만료(EXPIRED): 423 Locked")
+  void create_expired_423() {
+    Long qiId = 1L; Long userId = 2L; Long matchId = 7L;
+    var req = new AnswerContentRequest("a");
+    var qi = qi(qiId, matchId, InstanceStatus.EXPIRED);
+    var user = User.builder().id(userId).currentMatchId(matchId).build();
+
+    given(qiRepo.findById(qiId)).willReturn(Optional.of(qi));
+    given(userRepo.findById(userId)).willReturn(Optional.of(user));
+
+    assertThatThrownBy(() -> sut.create(qiId, userId, req))
+        .isInstanceOf(AnswerCannotModifyException.class);
+  }
+
+  @Test
+  @DisplayName("완료(COMPLETED): 423 Locked")
+  void create_completed_423() {
+    // given
+    Long qiId = 1L, userId = 2L, matchId = 7L;
+    var req = new AnswerContentRequest("a");
+    var qi = qi(qiId, matchId, InstanceStatus.COMPLETED);
+    var user = User.builder().id(userId).currentMatchId(matchId).build();
+
+    given(qiRepo.findById(qiId)).willReturn(Optional.of(qi));
+    given(userRepo.findById(userId)).willReturn(Optional.of(user));
+
+    // expect
+    thenThrownBy(() -> sut.create(qiId, userId, req))
+        .isInstanceOf(AnswerCannotModifyException.class);
+  }
+
+  @Test
+  void create_중복답변_409() {
+    Long qiId = 1L; Long userId = 2L; Long matchId = 7L;
+    var req = new AnswerContentRequest("a");
+    var qi = qi(qiId, matchId, InstanceStatus.PENDING);
+    var user = User.builder().id(userId).currentMatchId(matchId).build();
+
+    given(qiRepo.findById(qiId)).willReturn(Optional.of(qi));
+    given(userRepo.findById(userId)).willReturn(Optional.of(user));
+    given(answerRepo.save(any(Answer.class)))
+        .willThrow(new DataIntegrityViolationException("dup"));
+
+    assertThatThrownBy(() -> sut.create(qiId, userId, req))
+        .isInstanceOf(AnswerAlreadyExistsException.class);
+  }
+
+  @Test
+  void create_QI없음_404_USER없음_404() {
+    Long qiId = 1L; Long userId = 2L;
+    given(qiRepo.findById(qiId)).willReturn(Optional.empty());
+    assertThatThrownBy(() -> sut.create(qiId, userId, new AnswerContentRequest("a")))
+        .isInstanceOf(QuestionInstanceNotFoundException.class);
+
+    given(qiRepo.findById(qiId)).willReturn(Optional.of(qi(qiId, 7L, InstanceStatus.PENDING)));
+    given(userRepo.findById(userId)).willReturn(Optional.empty());
+    assertThatThrownBy(() -> sut.create(qiId, userId, new AnswerContentRequest("a")))
+        .isInstanceOf(UserNotFoundException.class);
+  }
+}


### PR DESCRIPTION
## 개요
질문 인스턴스(QI)에 대해 **사용자의 답변을 최초 1회 제출**하는 기능을 추가했습니다.  
저장은 QI 상태/권한/중복 제약을 만족할 때만 수행됩니다.

## 변경 사항

### API
- `POST /api/question-instances/{questionInstanceId}/answers`
  - Request Body
    ```
    { "content": "최대 100자" }
    ```
  - Response (201 Created)
    ```
    {
      "answerId": 456,
      "questionInstanceId": 123,
      "userId": 99,
      "content": "최대 100자",
      "submittedAt": "2025-09-11T12:20:00"
    }
    ```
  - Headers
    ```
    Location: /api/question-instances/{questionInstanceId}
    ```
  - 제약/상태코드
    - 권한 불일치 → **403 Forbidden**
    - 상태가 `PENDING`이 아니면(`COMPLETED`/`EXPIRED`) → **423 Locked**
    - 동일 QI에 동일 사용자 재제출(유니크 위반) → **409 Conflict**
    - 대상 QI/USER 없음 → **404 Not Found**
    - 본문 검증 실패(`@NotBlank`, `@Size`) → **400 Bad Request**

### DTO
- `AnswerContentRequest` (class)
  - `content` (`@NotBlank`, `@Size(max = AnswerConstants.MAX_CONTENT_LENGTH)`)
- `AnswerCreateResponse` (class)
  - `answerId, questionInstanceId, userId, content, submittedAt`

### Mapper
- `AnswerMapper`
  - `toEntity(QuestionInstance qi, User user, AnswerContentRequest req)`
    - 내용 **trim + 개행 정규화**(`\r\n` → `\n`)
    - 연관(QI, User) 설정
  - `toResponse(Answer a)`
    - 엔티티에서 응답 필드 매핑

### Repository
- `AnswerRepository`
  - `long countByQuestionInstance_Id(Long qiId)` — 두 사람 답변 여부 판단

### Service
- `AnswerService#create(Long questionInstanceId, Long userId, AnswerContentRequest req)`
  1) QI/USER 로드(없으면 404)  
  2) 권한 검증: `qi.match.matchId == user.currentMatchId` 아니면 403  
  3) 상태 검증: `PENDING`만 허용, 그 외는 `AnswerCannotModifyException` → 423  
  4) 저장 시 유니크 충돌은 `AnswerAlreadyExistsException` → 409  
  5) 저장 후 `countByQuestionInstance_Id(qiId) >= 2`면 `qi.markCompleted(now)`

### Controller
- `AnswerController#create(Long questionInstanceId, AnswerContentRequest request)`
  - (임시) principal 미연동 → `userId = 1L`로 서비스 호출
  - 성공 시 **201 Created** + `Location: /api/question-instances/{qiId}` + 응답 바디 반환

### Tests
- **Mapper 단위 테스트**
  - `toEntity`: 트리밍/개행 정규화 및 연관 매핑 검증
  - `toResponse`: 필드 매핑 검증
- **Service 단위 테스트 (BDD + Mockito)**
  - 정상: 저장 및 `count=2` → QI `COMPLETED` 전이
  - 권한 불일치 → 403
  - 상태 `EXPIRED/COMPLETED` → 423
  - 중복 제출 → 409
  - QI/USER 미존재 → 404
- **Controller MVC 테스트 (@WebMvcTest)**
  - 성공: **201** + `Location=/api/question-instances/{qiId}` + 바디 5필드
  - 본문 검증 실패: **400**
  - 권한 불일치: **403**
  - 완료/만료: **423**
  - 중복: **409**
  - QI 없음: **404**

## 기타
- 추후 인증 연동 시 `@AuthenticationPrincipal CustomUserDetails principal`에서 `userId` 추출로 컨트롤러 교체 예정(컨트롤러 테스트는 서비스 스텁에 `anyLong()` 사용으로 변경 영향 최소화).
