### PR TITLE
feat: JWT 기반 시큐리티 강화 및 어드민 인가 규칙 추가

### DIFF
--- a/back/src/main/java/com/qmate/config/SecurityConfig.java
+++ b/back/src/main/java/com/qmate/config/SecurityConfig.java
@@ -1,16 +1,23 @@
 package com.qmate.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.qmate.domain.auth.JwtService;
+import com.qmate.exception.CommonErrorCode;
+import com.qmate.exception.ErrorCode;
+import com.qmate.exception.ErrorResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
@@ -33,14 +40,33 @@ public class SecurityConfig {
   };
 
   @Bean
-  public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+  public SecurityFilterChain securityFilterChain(HttpSecurity http, ObjectMapper om) throws Exception {
     http
         .csrf(AbstractHttpConfigurer::disable)
         .formLogin(AbstractHttpConfigurer::disable)
         .httpBasic(AbstractHttpConfigurer::disable)
-        .authorizeHttpRequests(authz -> authz
-            .requestMatchers("/auth/register", "/auth/login", "/auth/logout").permitAll()
+        // 세션 기반 인증 사용 안함
+        .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+        .exceptionHandling(e -> e
+            .authenticationEntryPoint((req, res, ex) -> {
+              ErrorCode code = CommonErrorCode.unauthorized();
+              res.setStatus(code.getHttpStatus().value());
+              res.setContentType("application/json;charset=UTF-8");
+              ErrorResponse body = new ErrorResponse(code.getCode(), code.getMessage());
+              res.getWriter().write(om.writeValueAsString(body));
+            })
+            .accessDeniedHandler((req, res, ex) -> {
+              ErrorCode code = CommonErrorCode.forbidden();
+              res.setStatus(code.getHttpStatus().value());
+              res.setContentType("application/json;charset=UTF-8");
+              ErrorResponse body = new ErrorResponse(code.getCode(), code.getMessage());
+              res.getWriter().write(om.writeValueAsString(body));
+            })
+        )
+        .authorizeHttpRequests(auth -> auth
+            .requestMatchers("/auth/**").permitAll()
             .requestMatchers(SWAGGER_WHITELIST).permitAll()
+            .requestMatchers("/api/admin/**").hasRole("ADMIN")
             .anyRequest().authenticated()  // 나머지 모든 요청은 인증 필요
         )
         .addFilterBefore(new JwtAuthenticationFilter(jwtService), UsernamePasswordAuthenticationFilter.class);  // JWT 필터 추가

--- a/back/src/test/java/com/qmate/config/SecurityTest.java
+++ b/back/src/test/java/com/qmate/config/SecurityTest.java
@@ -1,0 +1,56 @@
+package com.qmate.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithAnonymousUser;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+@AutoConfigureMockMvc
+@SpringBootTest
+class SecurityTest {
+
+  @Autowired
+  MockMvc mvc;
+
+  @Test
+  void authPaths_are_permitAll_for_anonymous() throws Exception {
+    mvc.perform(post("/auth/login"))
+        .andExpect(result -> {
+          int code = result.getResponse().getStatus();
+          // 내부 비즈니스 오류로 5xx/4xx가 나와도, 보안 관점에서는 401/403만 아니면 통과
+          assertThat(code).isNotIn(401, 403);
+        });
+  }
+
+  @Test
+  void adminPaths_require_authentication() throws Exception {
+    mvc.perform(get("/api/admin/question-categories"))
+        .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @WithMockUser(roles = "USER")
+  void adminPaths_forbid_user_role() throws Exception {
+    mvc.perform(get("/api/admin/question-categories"))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @WithMockUser(roles = "ADMIN")
+  void adminPaths_allow_admin_role() throws Exception {
+    mvc.perform(get("/api/admin/question-categories"))
+        .andExpect(result -> {
+          int code = result.getResponse().getStatus();
+          // 내부 비즈니스 오류로 5xx/4xx가 나와도, 보안 관점에서는 401/403만 아니면 통과
+          assertThat(code).isNotIn(401, 403);
+        });
+  }
+}

--- a/back/src/test/java/com/qmate/questioninstance/QIServiceListTest.java
+++ b/back/src/test/java/com/qmate/questioninstance/QIServiceListTest.java
@@ -12,7 +12,7 @@ import com.qmate.domain.questioninstance.repository.QuestionInstanceQueryReposit
 import com.qmate.domain.questioninstance.repository.QuestionInstanceRepository;
 import com.qmate.domain.questioninstance.service.QuestionInstanceService;
 import com.qmate.domain.user.UserRepository;
-import com.qmate.exception.custom.UserNotFoundException;
+import com.qmate.exception.custom.matchinstance.UserNotFoundException;
 import com.qmate.exception.custom.questioninstance.QuestionInstanceForbiddenException;
 import java.time.LocalDateTime;
 import java.util.Optional;


### PR DESCRIPTION
## 개요
JWT 기반 보안 설정을 정리하고, `/api/admin/**` 경로를 `ROLE_ADMIN` 전용으로 강화했습니다. 미인증/권한부족 응답을 공통 JSON 포맷(`ErrorResponse`)으로 통일하여 프런트 처리 일관성을 확보했습니다.

## 변경 사항
- SecurityConfig
  - 세션 비활성화: `sessionCreationPolicy(STATELESS)`로 JSESSIONID 생성 방지 및 완전 무상태화
  - 엔드포인트 접근 제어:
    - `/auth/**` 및 Swagger(`SWAGGER_WHITELIST`) → `permitAll()`
    - `/api/admin/**` → `hasRole("ADMIN")`
    - 그 외 → `authenticated()`
  - 예외 응답 포맷 통일:
    - `AuthenticationEntryPoint` → 401 JSON(`CommonErrorCode.unauthorized()`)
    - `AccessDeniedHandler` → 403 JSON(`CommonErrorCode.forbidden()`)
    - **사유**: 인증/인가 예외는 Spring Security의 `ExceptionTranslationFilter` 단계에서 처리되어 
    `@RestControllerAdvice`의 글로벌 핸들러까지 전달되지 않으므로, 필터 체인에서 바로 표준 `ErrorResponse`를 내려 일관된 응답을 보장.
- 의존/유틸
  - `ObjectMapper` 주입으로 표준 `ErrorResponse` 직렬화 적용
- 테스트(SecurityTest)
  - 익명 사용자가 `/api/admin/**` 접근 시 401
  - `@WithMockUser(roles="USER")`가 `/api/admin/**` 접근 시 403
  - `@WithMockUser(roles="ADMIN")`가 `/api/admin/**` 접근 시 2xx(또는 비즈니스 예외) — 단, 401/403은 아님
  - `/auth/login` 경로는 비인증 상태에서도 401/403 이외 코드로 응답(내부 로직과 무관하게 “보안 관점”만 검증)
