### PR TITLE
docs: OpenAPI 스펙(publish-openapi.yml) 추가 및 doc 프로필 더미 메일 설정 적용

### DIFF
--- a/.github/workflows/publish-openapi.yml
+++ b/.github/workflows/publish-openapi.yml
@@ -1,0 +1,107 @@
+name: Publish OpenAPI docs
+
+on:
+  push:
+    branches: [ dev ]
+  pull_request:
+    branches: [ dev ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages-${{ github.ref_name }}"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Grant execute permission for gradlew (root)
+        run: chmod +x ./gradlew
+
+      - name: Build (bootJar, skip tests)
+        run: ./gradlew -p back bootJar -x test
+
+      - name: Start app (doc profile) and wait for /v3/api-docs
+        env:
+          JAVA_TOOL_OPTIONS: "-XX:MaxRAMPercentage=75"
+        run: |
+          JAR_FILE=$(ls back/build/libs/*.jar | head -n 1)
+          echo "Using JAR: $JAR_FILE"
+          nohup java -jar "$JAR_FILE" --spring.profiles.active=doc > back/build/app.log 2>&1 &
+          APP_PID=$!
+          echo "App PID: $APP_PID"
+
+          for i in {1..90}; do
+            if curl -fsS http://localhost:8080/v3/api-docs >/dev/null; then
+              echo "OpenAPI endpoint is up"; READY=1; break
+            fi
+            if ! ps -p $APP_PID >/dev/null; then
+              echo "App exited early. Recent logs:"; tail -n 200 back/build/app.log || true; exit 1
+            fi
+            echo "Waiting for app... ($i)"; sleep 2
+          done
+
+          if [ -z "$READY" ]; then
+            echo "Timeout waiting for /v3/api-docs"; tail -n 300 back/build/app.log || true; exit 1
+          fi
+
+      - name: Export OpenAPI JSON
+        run: |
+          mkdir -p back/build/docs
+          curl -fsS http://localhost:8080/v3/api-docs > back/build/docs/openapi.json
+          test -s back/build/docs/openapi.json
+
+      - name: Create static Swagger UI
+        run: |
+          mkdir -p back/build/docs
+          cat > back/build/docs/index.html <<'HTML'
+          <!doctype html><html><head>
+            <meta charset="utf-8"/>
+            <title>API Docs</title>
+            <meta name="viewport" content="width=device-width,initial-scale=1"/>
+            <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist/swagger-ui.css"/>
+          </head><body>
+            <div id="swagger-ui"></div>
+            <script src="https://unpkg.com/swagger-ui-dist/swagger-ui-bundle.js"></script>
+            <script>
+              window.onload = () => {
+                window.ui = SwaggerUIBundle({ url: 'openapi.json', dom_id: '#swagger-ui' });
+              };
+            </script>
+          </body></html>
+          HTML
+
+      - name: Upload artifact for Pages
+        if: github.ref_name == 'dev'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: back/build/docs
+
+      - name: Upload preview artifact (openapi.json + index.html)
+        uses: actions/upload-artifact@v4
+        with:
+          name: api-docs-preview
+          path: back/build/docs
+
+  deploy:
+    needs: build
+    if: github.ref_name == 'dev'
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/back/src/main/resources/application-doc.yml
+++ b/back/src/main/resources/application-doc.yml
@@ -14,6 +14,11 @@ spring:
     hibernate:
       ddl-auto: none
 
+  mail:
+    host: smtp.example.com
+    port: 587
+    test-connection: false
+
 # 필요 시 springdoc 커스터마이즈(옵션)
 # springdoc:
 #   api-docs:


### PR DESCRIPTION
## 개요
- dev 브랜치에서 OpenAPI 스펙(`/v3/api-docs`)을 추출하고 정적 Swagger UI로 변환하여 GitHub Pages로 배포합니다.
- Pages 배포 전에도 Actions 아티팩트(`api-docs-preview`)로 미리보기 가능합니다.
- 문서 추출 시 메일 설정으로 인한 부팅 이슈를 방지하기 위해 **doc 프로필에 더미 메일 설정**을 추가했습니다.

## 변경 사항
- `.github/workflows/publish-openapi.yml` 추가
  - 루트 `gradlew` + 서브프로젝트 `back/`(build.gradle 위치)에 맞춰 `-p back` 사용
  - `bootJar` 빌드 후 `java -jar --spring.profiles.active=doc` 로 앱 기동
  - `/v3/api-docs` 준비까지 대기(최대 180초) 및 조기 종료 시 로그 출력
  - `back/build/docs/openapi.json` 추출 및 `index.html`(Swagger UI) 생성
  - dev에서만 Pages 배포, 모든 트리거에서 미리보기 아티팩트 업로드
- `application-doc.yml` 업데이트
  - **더미 메일 설정 추가**: 
    - `spring.mail.host: smtp.example.com`
    - `spring.mail.port: 587`
    - `spring.mail.test-connection: false`
  - 목적: 문서 추출용(doc) 실행 시 `MailSender` 초기화/연결 시도 방지

## 트리거
- `push`: dev
- `pull_request`: dev 대상
- `workflow_dispatch`: 수동 실행

## 확인 방법
1. Actions 실행 로그에서 `OpenAPI endpoint is up` 메시지 확인  
2. 아티팩트:
   - **Artifacts → `api-docs-preview`** 다운로드 → `index.html` 로컬 열람
3. Pages(오너 설정 완료 시):
   - Settings → Pages의 배포 URL 접속 → Swagger UI에서 스펙 로딩 확인

## 오너에게 필요한 2가지 설정
- Settings → **Pages** → Source: **GitHub Actions**
- Settings → **Actions → General** → Workflow permissions: **Read and write permissions**