### PR TITLE
build: springdoc(OpenAPI) 추가 및 doc 프로필 구성, 보안에 Swagger 경로 허용

### DIFF
--- a/back/build.gradle
+++ b/back/build.gradle
@@ -48,6 +48,10 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+    // openapi
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
+    runtimeOnly 'com.h2database:h2' // doc 프로필에서 메모리 DB로만 띄우기 위함
+
     // test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/back/src/main/java/com/qmate/config/SecurityConfig.java
+++ b/back/src/main/java/com/qmate/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.qmate.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -13,11 +14,18 @@ import org.springframework.security.web.SecurityFilterChain;
 @EnableWebSecurity
 public class SecurityConfig {
 
+  private static final String[] SWAGGER_WHITELIST = {
+      "/v3/api-docs/**",
+      "/swagger-ui/**",
+      "/swagger-ui.html"
+  };
+
   @Bean
   SecurityFilterChain filter(HttpSecurity http) throws Exception {
     return http
         .csrf(AbstractHttpConfigurer::disable)                 // Postman/프론트 테스트 용
         .authorizeHttpRequests(auth -> auth
+            .requestMatchers(SWAGGER_WHITELIST).permitAll()
             .anyRequest().permitAll()                  // 일단 전부 허용
         )
         .build();

--- a/back/src/main/resources/application-doc.yml
+++ b/back/src/main/resources/application-doc.yml
@@ -1,0 +1,22 @@
+server:
+  port: 8080
+
+spring:
+  main:
+    banner-mode: off
+  datasource:
+    url: jdbc:h2:mem:doc;MODE=MySQL;DB_CLOSE_DELAY=-1
+    driverClassName: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    open-in-view: false
+    hibernate:
+      ddl-auto: none
+
+# 필요 시 springdoc 커스터마이즈(옵션)
+# springdoc:
+#   api-docs:
+#     enabled: true
+#   swagger-ui:
+#     enabled: true


### PR DESCRIPTION
## 개요
프로젝트에 **API 문서가 존재하지 않았던 상태**에서, springdoc(OpenAPI) 도입으로 스펙을 자동 생성/열람 가능하게 했습니다. 또한 `doc` 프로필을 추가해 가볍게 기동하고, Swagger 관련 경로를 보안에서 허용했습니다. 다음 단계로 GitHub Pages에 정적 문서 배포(워크플로우) 예정입니다.

## AS-IS
- API 문서 부재(자동 생성/열람 경로 없음)
- 프론트에서 스펙 확인 불가

## TO-BE
- `/v3/api-docs`에서 OpenAPI 스펙 자동 제공
- `doc` 프로필(H2 메모리)로 경량 기동
- Swagger UI 접근 허용으로 프론트 열람 가능
  - `/swagger-ui/**`, `/swagger-ui.html`

## 변경사항
- `build.gradle`
  - `org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.x` 추가
  - `runtimeOnly 'com.h2database:h2'` 추가 (doc 프로필용)
- `src/main/resources/application-doc.yml` 추가
  - H2 메모리 및 최소 옵션 설정
- `SecurityConfig` 수정
  - 허용 URL: `/v3/api-docs/**`, `/swagger-ui/**`, `/swagger-ui.html`