### PR TITLE
design invite 경로 아래의 공백 수정

### DIFF
--- a/front/src/app/invite/layout.tsx
+++ b/front/src/app/invite/layout.tsx
@@ -1,0 +1,24 @@
+import Image from 'next/image';
+import React, { ReactNode } from 'react';
+
+export default function InviteLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="w-full min-h-[calc(100vh-70px)]  flex flex-col items-center justify-center">
+      <div className="absolute inset-0 pointer-events-none z-0">
+        <picture>
+          <source media="(max-width: 768px) " srcSet="/images/background_deco_M.png" />
+
+          <Image
+            src="/images/background_deco_W.png"
+            alt="배경 장식 이미지"
+            priority
+            fill
+            sizes="100vw"
+            className="object-cover object-bottom "
+          />
+        </picture>
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/front/src/app/invite/relationship_select/page.tsx
+++ b/front/src/app/invite/relationship_select/page.tsx
@@ -1,26 +1,23 @@
 import { Button } from '@/components/common/Button';
-import InviteLayout from '@/components/invite/ui/InviteLayout';
 import Image from 'next/image';
 import React from 'react';
 
 export default function page() {
   return (
     <>
-      <InviteLayout>
-        <div className="mb-10 font-Gumi text-24 text-center">
-          <p>버블리와 함께 기록할 사람의</p>
-          <p>관계를 골라주세요</p>
-        </div>
-        <Image src="/images/bubbley_baby.png" alt="버블리 캐릭터" width={120} height={167} />
-        <div className="mt-10 flex flex-col gap-5">
-          <Button variant="invite" className="w-[300px] z-10">
-            연인
-          </Button>
-          <Button variant="invite" className="w-[300px] z-10">
-            친구
-          </Button>
-        </div>
-      </InviteLayout>
+      <div className="mb-10 font-Gumi text-24 text-center">
+        <p>버블리와 함께 기록할 사람의</p>
+        <p>관계를 골라주세요</p>
+      </div>
+      <Image src="/images/bubbley_baby.png" alt="버블리 캐릭터" width={120} height={167} />
+      <div className="mt-10 flex flex-col gap-5">
+        <Button variant="invite" className="w-[300px] z-10">
+          연인
+        </Button>
+        <Button variant="invite" className="w-[300px] z-10">
+          친구
+        </Button>
+      </div>
     </>
   );
 }

--- a/front/src/app/layout.tsx
+++ b/front/src/app/layout.tsx
@@ -20,9 +20,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           <Providers>
             <div className="flex flex-col h-full">
               <NavGuard />
-<main className="flex-1 pt-0 sm:pt-[70px] pb-[env(safe-area-inset-bottom,70px)] sm:pb-0">
-  {children}
-</main>            </div>
+              <main className="flex-1 pt-0 sm:pt-[70px] pb-[env(safe-area-inset-bottom,70px)] sm:pb-0">
+                {children}
+              </main>
+            </div>
           </Providers>
         </BodyWrapper>
       </body>

--- a/front/src/components/common/NavGuard.tsx
+++ b/front/src/components/common/NavGuard.tsx
@@ -6,11 +6,10 @@ import Nav from './Nav';
 
 export default function NavGuard() {
   const pathName = usePathname();
-  const cleanPath = pathName.replace(/\/$/, '');
   const hideNav =
-    cleanPath.startsWith('/login') ||
-    cleanPath.startsWith('/signup') ||
-    cleanPath.startsWith('/invite');
+    pathName.startsWith('/login') ||
+    pathName.startsWith('/signup') ||
+    pathName.startsWith('/invite');
 
   if (hideNav) return null;
   return <Nav />;

--- a/front/src/components/invite/Invited.tsx
+++ b/front/src/components/invite/Invited.tsx
@@ -1,6 +1,5 @@
 'use client';
 import React, { useState } from 'react';
-import InviteLayout from './ui/InviteLayout';
 import Image from 'next/image';
 import { Button } from '../common/Button';
 import InvitedCheckModal from './ui/InvitedCheckModal';
@@ -9,7 +8,7 @@ export default function Invited() {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
-    <InviteLayout>
+    <>
       <div className="mb-10 text-center">
         <p className="font-Gumi text-24">초대 코드를</p>
         <p className="font-Gumi text-24">등록해주세요</p>
@@ -25,6 +24,6 @@ export default function Invited() {
         등록하기
       </Button>
       <InvitedCheckModal open={isOpen} setIsOpen={setIsOpen} />
-    </InviteLayout>
+    </>
   );
 }


### PR DESCRIPTION
**AS-IS**

- /invite 경로 페이지에서 하단에 불필요한 공백 발생
- 원인: min-h-screen과 메인 레이아웃의 pt-[70px]이 동시에 적용되어 높이가 중복 계산됨

**TO-BE**

- /invite 페이지 하단 공백 제거 완료
- 메인 영역 높이를 min-h-[calc(100vh-70px)]로 조정하여 nav 높이(70px)를 뺀 값만 차지하도록 변경