### PR TITLE
Feature/qi 04 answer update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ back/out/
 back/.classpath
 back/.project
 back/.settings/back/src/main/resources/application-local.yml
+back/src/main/resources/application-test.yml

--- a/back/src/main/java/com/qmate/api/questioninstance/AnswerController.java
+++ b/back/src/main/java/com/qmate/api/questioninstance/AnswerController.java
@@ -1,7 +1,7 @@
 package com.qmate.api.questioninstance;
 
 import com.qmate.domain.questioninstance.model.request.AnswerContentRequest;
-import com.qmate.domain.questioninstance.model.response.AnswerCreateResponse;
+import com.qmate.domain.questioninstance.model.response.AnswerResponse;
 import com.qmate.domain.questioninstance.service.AnswerService;
 import jakarta.validation.Valid;
 import java.net.URI;
@@ -21,14 +21,14 @@ public class AnswerController {
   private final AnswerService answerService;
 
   @PostMapping(value = "/question-instances/{questionInstanceId}/answers")
-  public ResponseEntity<AnswerCreateResponse> create(
+  public ResponseEntity<AnswerResponse> create(
       @PathVariable Long questionInstanceId,
       // TODO: @AuthenticationPrincipal CustomUserDetails principal
       @Valid @RequestBody AnswerContentRequest request
   ) {
     Long userId = 1L; // TODO: principal.getUserId();
 
-    AnswerCreateResponse response = answerService.create(questionInstanceId, userId, request);
+    AnswerResponse response = answerService.create(questionInstanceId, userId, request);
 
     // Location: 생성으로 인해 최신 상태가 된 QI 상세 리소스
     URI location = URI.create("/api/question-instances/" + questionInstanceId);

--- a/back/src/main/java/com/qmate/api/questioninstance/AnswerController.java
+++ b/back/src/main/java/com/qmate/api/questioninstance/AnswerController.java
@@ -7,6 +7,7 @@ import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -20,7 +21,7 @@ public class AnswerController {
 
   private final AnswerService answerService;
 
-  @PostMapping(value = "/question-instances/{questionInstanceId}/answers")
+  @PostMapping("/question-instances/{questionInstanceId}/answers")
   public ResponseEntity<AnswerResponse> create(
       @PathVariable Long questionInstanceId,
       // TODO: @AuthenticationPrincipal CustomUserDetails principal
@@ -33,5 +34,17 @@ public class AnswerController {
     // Location: 생성으로 인해 최신 상태가 된 QI 상세 리소스
     URI location = URI.create("/api/question-instances/" + questionInstanceId);
     return ResponseEntity.created(location).body(response);
+  }
+
+  @PatchMapping("/answers/{answerId}")
+  public ResponseEntity<AnswerResponse> update(
+      @PathVariable Long answerId,
+      // TODO: @AuthenticationPrincipal CustomUserDetails principal
+      @Valid @RequestBody AnswerContentRequest request
+  ) {
+    Long userId = 1L; // TODO: principal.getUserId();
+
+    AnswerResponse response = answerService.update(answerId, userId, request);
+    return ResponseEntity.ok(response);
   }
 }

--- a/back/src/main/java/com/qmate/domain/questioninstance/mapper/AnswerMapper.java
+++ b/back/src/main/java/com/qmate/domain/questioninstance/mapper/AnswerMapper.java
@@ -5,6 +5,7 @@ import com.qmate.domain.questioninstance.entity.QuestionInstance;
 import com.qmate.domain.questioninstance.model.request.AnswerContentRequest;
 import com.qmate.domain.questioninstance.model.response.AnswerResponse;
 import com.qmate.domain.user.User;
+import java.time.LocalDateTime;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
@@ -29,7 +30,7 @@ public class AnswerMapper {
         .build();
   }
 
-  private static String normalize(String raw) {
+  public static String normalize(String raw) {
     if (raw == null) return null;
     return raw.trim().replace("\r\n", "\n");
   }

--- a/back/src/main/java/com/qmate/domain/questioninstance/mapper/AnswerMapper.java
+++ b/back/src/main/java/com/qmate/domain/questioninstance/mapper/AnswerMapper.java
@@ -3,7 +3,7 @@ package com.qmate.domain.questioninstance.mapper;
 import com.qmate.domain.questioninstance.entity.Answer;
 import com.qmate.domain.questioninstance.entity.QuestionInstance;
 import com.qmate.domain.questioninstance.model.request.AnswerContentRequest;
-import com.qmate.domain.questioninstance.model.response.AnswerCreateResponse;
+import com.qmate.domain.questioninstance.model.response.AnswerResponse;
 import com.qmate.domain.user.User;
 import lombok.NoArgsConstructor;
 
@@ -19,13 +19,13 @@ public class AnswerMapper {
         .build();
   }
 
-  public static AnswerCreateResponse toResponse(Answer a) {
-    return AnswerCreateResponse.builder()
+  public static AnswerResponse toResponse(Answer a) {
+    return AnswerResponse.builder()
         .answerId(a.getId())
         .questionInstanceId(a.getQuestionInstance().getId())
-        .userId(a.getUser().getId())
         .content(a.getContent())
         .submittedAt(a.getSubmittedAt())
+        .updatedAt(a.getUpdatedAt())
         .build();
   }
 

--- a/back/src/main/java/com/qmate/domain/questioninstance/model/response/AnswerResponse.java
+++ b/back/src/main/java/com/qmate/domain/questioninstance/model/response/AnswerResponse.java
@@ -10,11 +10,11 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class AnswerCreateResponse {
+public class AnswerResponse {
 
   private Long answerId;
   private Long questionInstanceId;
-  private Long userId;
   private String content;
   private LocalDateTime submittedAt;
+  private LocalDateTime updatedAt;
 }

--- a/back/src/main/java/com/qmate/domain/questioninstance/service/AnswerService.java
+++ b/back/src/main/java/com/qmate/domain/questioninstance/service/AnswerService.java
@@ -5,7 +5,7 @@ import com.qmate.domain.questioninstance.entity.InstanceStatus;
 import com.qmate.domain.questioninstance.entity.QuestionInstance;
 import com.qmate.domain.questioninstance.mapper.AnswerMapper;
 import com.qmate.domain.questioninstance.model.request.AnswerContentRequest;
-import com.qmate.domain.questioninstance.model.response.AnswerCreateResponse;
+import com.qmate.domain.questioninstance.model.response.AnswerResponse;
 import com.qmate.domain.questioninstance.repository.AnswerRepository;
 import com.qmate.domain.questioninstance.repository.QuestionInstanceRepository;
 import com.qmate.domain.user.User;
@@ -16,11 +16,8 @@ import com.qmate.exception.custom.questioninstance.AnswerCannotModifyException;
 import com.qmate.exception.custom.questioninstance.QuestionInstanceForbiddenException;
 import com.qmate.exception.custom.questioninstance.QuestionInstanceNotFoundException;
 import java.time.LocalDateTime;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
-import org.apache.coyote.BadRequestException;
 import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.data.crossstore.ChangeSetPersister.NotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,7 +30,7 @@ public class AnswerService {
   private final AnswerRepository answerRepository;
 
   @Transactional
-  public AnswerCreateResponse create(Long questionInstanceId, Long userId, AnswerContentRequest req) {
+  public AnswerResponse create(Long questionInstanceId, Long userId, AnswerContentRequest req) {
 
     // 1) 로드
     QuestionInstance qi = questionInstanceRepository.findById(questionInstanceId)

--- a/back/src/main/java/com/qmate/domain/questioninstance/service/AnswerService.java
+++ b/back/src/main/java/com/qmate/domain/questioninstance/service/AnswerService.java
@@ -13,6 +13,7 @@ import com.qmate.domain.user.UserRepository;
 import com.qmate.exception.custom.UserNotFoundException;
 import com.qmate.exception.custom.questioninstance.AnswerAlreadyExistsException;
 import com.qmate.exception.custom.questioninstance.AnswerCannotModifyException;
+import com.qmate.exception.custom.questioninstance.AnswerForbiddenException;
 import com.qmate.exception.custom.questioninstance.AnswerNotFoundException;
 import com.qmate.exception.custom.questioninstance.QuestionInstanceForbiddenException;
 import com.qmate.exception.custom.questioninstance.QuestionInstanceNotFoundException;
@@ -64,6 +65,8 @@ public class AnswerService {
       throw new AnswerAlreadyExistsException();
     }
 
+    // TODO matchMember의 lastAnsweredAt 갱신
+
     // 5) 두 사람 모두 답하면 QI 완료 전이
     if (answerRepository.countByQuestionInstance_Id(questionInstanceId) >= 2L) {
       qi.markCompleted(LocalDateTime.now());
@@ -83,7 +86,7 @@ public class AnswerService {
 
     // 2) 권한 검증: 작성자만 가능
     if (!answer.getUser().getId().equals(userId)) {
-      throw new QuestionInstanceForbiddenException();
+      throw new AnswerForbiddenException();
     }
 
     // 3) 상태 검증
@@ -97,7 +100,12 @@ public class AnswerService {
     String normalized = AnswerMapper.normalize(req.getContent());
     answer.setContent(normalized);
 
-    // 5) 응답 매핑
+    // TODO matchMember의 lastAnsweredAt 갱신
+
+    // 5) updatedAt(@LastModifiedDate) 보장
+    answerRepository.saveAndFlush(answer);
+
+    // 6) 응답 매핑
     return AnswerMapper.toResponse(answer);
   }
 }

--- a/back/src/main/java/com/qmate/domain/questioninstance/service/AnswerService.java
+++ b/back/src/main/java/com/qmate/domain/questioninstance/service/AnswerService.java
@@ -13,6 +13,7 @@ import com.qmate.domain.user.UserRepository;
 import com.qmate.exception.custom.UserNotFoundException;
 import com.qmate.exception.custom.questioninstance.AnswerAlreadyExistsException;
 import com.qmate.exception.custom.questioninstance.AnswerCannotModifyException;
+import com.qmate.exception.custom.questioninstance.AnswerNotFoundException;
 import com.qmate.exception.custom.questioninstance.QuestionInstanceForbiddenException;
 import com.qmate.exception.custom.questioninstance.QuestionInstanceNotFoundException;
 import java.time.LocalDateTime;
@@ -71,5 +72,32 @@ public class AnswerService {
 
     // 6) 응답 매핑
     return AnswerMapper.toResponse(saved);
+  }
+
+  @Transactional
+  public AnswerResponse update(Long answerId, Long userId, AnswerContentRequest req) {
+
+    // 1) 로드
+    Answer answer = answerRepository.findById(answerId)
+        .orElseThrow(AnswerNotFoundException::new);
+
+    // 2) 권한 검증: 작성자만 가능
+    if (!answer.getUser().getId().equals(userId)) {
+      throw new QuestionInstanceForbiddenException();
+    }
+
+    // 3) 상태 검증
+    InstanceStatus status = answer.getQuestionInstance().getStatus();
+    // PENDING만 통과
+    if (status != InstanceStatus.PENDING) {
+      throw new AnswerCannotModifyException();
+    }
+
+    // 4) 수정
+    String normalized = AnswerMapper.normalize(req.getContent());
+    answer.setContent(normalized);
+
+    // 5) 응답 매핑
+    return AnswerMapper.toResponse(answer);
   }
 }

--- a/back/src/main/java/com/qmate/exception/custom/questioninstance/AnswerForbiddenException.java
+++ b/back/src/main/java/com/qmate/exception/custom/questioninstance/AnswerForbiddenException.java
@@ -1,0 +1,12 @@
+package com.qmate.exception.custom.questioninstance;
+
+import com.qmate.exception.BusinessGlobalException;
+import com.qmate.exception.errorcode.AnswerErrorCode;
+
+public class AnswerForbiddenException extends BusinessGlobalException {
+
+  public AnswerForbiddenException() {
+    super(AnswerErrorCode.answerForbidden());
+  }
+
+}

--- a/back/src/main/java/com/qmate/exception/custom/questioninstance/AnswerNotFoundException.java
+++ b/back/src/main/java/com/qmate/exception/custom/questioninstance/AnswerNotFoundException.java
@@ -1,0 +1,11 @@
+package com.qmate.exception.custom.questioninstance;
+
+import com.qmate.exception.BusinessGlobalException;
+import com.qmate.exception.errorcode.AnswerErrorCode;
+
+public class AnswerNotFoundException extends BusinessGlobalException {
+
+  public AnswerNotFoundException() {
+    super(AnswerErrorCode.answerNotFound());
+  }
+}

--- a/back/src/main/java/com/qmate/exception/errorcode/AnswerErrorCode.java
+++ b/back/src/main/java/com/qmate/exception/errorcode/AnswerErrorCode.java
@@ -10,6 +10,7 @@ public class AnswerErrorCode extends ErrorCode {
   private static final String ANSWER_NOT_FOUND = "답변을 찾을 수 없습니다.";
   public static final String ANSWER_ALREADY_EXISTS = "이미 답변이 존재합니다.";
   public static final String ANSWER_CANNOT_MODIFY = "답변을 작성/수정할 수 없는 상태입니다.";
+  public static final String ANSWER_FORBIDDEN = "답변에 접근할 수 있는 권한이 없습니다.";
 
   public static ErrorCode answerNotFound() {
     return new AnswerErrorCode(HttpStatus.NOT_FOUND, "ANSWER_001", ANSWER_NOT_FOUND);
@@ -21,6 +22,10 @@ public class AnswerErrorCode extends ErrorCode {
 
   public static ErrorCode answerCannotModify() {
     return new AnswerErrorCode(HttpStatus.LOCKED, "ANSWER_003", ANSWER_CANNOT_MODIFY);
+  }
+
+  public static ErrorCode answerForbidden() {
+    return new AnswerErrorCode(HttpStatus.FORBIDDEN, "ANSWER_004", ANSWER_FORBIDDEN);
   }
 
   protected AnswerErrorCode(HttpStatus httpStatus, String code, String message) {

--- a/back/src/test/java/com/qmate/questioninstance/AnswerControllerCreateTest.java
+++ b/back/src/test/java/com/qmate/questioninstance/AnswerControllerCreateTest.java
@@ -32,7 +32,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(controllers = AnswerController.class)
 @AutoConfigureMockMvc(addFilters = false)
-class AnswerControllerTest {
+class AnswerControllerCreateTest {
 
   @Autowired
   MockMvc mockMvc;
@@ -60,14 +60,12 @@ class AnswerControllerTest {
 
     // expect
     mockMvc.perform(post("/api/question-instances/{qiId}/answers", qiId)
-            .with(csrf())
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(req)))
         .andExpect(status().isCreated())
         .andExpect(header().string("Location", "/api/question-instances/" + qiId))
         .andExpect(jsonPath("$.answerId").value(456))
         .andExpect(jsonPath("$.questionInstanceId").value(123))
-        .andExpect(jsonPath("$.userId").value(99))
         .andExpect(jsonPath("$.content").value("최대 100자"))
         .andExpect(jsonPath("$.submittedAt").value("2025-09-11T12:20:00"));
   }
@@ -80,7 +78,6 @@ class AnswerControllerTest {
 
     // expect
     mockMvc.perform(post("/api/question-instances/{qiId}/answers", 1L)
-            .with(csrf())
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(bad)))
         .andExpect(status().isBadRequest());
@@ -97,7 +94,6 @@ class AnswerControllerTest {
 
     // expect
     mockMvc.perform(post("/api/question-instances/{qiId}/answers", qiId)
-            .with(csrf())
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(req)))
         .andExpect(status().isForbidden());
@@ -114,7 +110,6 @@ class AnswerControllerTest {
 
     // expect
     mockMvc.perform(post("/api/question-instances/{qiId}/answers", qiId)
-            .with(csrf())
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(req)))
         .andExpect(status().isLocked());
@@ -131,7 +126,6 @@ class AnswerControllerTest {
 
     // expect
     mockMvc.perform(post("/api/question-instances/{qiId}/answers", qiId)
-            .with(csrf())
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(req)))
         .andExpect(status().isConflict());
@@ -148,7 +142,6 @@ class AnswerControllerTest {
 
     // expect
     mockMvc.perform(post("/api/question-instances/{qiId}/answers", qiId)
-            .with(csrf())
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(req)))
         .andExpect(status().isNotFound());

--- a/back/src/test/java/com/qmate/questioninstance/AnswerControllerTest.java
+++ b/back/src/test/java/com/qmate/questioninstance/AnswerControllerTest.java
@@ -14,7 +14,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.qmate.api.questioninstance.AnswerController;
 import com.qmate.domain.questioninstance.model.request.AnswerContentRequest;
-import com.qmate.domain.questioninstance.model.response.AnswerCreateResponse;
+import com.qmate.domain.questioninstance.model.response.AnswerResponse;
 import com.qmate.domain.questioninstance.service.AnswerService;
 import com.qmate.exception.custom.questioninstance.AnswerAlreadyExistsException;
 import com.qmate.exception.custom.questioninstance.AnswerCannotModifyException;
@@ -34,8 +34,10 @@ import org.springframework.test.web.servlet.MockMvc;
 @AutoConfigureMockMvc(addFilters = false)
 class AnswerControllerTest {
 
-  @Autowired MockMvc mockMvc;
-  @Autowired ObjectMapper objectMapper;
+  @Autowired
+  MockMvc mockMvc;
+  @Autowired
+  ObjectMapper objectMapper;
 
   @MockitoBean
   AnswerService answerService;
@@ -47,8 +49,9 @@ class AnswerControllerTest {
     Long qiId = 123L;
     var req = new AnswerContentRequest("최대 100자");
     // userId는 컨트롤러 내부 구현(현재는 1L, 이후 principal)과 무관하게 anyLong()로 대응
-    var res = new AnswerCreateResponse(
-        456L, qiId, 99L, "최대 100자",
+    var res = new AnswerResponse(
+        456L, qiId, "최대 100자",
+        LocalDateTime.parse("2025-09-11T12:20:00"),
         LocalDateTime.parse("2025-09-11T12:20:00")
     );
 

--- a/back/src/test/java/com/qmate/questioninstance/AnswerControllerUpdateTest.java
+++ b/back/src/test/java/com/qmate/questioninstance/AnswerControllerUpdateTest.java
@@ -1,0 +1,136 @@
+package com.qmate.questioninstance;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.times;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.qmate.api.questioninstance.AnswerController;
+import com.qmate.domain.questioninstance.model.request.AnswerContentRequest;
+import com.qmate.domain.questioninstance.model.response.AnswerResponse;
+import com.qmate.domain.questioninstance.service.AnswerService;
+import com.qmate.exception.custom.questioninstance.AnswerCannotModifyException;
+import com.qmate.exception.custom.questioninstance.AnswerNotFoundException;
+import com.qmate.exception.custom.questioninstance.QuestionInstanceForbiddenException;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = AnswerController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class AnswerControllerUpdateTest {
+
+  @Autowired
+  MockMvc mockMvc;
+  @Autowired
+  ObjectMapper objectMapper;
+
+  @MockitoBean
+  AnswerService answerService;
+
+  @Test
+  @DisplayName("200 OK: 수정 성공 시 공통 응답 반환")
+  void update_200_ok() throws Exception {
+    Long answerId = 1L;
+    var req = new AnswerContentRequest("수정된 내용");
+    var res = new AnswerResponse(
+        answerId, 123L, "수정된 내용",
+        LocalDateTime.parse("2025-09-11T12:00:00"),
+        LocalDateTime.parse("2025-09-11T12:30:00")
+    );
+
+    given(answerService.update(eq(answerId), anyLong(), any(AnswerContentRequest.class)))
+        .willReturn(res);
+
+    mockMvc.perform(patch("/api/answers/{answerId}", answerId)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(req)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.answerId").value(answerId))
+        .andExpect(jsonPath("$.questionInstanceId").value(123))
+        .andExpect(jsonPath("$.content").value("수정된 내용"))
+        .andExpect(jsonPath("$.submittedAt").value("2025-09-11T12:00:00"))
+        .andExpect(jsonPath("$.updatedAt").value("2025-09-11T12:30:00"));
+
+    then(answerService).should(times(1))
+        .update(eq(answerId), anyLong(), any(AnswerContentRequest.class));
+  }
+
+  @Test
+  @DisplayName("content > 100 → 400 Bad Request (컨트롤러 @Valid)")
+  void update_content_too_long_400() throws Exception {
+    String tooLong = "a".repeat(101);
+    String body = objectMapper.writeValueAsString(new AnswerContentRequest(tooLong));
+
+    mockMvc.perform(
+            patch("/api/answers/{answerId}", 1L)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
+        .andExpect(status().isBadRequest());
+
+    Mockito.verifyNoInteractions(answerService);
+  }
+
+  @Test
+  @DisplayName("423 Locked: QI 상태가 완료/만료라 수정 불가")
+  void update_423_locked() throws Exception {
+    // given
+    Long answerId = 11L;
+    var req = new AnswerContentRequest("ok");
+    willThrow(new AnswerCannotModifyException())
+        .given(answerService).update(eq(answerId), anyLong(), any(AnswerContentRequest.class));
+
+    // expect
+    mockMvc.perform(patch("/api/answers/{answerId}", answerId)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(req)))
+        .andExpect(status().isLocked());
+  }
+
+  @Test
+  @DisplayName("404 Not Found: answer가 없음")
+  void update_404_answerNotFound() throws Exception {
+    // given
+    Long answerId = 404L;
+    var req = new AnswerContentRequest("ok");
+    willThrow(new AnswerNotFoundException())
+        .given(answerService).update(eq(answerId), anyLong(), any(AnswerContentRequest.class));
+
+    // expect
+    mockMvc.perform(patch("/api/answers/{answerId}", answerId)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(req)))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  @DisplayName("403 forbidden: 작성자가 아님")
+  void update_403_forbidden() throws Exception {
+    // given
+    Long answerId = 13L;
+    var req = new AnswerContentRequest("ok");
+    willThrow(new QuestionInstanceForbiddenException())
+        .given(answerService).update(eq(answerId), anyLong(), any(AnswerContentRequest.class));
+
+    // expect
+    mockMvc.perform(patch("/api/answers/{answerId}", answerId)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(req)))
+        .andExpect(status().isForbidden());
+  }
+}

--- a/back/src/test/java/com/qmate/questioninstance/AnswerControllerUpdateTest.java
+++ b/back/src/test/java/com/qmate/questioninstance/AnswerControllerUpdateTest.java
@@ -18,6 +18,7 @@ import com.qmate.domain.questioninstance.model.request.AnswerContentRequest;
 import com.qmate.domain.questioninstance.model.response.AnswerResponse;
 import com.qmate.domain.questioninstance.service.AnswerService;
 import com.qmate.exception.custom.questioninstance.AnswerCannotModifyException;
+import com.qmate.exception.custom.questioninstance.AnswerForbiddenException;
 import com.qmate.exception.custom.questioninstance.AnswerNotFoundException;
 import com.qmate.exception.custom.questioninstance.QuestionInstanceForbiddenException;
 import java.time.LocalDateTime;
@@ -124,7 +125,7 @@ class AnswerControllerUpdateTest {
     // given
     Long answerId = 13L;
     var req = new AnswerContentRequest("ok");
-    willThrow(new QuestionInstanceForbiddenException())
+    willThrow(new AnswerForbiddenException())
         .given(answerService).update(eq(answerId), anyLong(), any(AnswerContentRequest.class));
 
     // expect

--- a/back/src/test/java/com/qmate/questioninstance/AnswerMapperTest.java
+++ b/back/src/test/java/com/qmate/questioninstance/AnswerMapperTest.java
@@ -6,7 +6,7 @@ import com.qmate.domain.questioninstance.entity.Answer;
 import com.qmate.domain.questioninstance.entity.QuestionInstance;
 import com.qmate.domain.questioninstance.mapper.AnswerMapper;
 import com.qmate.domain.questioninstance.model.request.AnswerContentRequest;
-import com.qmate.domain.questioninstance.model.response.AnswerCreateResponse;
+import com.qmate.domain.questioninstance.model.response.AnswerResponse;
 import com.qmate.domain.user.User;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.Test;
@@ -38,11 +38,10 @@ class AnswerMapperTest {
         .submittedAt(LocalDateTime.parse("2025-09-11T12:20:00"))
         .build();
 
-    AnswerCreateResponse res = AnswerMapper.toResponse(a);
+    AnswerResponse res = AnswerMapper.toResponse(a);
 
     assertThat(res.getAnswerId()).isEqualTo(456L);
     assertThat(res.getQuestionInstanceId()).isEqualTo(123L);
-    assertThat(res.getUserId()).isEqualTo(99L);
     assertThat(res.getContent()).isEqualTo("hello");
     assertThat(res.getSubmittedAt()).isEqualTo("2025-09-11T12:20:00");
   }

--- a/back/src/test/java/com/qmate/questioninstance/AnswerServiceCreateTest.java
+++ b/back/src/test/java/com/qmate/questioninstance/AnswerServiceCreateTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.BDDAssertions.thenThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.verify;
 
 import com.qmate.domain.match.Match;
 import com.qmate.domain.questioninstance.entity.Answer;
@@ -27,7 +26,6 @@ import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -78,7 +76,6 @@ class AnswerServiceCreateTest {
     // then
     assertThat(res.getAnswerId()).isEqualTo(456L);
     assertThat(res.getQuestionInstanceId()).isEqualTo(123L);
-    assertThat(res.getUserId()).isEqualTo(99L);
     assertThat(res.getContent()).isEqualTo("안녕\n하세요");
     assertThat(res.getSubmittedAt()).isEqualTo("2025-09-11T12:20:00");
 

--- a/back/src/test/java/com/qmate/questioninstance/AnswerServiceUpdateTest.java
+++ b/back/src/test/java/com/qmate/questioninstance/AnswerServiceUpdateTest.java
@@ -13,6 +13,7 @@ import com.qmate.domain.questioninstance.repository.AnswerRepository;
 import com.qmate.domain.questioninstance.service.AnswerService;
 import com.qmate.domain.user.User;
 import com.qmate.exception.custom.questioninstance.AnswerCannotModifyException;
+import com.qmate.exception.custom.questioninstance.AnswerForbiddenException;
 import com.qmate.exception.custom.questioninstance.AnswerNotFoundException;
 import com.qmate.exception.custom.questioninstance.QuestionInstanceForbiddenException;
 import java.time.LocalDate;
@@ -77,6 +78,7 @@ class AnswerServiceUpdateTest {
 
       // then: 리포지토리 호출 검증
       then(answerRepository).should(times(1)).findById(answerId);
+      then(answerRepository).should(times(1)).saveAndFlush(answer);
       then(answerRepository).shouldHaveNoMoreInteractions();
 
       // 엔티티 자체가 수정되었는지(정규화 반영) + 응답 스펙 확인
@@ -130,7 +132,7 @@ class AnswerServiceUpdateTest {
       given(answerRepository.findById(answerId)).willReturn(Optional.of(answer));
 
       // when / then
-      assertThrows(QuestionInstanceForbiddenException.class,
+      assertThrows(AnswerForbiddenException.class,
           () -> answerService.update(answerId, otherId, new AnswerContentRequest("x")));
 
       then(answerRepository).should(times(1)).findById(answerId);

--- a/back/src/test/java/com/qmate/questioninstance/AnswerServiceUpdateTest.java
+++ b/back/src/test/java/com/qmate/questioninstance/AnswerServiceUpdateTest.java
@@ -1,0 +1,171 @@
+package com.qmate.questioninstance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.*;
+
+import com.qmate.domain.questioninstance.entity.Answer;
+import com.qmate.domain.questioninstance.entity.InstanceStatus;
+import com.qmate.domain.questioninstance.entity.QuestionInstance;
+import com.qmate.domain.questioninstance.model.request.AnswerContentRequest;
+import com.qmate.domain.questioninstance.model.response.AnswerResponse;
+import com.qmate.domain.questioninstance.repository.AnswerRepository;
+import com.qmate.domain.questioninstance.service.AnswerService;
+import com.qmate.domain.user.User;
+import com.qmate.exception.custom.questioninstance.AnswerCannotModifyException;
+import com.qmate.exception.custom.questioninstance.AnswerNotFoundException;
+import com.qmate.exception.custom.questioninstance.QuestionInstanceForbiddenException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AnswerServiceUpdateTest {
+
+  @Mock
+  AnswerRepository answerRepository;
+  @InjectMocks
+  AnswerService answerService;
+
+  @Nested
+  @DisplayName("정상 작동")
+  class Success {
+
+    @Test
+    @DisplayName("작성자 본인이 PENDING 상태에서 내용 수정 → 응답 스펙/정규화 검증")
+    void update_ok() {
+      // given
+      Long answerId = 100L;
+      Long userId = 1L;
+
+      User owner = User.builder()
+          .id(userId)
+          .email("owner@test.com")
+          .nickname("owner")
+          .passwordHash("x")
+          .birthDate(LocalDate.now())
+          .build();
+
+      QuestionInstance qi = QuestionInstance.builder()
+          .id(10L)
+          .status(InstanceStatus.PENDING)
+          .build();
+
+      Answer answer = Answer.builder()
+          .id(answerId)
+          .user(owner)
+          .questionInstance(qi)
+          .content("초기 내용")
+          .submittedAt(LocalDateTime.parse("2025-09-11T12:00:00"))
+          .updatedAt(LocalDateTime.parse("2025-09-11T12:30:00"))
+          .build();
+
+      given(answerRepository.findById(answerId)).willReturn(Optional.of(answer));
+
+      String raw = "  수정된 내용\r\n두줄  ";
+      String normalized = "수정된 내용\n두줄";
+
+      // when
+      AnswerResponse res = answerService.update(answerId, userId, new AnswerContentRequest(raw));
+
+      // then: 리포지토리 호출 검증
+      then(answerRepository).should(times(1)).findById(answerId);
+      then(answerRepository).shouldHaveNoMoreInteractions();
+
+      // 엔티티 자체가 수정되었는지(정규화 반영) + 응답 스펙 확인
+      assertThat(answer.getContent()).isEqualTo(normalized);
+      assertThat(res.getAnswerId()).isEqualTo(answerId);
+      assertThat(res.getQuestionInstanceId()).isEqualTo(qi.getId());
+      assertThat(res.getContent()).isEqualTo(normalized);
+      assertThat(res.getSubmittedAt()).isEqualTo(answer.getSubmittedAt());
+      assertThat(res.getUpdatedAt()).isNotNull();
+    }
+  }
+
+  @Nested
+  @DisplayName("실패")
+  class Failures {
+
+    @Test
+    @DisplayName("404 Not Found: 미존재 answerId")
+    void update_notFound_404() {
+      // given
+      Long notExist = 999L;
+      given(answerRepository.findById(notExist)).willReturn(Optional.empty());
+
+      // when / then
+      assertThrows(AnswerNotFoundException.class,
+          () -> answerService.update(notExist, 1L, new AnswerContentRequest("x")));
+
+      then(answerRepository).should(times(1)).findById(notExist);
+      then(answerRepository).shouldHaveNoMoreInteractions();
+    }
+
+    @Test
+    @DisplayName("403 Forbidden: 작성자 아님")
+    void update_forbidden_403() {
+      // given
+      Long answerId = 100L;
+      Long ownerId = 1L;
+      Long otherId = 2L;
+
+      User owner = User.builder()
+          .id(ownerId).email("o@o").nickname("o")
+          .passwordHash("x").birthDate(LocalDate.now())
+          .build();
+
+      QuestionInstance qi = QuestionInstance.builder()
+          .id(10L).status(InstanceStatus.PENDING).build();
+
+      Answer answer = Answer.builder()
+          .id(answerId).user(owner).questionInstance(qi).content("초기").build();
+
+      given(answerRepository.findById(answerId)).willReturn(Optional.of(answer));
+
+      // when / then
+      assertThrows(QuestionInstanceForbiddenException.class,
+          () -> answerService.update(answerId, otherId, new AnswerContentRequest("x")));
+
+      then(answerRepository).should(times(1)).findById(answerId);
+      then(answerRepository).shouldHaveNoMoreInteractions();
+    }
+
+    @Test
+    @DisplayName("423 Locked: PENDING 이외 상태")
+    void update_locked_423() {
+      // given
+      Long answerId = 100L;
+      Long userId = 1L;
+
+      User owner = User.builder()
+          .id(userId).email("o@o").nickname("o")
+          .passwordHash("x").birthDate(LocalDate.now())
+          .build();
+
+      QuestionInstance qi = QuestionInstance.builder()
+          .id(10L).status(InstanceStatus.COMPLETED) // 수정 불가 상태
+          .build();
+
+      Answer answer = Answer.builder()
+          .id(answerId).user(owner).questionInstance(qi).content("초기").build();
+
+      given(answerRepository.findById(answerId)).willReturn(Optional.of(answer));
+
+      // when / then
+      assertThrows(AnswerCannotModifyException.class,
+          () -> answerService.update(answerId, userId, new AnswerContentRequest("x")));
+
+      then(answerRepository).should(times(1)).findById(answerId);
+      then(answerRepository).shouldHaveNoMoreInteractions();
+    }
+
+  }
+
+}

--- a/back/src/test/java/com/qmate/questioninstance/AnswerServiceUpdateTimestampTest.java
+++ b/back/src/test/java/com/qmate/questioninstance/AnswerServiceUpdateTimestampTest.java
@@ -1,0 +1,139 @@
+package com.qmate.questioninstance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.qmate.domain.match.Match;
+import com.qmate.domain.match.MatchStatus;
+import com.qmate.domain.question.entity.Question;
+import com.qmate.domain.question.entity.QuestionCategory;
+import com.qmate.domain.question.entity.RelationType;
+import com.qmate.domain.questioninstance.entity.Answer;
+import com.qmate.domain.questioninstance.entity.InstanceStatus;
+import com.qmate.domain.questioninstance.entity.QuestionInstance;
+import com.qmate.domain.questioninstance.model.request.AnswerContentRequest;
+import com.qmate.domain.questioninstance.model.response.AnswerResponse;
+import com.qmate.domain.questioninstance.service.AnswerService;
+import com.qmate.domain.user.User;
+import jakarta.persistence.EntityManager;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
+class AnswerServiceUpdateTimestampTest {
+
+  @Autowired AnswerService answerService;
+  @Autowired EntityManager em;
+
+  Long ownerId, qiId, answerId;
+
+  @BeforeEach
+  @Transactional
+  void setUp() {
+    // 1) user
+    User owner = User.builder()
+        .email("owner@test.com").nickname("owner")
+        .passwordHash("x").birthDate(LocalDate.now())
+        .build();
+    em.persist(owner);
+
+    // 2) match
+    Match match = Match.builder()
+        .relationType(com.qmate.domain.match.RelationType.FRIEND)
+        .status(MatchStatus.ACTIVE) // enum은 프로젝트 정의에 맞게
+        .build();
+    em.persist(match);
+
+    // 3) question_category + question (관리자 질문 루트)
+    QuestionCategory cat = QuestionCategory.builder()
+        .name("기본").relationType(RelationType.BOTH).isActive(true).build();
+    em.persist(cat);
+
+    Question q = Question.builder()
+        .category(cat)
+        .relationType(RelationType.BOTH)
+        .text("샘플 질문")
+        .isActive(true)
+        .build();
+    em.persist(q);
+
+    // 4) question_instance (PENDING, question_id만 설정, delivered_at 필수)
+    QuestionInstance qi = QuestionInstance.builder()
+        .match(match)
+        .question(q)                 // custom_question은 null 유지 (CHECK 제약 충족)
+        .deliveredAt(LocalDateTime.now()) // 필수
+        .status(InstanceStatus.PENDING)   // ‘PENDING|COMPLETED|EXPIRED’ 중 하나
+        .build();
+    em.persist(qi);
+
+    // 5) answer ((qi,user) 유니크), content <= 100
+    Answer answer = Answer.builder()
+        .questionInstance(qi)
+        .user(owner)
+        .content("초기") // VARCHAR(100)
+        .build();
+    em.persist(answer);
+
+    em.flush();
+    ownerId = owner.getId();
+    qiId = qi.getId();
+    answerId = answer.getId();
+  }
+
+  @Test
+  @Transactional
+  @DisplayName("A) 서비스에서 flush 하지 않을 때: 응답 updatedAt != DB 최종 updatedAt")
+  void response_updatedAt_is_not_db_latest_when_no_flush() throws Exception {
+    // given
+    var before = em.find(Answer.class, answerId);
+    var beforeUpdated = before.getUpdatedAt();
+    Thread.sleep(5);
+
+    // when: 서비스는 flush 안 함(현행)
+    var res = answerService.update(answerId, ownerId, new AnswerContentRequest("수정1"));
+
+    // then: 응답 시점 updatedAt 캡처
+    var responseUpdatedAt = res.getUpdatedAt();
+    assertThat(responseUpdatedAt).isNotNull();
+
+    // DB 최신값과 비교
+    em.flush(); em.clear();
+    var reloaded = em.find(Answer.class, answerId);
+    var dbUpdatedAt = reloaded.getUpdatedAt();
+
+    // 핵심 검증: 현행 구현에서는 '동일'을 보장하지 않음 → 대개 다르거나 응답이 더 이른 값
+    assertThat(dbUpdatedAt).isAfterOrEqualTo(beforeUpdated);
+    assertThat(responseUpdatedAt).isNotEqualTo(dbUpdatedAt);
+    // (정밀 환경에 따라 같을 수 없도록 약간의 시간차를 두기 위해 Thread.sleep 사용)
+  }
+
+  @Test
+  @Transactional
+  @DisplayName("B) 서비스가 flush/saveAndFlush 할 때: 응답 updatedAt == DB 최종 updatedAt")
+  void response_updatedAt_equals_db_latest_when_service_flushes() throws Exception {
+    // 전제: 아래 라인이 서비스에 반영되어 있어야 함 (둘 중 택1)
+    //  - answerRepository.saveAndFlush(answer);
+    //  - entityManager.flush() 직후 DTO 매핑
+    // 없다면 이 테스트는 @Disabled 처리
+    Thread.sleep(5);
+
+    var res = answerService.update(answerId, ownerId, new AnswerContentRequest("수정2"));
+    var responseUpdatedAt = res.getUpdatedAt();
+
+    em.flush(); em.clear();
+    var reloaded = em.find(Answer.class, answerId);
+    var dbUpdatedAt = reloaded.getUpdatedAt();
+
+    // 핵심 검증: flush 후 응답-DB 시각 일치
+    assertThat(responseUpdatedAt).isEqualTo(dbUpdatedAt);
+  }
+}


### PR DESCRIPTION
## 개요
**답변 수정(PATCH /api/answers/{answerId})** 기능을 구현하고 테스트를 추가했습니다.  
또한 **생성/수정 응답을 공통 DTO(AnswerResponse)** 로 **통일**했습니다. (기존 생성 응답 변경 포함)

## 변경 사항

### API
- `PATCH /api/answers/{answerId}`
  - Request Body
     ``` 
     { "content": "최대 100자" }
     ``` 
  - Response (200 OK) — 공통 스펙
     ``` 
     {
       "answerId": 456,
       "questionInstanceId": 123,
       "content": "수정된 내용",
       "submittedAt": "2025-09-11T12:00:00",
       "updatedAt": "2025-09-11T12:30:00"
     }
     ``` 
  - 제약/상태코드
    - 작성자 아님 → **403 Forbidden**
    - QI 상태가 `PENDING`이 아니면(`COMPLETED`/`EXPIRED`) → **423 Locked**
    - 대상 Answer 없음 → **404 Not Found**
    - 본문 검증 실패(`@NotBlank`, `@Size(max=100)`) → **400 Bad Request**  *(컨트롤러 @Valid)*

- `POST /api/question-instances/{questionInstanceId}/answers` **(응답 변경됨)**
  - Response (201 Created) — **공통 스펙으로 변경**
     ``` 
     {
       "answerId": 456,
       "questionInstanceId": 123,
       "content": "최대 100자",
       "submittedAt": "2025-09-11T12:20:00",
       "updatedAt": "2025-09-11T12:20:00"
     }
     ``` 
  - Headers
     ``` 
     Location: /api/question-instances/{questionInstanceId}
     ``` 
  - ⚠️ 변경 사항 요약
    - `userId` **필드 제거**
    - `updatedAt` **필드 추가**
    - 프론트는 생성/수정 모두 **동일 스키마** 파싱

### DTO
- `AnswerResponse` (공통)
  - `answerId, questionInstanceId, content, submittedAt, updatedAt`
- `AnswerContentRequest`
  - `content` (`@NotBlank`, `@Size(max = 100)`)

### Mapper
- `AnswerMapper`
  - `normalize(String)` — `trim()` + `\r\n → \n`
  - `toResponse(Answer a)` — 엔티티 → 공통 DTO

### Service
- `AnswerService#update(Long answerId, Long userId, AnswerContentRequest req)`
  1) Answer 로드(없으면 `AnswerNotFoundException` → 404)  
  2) 권한 검증: **작성자 본인만** (`AnswerForbiddenException` → 403)  
  3) 상태 검증: **PENDING만 허용**, 그 외 `AnswerCannotModifyException` → 423  
  4) 내용 정규화 후 `setContent`  
  5) `saveAndFlush`로 감사 필드(@LastModifiedDate) 적용 보장 → 응답 `updatedAt`이 **DB와 동일**  
  6) `AnswerMapper.toResponse` 반환

### Controller
- `PATCH /api/answers/{answerId}`: 200 OK + 공통 응답  
- `POST /api/question-instances/{questionInstanceId}/answers`: 201 Created + 공통 응답  
- (임시) 인증 연동 전: `userId = 1L` 사용

### 예외
- `AnswerForbiddenException` (신규, 403)
- 기존: `AnswerNotFoundException` (404), `AnswerCannotModifyException` (423)

## Tests

### Service 단위 테스트 (BDD Mockito, 엔티티 실객체)
- 성공: 작성자 본인 + PENDING + 정규화 반영 + 공통 응답 스펙
- 예외: 404(미존재) / 403(권한) / 423(상태)
- *(flush 적용 후)* 성공 케이스에서 `saveAndFlush` 호출 검증 추가

### Controller MVC 테스트 (@WebMvcTest)
- PATCH 성공: **200 OK** + 공통 응답 직렬화 확인
- PATCH 실패: **400/403/404/423** 매핑 검증 (400은 @Valid)
- 생성 컨트롤러 테스트는 **공통 응답으로 기대값 갱신** (`userId` 제거, `updatedAt` 추가)

### 통합 테스트
- `updatedAt` 동작 확인
  - flush 전/후 차이 관찰 케이스
  - `saveAndFlush` 적용 후 **응답 updatedAt == DB updatedAt** 동등성 검증
