### PR TITLE
refactor: 엔티티 ID 필드명을 id로 통일하고 DB 컬럼명 명시

### DIFF
--- a/back/src/main/java/com/qmate/domain/match/Match.java
+++ b/back/src/main/java/com/qmate/domain/match/Match.java
@@ -32,6 +32,7 @@ public class Match {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "match_id")
   private Long id;
 
   @Enumerated(EnumType.STRING)

--- a/back/src/main/java/com/qmate/domain/match/MatchMember.java
+++ b/back/src/main/java/com/qmate/domain/match/MatchMember.java
@@ -29,6 +29,7 @@ public class MatchMember {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "match_member_id")
   private Long id;
 
   @ManyToOne(fetch = FetchType.LAZY)


### PR DESCRIPTION
##개요
코드의 일관성 및 가독성 향상을 위해 여러 엔티티의 ID 필드명을 id로 통일하고, DB 컬럼명은 기존 이름을 유지하도록 리팩토링했습니다. 또한, 멘토링 피드백을 반영하여 로컬 개발 환경의 DB 스키마 관리 방식을 실무에 가깝게 개선했습니다.

##변경 사항
AS-IS

Match, MatchMember 등의 엔티티에서 matchId, matchMemberId와 같이 각기 다른 ID 필드명을 사용하고 있었습니다.

로컬 개발 시 spring.jpa.hibernate.ddl-auto: update 옵션에 의존하여, 엔티티와 실제 DB 스키마 간의 불일치로 인한 실행 오류가 종종 발생했습니다.

TO-BE

엔티티 ID 필드명 통일 (리팩토링)

Match, MatchMember 등 관련 엔티티의 ID 필드명을 모두 id로 통일했습니다.

@Column(name = "...") 어노테이션을 사용하여, 실제 DB 컬럼명은 기존의 match_id, match_member_id로 유지되도록 명시했습니다.

관련 Repository 및 Service 코드도 모두 .getId()를 사용하도록 일관성 있게 수정했습니다.

로컬 DB 스키마 관리 방식 개선 (개발 환경)

application-local.yml 파일의 ddl-auto 옵션을 update에서 **none**으로 변경했습니다.

이를 통해 JPA의 자동 스키마 변경 기능에 의존하지 않고, 팀에서 공식적으로 관리하는 Notion의 DDL 스크립트를 통해 DB 스키마를 직접 관리하도록 프로세스를 개선했습니다.

테스트
[X] 로컬 환경에서 ddl-auto: none으로 설정한 뒤, Notion의 DDL 스크립트를 직접 실행하여 테이블을 생성하고 애플리케이션이 정상적으로 실행되는 것을 확인했습니다.

[ ] (별도의 기능 변경이 아니므로 신규 테스트 코드는 없음)