### PR TITLE
fix 스크롤 오류 수정

### DIFF
--- a/front/src/app/layout.tsx
+++ b/front/src/app/layout.tsx
@@ -20,7 +20,13 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           <Providers>
             <div className="flex flex-col h-full">
               <NavGuard />
-              <main className="flex-1 pt-0 sm:pt-[70px] pb-[env(safe-area-inset-bottom,70px)] sm:pb-0">
+              <main
+                className="
+                  flex-1
+                  sm:pt-[70px]   
+                  pb-[70px] sm:pb-0
+                "
+              >
                 {children}
               </main>
             </div>

--- a/front/src/app/schedule/page.tsx
+++ b/front/src/app/schedule/page.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 
 export default function page() {
   return (
-    <div className="w-full min-h-screen flex flex-col  justify-center">
+    <div className="w-full h-full flex flex-col  justify-center">
       <ScheduleListWeb />
       <Link href="/schedule/list">
         <CalendarDays />

--- a/front/src/components/invite/ui/InviteLayout.tsx
+++ b/front/src/components/invite/ui/InviteLayout.tsx
@@ -3,7 +3,7 @@ import React, { ReactNode } from 'react';
 
 export default function InviteLayout({ children }: { children: ReactNode }) {
   return (
-    <div className="w-full min-h-screen  flex flex-col items-center justify-center ">
+    <div className="w-full h-full  flex flex-col items-center justify-center ">
       <div className="absolute inset-0 pointer-events-none z-0">
         <picture>
           <source media="(max-width: 768px) " srcSet="/images/background_deco_M.png" />

--- a/front/src/components/login/Login.tsx
+++ b/front/src/components/login/Login.tsx
@@ -18,7 +18,7 @@ export default function Login() {
   const isFormValid = isEmailValid && isPasswordValid;
 
   return (
-    <div className=" w-full min-h-screen flex flex-col gap-3 items-center justify-center ">
+    <div className=" w-full h-full flex flex-col gap-3 items-center justify-center ">
       <Image src="/images/logo/day_logo.svg" alt="큐메이트" width={173} height={55} />
 
       <form onSubmit={(e) => e.preventDefault()} className="flex flex-col gap-3">

--- a/front/src/components/main/Main.tsx
+++ b/front/src/components/main/Main.tsx
@@ -37,7 +37,7 @@ export default function Main() {
   const MotionImage = motion(Image);
 
   return (
-    <div className="w-full min-h-screen flex flex-col items-center justify-center">
+    <div className="w-full h-full flex flex-col items-center justify-center">
       <div className="fixed inset-0 pointer-events-none z-0">
         <AnimatePresence mode="wait">
           <MotionImage

--- a/front/src/components/question/AnswerForm.tsx
+++ b/front/src/components/question/AnswerForm.tsx
@@ -21,7 +21,7 @@ export default function AnswerForm({ questionText, mode }: AnswerFormProps) {
           <Image src="/images/logo/day_logo.svg" alt="큐메이트" width={94} height={30} />
         </Link>
       </div>
-      <div className="flex flex-col items-center justify-center h-screen bg-gradient-sub gap-10">
+      <div className="flex flex-col items-center justify-center h-full bg-gradient-sub gap-10">
         <div className="flex flex-col h-[246px] gap-8">
           <span className="font-bold text-24 text-center pb-5">{questionText}</span>
           <textarea

--- a/front/src/components/question/Custom.tsx
+++ b/front/src/components/question/Custom.tsx
@@ -16,7 +16,7 @@ export default function Custom({ value }: { value?: string }) {
           <Image src="/images/logo/day_logo.svg" alt="큐메이트" width={94} height={30} />
         </Link>
       </div>
-      <div className="flex items-center justify-center h-screen ">
+      <div className="flex items-center justify-center h-full ">
         <div className="flex flex-col h-[246px]">
           <span className="font-bold text-[24px] pb-5">궁금한 질문 작성하기</span>
           <textarea

--- a/front/src/components/question/QuestionDetailMob.tsx
+++ b/front/src/components/question/QuestionDetailMob.tsx
@@ -28,7 +28,7 @@ export default function QuestionDetailMob() {
 
   if (customItem) {
     return (
-      <div className="w-full h-screen  relative p-10 flex flex-col items-center md:hidden">
+      <div className="w-full h-full relative p-10 flex flex-col items-center md:hidden">
         <Link href={'/question/list'}>
           <X className="absolute right-3 top-3 !w-4 !h-4" />
         </Link>
@@ -43,7 +43,7 @@ export default function QuestionDetailMob() {
   if (!item) return <div className="p-6">선택된 질문이 없습니다.</div>;
 
   return (
-    <div className="w-full h-screen  relative p-10 flex flex-col items-center">
+    <div className="w-full h-full  relative p-10 flex flex-col items-center">
       <Link href={'/question/list'}>
         <X className="absolute right-3 top-3" />
       </Link>

--- a/front/src/components/question/QuestionListMob.tsx
+++ b/front/src/components/question/QuestionListMob.tsx
@@ -52,7 +52,7 @@ export default function QuestionListMob() {
   if (theme === 'night') whiteClass = 'text-secondary';
 
   return (
-    <div className="w-full min-h-screen py-5">
+    <div className="w-full h-full py-5">
       <div className="flex justify-between items-center h-[70px] px-5">
         <Filter setShowCustomOnly={setShowCustomOnly} />
         <p className={`text-20 font-Gumi ${whiteClass}`}>질문 리스트</p>

--- a/front/src/components/question/QuestionListWeb.tsx
+++ b/front/src/components/question/QuestionListWeb.tsx
@@ -57,8 +57,8 @@ export default function QuestionListWeb() {
   else colorClass = '!bg-sunset-active';
 
   return (
-    <div className="w-full h-screen">
-      <div className="mx-5 md:mx-7 h-screen flex items-center">
+    <div className="w-full h-full">
+      <div className="mx-5 md:mx-7 h-full flex items-center">
         {/* 좌측 리스트 */}
         <div className="bg-secondary rounded-md shadow-md lg:w-[350px] w-[220px] h-[550px] flex flex-col">
           <div className="mt-6">

--- a/front/src/components/record/Record.tsx
+++ b/front/src/components/record/Record.tsx
@@ -21,7 +21,7 @@ export default function Record() {
 
         <BellBtn />
       </div>
-      <div className="w-full min-h-screen flex items-center justify-center">
+      <div className="w-full h-full flex items-center justify-center">
         <div className="w-[320px] h-[481px] flex flex-col justify-center ">
           <QuestionCard />
           <div className="pt-5 flex gap-6 ">

--- a/front/src/components/schedule/ScheduleListMob.tsx
+++ b/front/src/components/schedule/ScheduleListMob.tsx
@@ -20,7 +20,7 @@ export default function ScheduleListMob() {
   });
 
   return (
-    <div className=" w-full min-h-screen ">
+    <div className=" w-full h-full ">
       <div className="flex justify-center items-center h-[70px] relative">
         <p className="text-20 font-Gumi select-none">일정</p>
         <Trash2

--- a/front/src/components/schedule/ScheduleRegister.tsx
+++ b/front/src/components/schedule/ScheduleRegister.tsx
@@ -10,7 +10,7 @@ export default function ScheduleRegister() {
   const theme = useThemeStore((state) => state.theme);
 
   return (
-    <div className="w-full h-screen  flex justify-center items-center">
+    <div className="w-full h-full flex justify-center items-center">
       <form
         className="flex w-[310px]  sm:px-0 sm:w-[400px]  flex-col gap-5"
         onSubmit={(e) => e.preventDefault()}

--- a/front/src/components/settings/Settings.tsx
+++ b/front/src/components/settings/Settings.tsx
@@ -51,7 +51,7 @@ export default function Settings() {
   if (theme === 'night') whiteClass = 'text-secondary';
 
   return (
-    <div className="w-full min-h-screen flex flex-col justify-center items-center sm:pt-0 pt-[70px]">
+    <div className="w-full h-full flex flex-col justify-center items-center sm:pt-0 pt-[70px]">
       {/* 모바일 상단바 */}
       <div className="fixed top-0 left-0 right-0 flex items-center justify-between py-5 sm:hidden px-4 ">
         <div className="w-6" />

--- a/front/src/components/siginup/SocialOnboardingForm.tsx
+++ b/front/src/components/siginup/SocialOnboardingForm.tsx
@@ -9,7 +9,7 @@ export default function SocialOnboardingForm() {
   const [active, setActive] = useState(false);
 
   return (
-    <div className=" w-full min-h-screen flex flex-col gap-3 items-center justify-center ">
+    <div className=" w-full h-full flex flex-col gap-3 items-center justify-center ">
       <Image src="/images/logo/day_logo.svg" alt="큐메이트" width={173} height={55} />
 
       <form onSubmit={(e) => e.preventDefault()} className="flex flex-col gap-3">


### PR DESCRIPTION
**AS-IS**
/invite 경로 제외 경로 페이지에서 하단에 불필요한 공백 발생
원인: min-h-screen과 메인 레이아웃의 pt-[70px]이 동시에 적용되어 높이가 중복 계산됨

**TO-BE**
페이지 하단 공백 제거 완료
메인 영역 높이를 h-full 로 조정