### PR TITLE
Feature/get match members

### DIFF
--- a/back/src/main/java/com/qmate/api/MatchController.java
+++ b/back/src/main/java/com/qmate/api/MatchController.java
@@ -57,8 +57,10 @@ public class MatchController {
 
 
   }
+
   /**
    * 특정 매칭의 상세 정보를 조회합니다.
+   *
    * @param matchId URL 경로에서 받아온 매칭 ID
    * @return 200 OK 상태 코드와 함께 매칭 정보 DTO를 반환
    */
@@ -66,10 +68,10 @@ public class MatchController {
   public ResponseEntity<MatchInfoResponse> getMatchInfo(
       @PathVariable Long matchId
       // @AuthenticationPrincipal UserDetailsImpl userDetails //  나중에 로그인 기능 연동
-  ){
+  ) {
     Long currentUserId = 5L;
     // 임시로 사용자 Id를 1L로 가정 Long currentUserId = userDetails.getUser().getId();
-    MatchInfoResponse response = matchService.getMatchInfo(matchId,currentUserId);
+    MatchInfoResponse response = matchService.getMatchInfo(matchId, currentUserId);
 
     return ResponseEntity.ok(response);
   }

--- a/back/src/main/java/com/qmate/api/MatchController.java
+++ b/back/src/main/java/com/qmate/api/MatchController.java
@@ -5,7 +5,7 @@ import com.qmate.domain.match.model.request.MatchJoinRequest;
 import com.qmate.domain.match.model.response.MatchCreationResponse;
 import com.qmate.domain.match.model.response.MatchInfoResponse;
 import com.qmate.domain.match.model.response.MatchJoinResponse;
-import com.qmate.domain.match.model.response.MatchMemberResponse;
+import com.qmate.domain.match.model.response.MatchMembersResponse;
 import com.qmate.domain.match.service.MatchService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -78,14 +78,14 @@ public class MatchController {
   }
   //특정 매칭의 구성원 목록(상세정보)을 조회.
   @GetMapping("/{matchId}/members")
-  public ResponseEntity<MatchMemberResponse> getMatchMembers(
+  public ResponseEntity<MatchMembersResponse> getMatchMembers(
       @PathVariable Long matchId
       // @AuthenticationPrincipal UserDetailsImpl userDetails
   ){
     Long currentUserId = 3L;
     // Long currentUserId = userDetails.getUser().getId();
 
-    MatchMemberResponse response = matchService.getMatchMembers(matchId, currentUserId);
+    MatchMembersResponse response = matchService.getMatchMembers(matchId, currentUserId);
     return ResponseEntity.ok(response);
   }
 }

--- a/back/src/main/java/com/qmate/api/MatchController.java
+++ b/back/src/main/java/com/qmate/api/MatchController.java
@@ -5,6 +5,7 @@ import com.qmate.domain.match.model.request.MatchJoinRequest;
 import com.qmate.domain.match.model.response.MatchCreationResponse;
 import com.qmate.domain.match.model.response.MatchInfoResponse;
 import com.qmate.domain.match.model.response.MatchJoinResponse;
+import com.qmate.domain.match.model.response.MatchMemberResponse;
 import com.qmate.domain.match.service.MatchService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -69,10 +70,22 @@ public class MatchController {
       @PathVariable Long matchId
       // @AuthenticationPrincipal UserDetailsImpl userDetails //  나중에 로그인 기능 연동
   ) {
-    Long currentUserId = 5L;
+    Long currentUserId = 3L;
     // 임시로 사용자 Id를 1L로 가정 Long currentUserId = userDetails.getUser().getId();
     MatchInfoResponse response = matchService.getMatchInfo(matchId, currentUserId);
 
+    return ResponseEntity.ok(response);
+  }
+  //특정 매칭의 구성원 목록(상세정보)을 조회.
+  @GetMapping("/{matchId}/members")
+  public ResponseEntity<MatchMemberResponse> getMatchMembers(
+      @PathVariable Long matchId
+      // @AuthenticationPrincipal UserDetailsImpl userDetails
+  ){
+    Long currentUserId = 3L;
+    // Long currentUserId = userDetails.getUser().getId();
+
+    MatchMemberResponse response = matchService.getMatchMembers(matchId, currentUserId);
     return ResponseEntity.ok(response);
   }
 }

--- a/back/src/main/java/com/qmate/domain/match/model/response/MatchInfoResponse.java
+++ b/back/src/main/java/com/qmate/domain/match/model/response/MatchInfoResponse.java
@@ -15,13 +15,13 @@ public class MatchInfoResponse {
   private final List<MemberInfoResponse> users;
 
   // Match 엔티티를 통째로 받아서 이 DTO를 완성하는 생성자
-  public MatchInfoResponse(Match match) {
+  public MatchInfoResponse(Match match, Long requesterId) {
     this.matchId = match.getId();
     this.relationType = match.getRelationType();
     this.startDate = match.getStartDate();
     // Match 엔티티가 가진 MatchMember 리스트를 순회하며 MemberInfo DTO 리스트로 변환
     this.users = match.getMembers().stream()
-        .map(matchMember -> new MemberInfoResponse(matchMember.getUser()))
+        .map(matchMember -> new MemberInfoResponse(matchMember.getUser(), requesterId))
         .toList();
   }
 }

--- a/back/src/main/java/com/qmate/domain/match/model/response/MatchMemberDetailResponse.java
+++ b/back/src/main/java/com/qmate/domain/match/model/response/MatchMemberDetailResponse.java
@@ -10,11 +10,13 @@ public class MatchMemberDetailResponse {
   private final Long userId;
   private final String nickname;
   private final LocalDate birthDate;
+  private final boolean isMe;
 
-  public MatchMemberDetailResponse(User user) {
+  public MatchMemberDetailResponse(User user, Long requesterId) {
     this.userId = user.getId();
     this.nickname = user.getNickname();
     this.birthDate = user.getBirthDate();
+    this.isMe = user.getId().equals(requesterId);
   }
 
 }

--- a/back/src/main/java/com/qmate/domain/match/model/response/MatchMemberDetailResponse.java
+++ b/back/src/main/java/com/qmate/domain/match/model/response/MatchMemberDetailResponse.java
@@ -1,18 +1,20 @@
 package com.qmate.domain.match.model.response;
 
 import com.qmate.domain.user.User;
+import java.time.LocalDate;
 import lombok.Getter;
 
 @Getter
-public class MemberInfoResponse {
+public class MatchMemberDetailResponse {
 
   private final Long userId;
   private final String nickname;
+  private final LocalDate birthDate;
 
-  // User 엔티티를 받아서 필요한 정보만 뽑아내는 생성자
-  public MemberInfoResponse(User user) {
+  public MatchMemberDetailResponse(User user) {
     this.userId = user.getId();
     this.nickname = user.getNickname();
+    this.birthDate = user.getBirthDate();
   }
 
 }

--- a/back/src/main/java/com/qmate/domain/match/model/response/MatchMemberResponse.java
+++ b/back/src/main/java/com/qmate/domain/match/model/response/MatchMemberResponse.java
@@ -1,0 +1,20 @@
+package com.qmate.domain.match.model.response;
+
+import com.qmate.domain.match.Match;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class MatchMemberResponse {
+
+  private final Long matchId;
+  private final List<MatchMemberDetailResponse> members;
+
+  public MatchMemberResponse(Match match){
+    this.matchId = match.getId();
+    this.members = match.getMembers().stream()
+        .map(matchMember -> new MatchMemberDetailResponse(matchMember.getUser()))
+        .toList();
+  }
+
+}

--- a/back/src/main/java/com/qmate/domain/match/model/response/MatchMembersResponse.java
+++ b/back/src/main/java/com/qmate/domain/match/model/response/MatchMembersResponse.java
@@ -10,10 +10,10 @@ public class MatchMembersResponse {
   private final Long matchId;
   private final List<MatchMemberDetailResponse> members;
 
-  public MatchMembersResponse(Match match){
+  public MatchMembersResponse(Match match, Long requesterId) {
     this.matchId = match.getId();
     this.members = match.getMembers().stream()
-        .map(matchMember -> new MatchMemberDetailResponse(matchMember.getUser()))
+        .map(matchMember -> new MatchMemberDetailResponse(matchMember.getUser(), requesterId))
         .toList();
   }
 

--- a/back/src/main/java/com/qmate/domain/match/model/response/MatchMembersResponse.java
+++ b/back/src/main/java/com/qmate/domain/match/model/response/MatchMembersResponse.java
@@ -5,12 +5,12 @@ import java.util.List;
 import lombok.Getter;
 
 @Getter
-public class MatchMemberResponse {
+public class MatchMembersResponse {
 
   private final Long matchId;
   private final List<MatchMemberDetailResponse> members;
 
-  public MatchMemberResponse(Match match){
+  public MatchMembersResponse(Match match){
     this.matchId = match.getId();
     this.members = match.getMembers().stream()
         .map(matchMember -> new MatchMemberDetailResponse(matchMember.getUser()))

--- a/back/src/main/java/com/qmate/domain/match/model/response/MemberInfoResponse.java
+++ b/back/src/main/java/com/qmate/domain/match/model/response/MemberInfoResponse.java
@@ -8,11 +8,13 @@ public class MemberInfoResponse {
 
   private final Long userId;
   private final String nickname;
+  private final boolean isMe; //본인 여부 필드
 
   // User 엔티티를 받아서 필요한 정보만 뽑아내는 생성자
-  public MemberInfoResponse(User user) {
+  public MemberInfoResponse(User user, Long requesterId) {
     this.userId = user.getId();
     this.nickname = user.getNickname();
+    this.isMe = user.getId().equals(requesterId);
   }
 
 }

--- a/back/src/main/java/com/qmate/domain/match/service/MatchService.java
+++ b/back/src/main/java/com/qmate/domain/match/service/MatchService.java
@@ -67,12 +67,12 @@ public class MatchService {
   //초대 코드를 사용하여 기존 매칭에 참여 로직.
   @Transactional
   public MatchJoinResponse joinMatch(MatchJoinRequest request, Long joinerId) {
-    if (redisHelper.isLocked(joinerId)){
+    if (redisHelper.isLocked(joinerId)) {
       throw new InviteAttemptLockedException();
     }
 
     User joiner = userRepository.findById(joinerId)
-            .orElseThrow(UserNotFoundException::new);
+        .orElseThrow(UserNotFoundException::new);
     validateUserNotInActiveMatch(joinerId);
 
     String inviteCode = request.getInviteCode();
@@ -82,7 +82,7 @@ public class MatchService {
           .orElseThrow(InviteCodeExpiredException::new);
 
       Match match = matchRepository.findById(matchId)
-              .orElseThrow(MatchNotFoundException::new);
+          .orElseThrow(MatchNotFoundException::new);
 
       validateJoinAttempt(match, joinerId);
 
@@ -93,16 +93,15 @@ public class MatchService {
       MatchMember partner = findPartner(matchId, joinerId);
       redisHelper.deleteInviteCode(inviteCode);
 
-
       return MatchJoinResponse.builder()
           .matchId(matchId)
           .message("매칭에 성공적으로 참여했습니다.")
           .partnerNickname(partner.getUser().getNickname())
           .build();
-    }catch (InviteCodeExpiredException e){
+    } catch (InviteCodeExpiredException e) {
       //초대 코드가 틀렸을 때 실행되는 실패 로직
       long attempCount = redisHelper.incrementAttemptCount(joinerId);
-      if (attempCount >= 5){
+      if (attempCount >= 5) {
         redisHelper.lockUser(joinerId);
         throw new InviteAttemptLockedException();//5번 실패 시 발생
       }
@@ -112,30 +111,30 @@ public class MatchService {
 
   //특정 매칭의 상세 정보를 조회합니다.
   @Transactional(readOnly = true)
-  public MatchInfoResponse getMatchInfo(Long matchId, Long userId){
+  public MatchInfoResponse getMatchInfo(Long matchId, Long userId) {
     Match match = matchRepository.findWithMembersAndUsersById(matchId)
         .orElseThrow(MatchNotFoundException::new);
 
     boolean isMember = match.getMembers().stream()
         .anyMatch(matchMember -> matchMember.getUser().getId().equals(userId));
 
-    if (!isMember){
+    if (!isMember) {
       throw new MatchForbiddenException();
     }
-    return new MatchInfoResponse(match);
+    return new MatchInfoResponse(match, userId);
   }
 
   //특정 매칭의 구성원 목록(상세 정보)을 조회합니다.
   @Transactional(readOnly = true)
-  public MatchMembersResponse getMatchMembers(Long matchId,Long userId){
+  public MatchMembersResponse getMatchMembers(Long matchId, Long userId) {
     Match match = matchRepository.findWithMembersAndUsersById(matchId)
         .orElseThrow(MatchNotFoundException::new);
     boolean isMember = match.getMembers().stream()
         .anyMatch(matchMember -> matchMember.getUser().getId().equals(userId));
-    if (!isMember){
+    if (!isMember) {
       throw new MatchForbiddenException();
     }
-    return new MatchMembersResponse(match);
+    return new MatchMembersResponse(match, userId);
   }
 
 
@@ -146,6 +145,7 @@ public class MatchService {
           throw new AlreadyInMatchException();
         });
   }
+
   //커플이 아니라면 입력 필요 없어서 = return null
   private LocalDateTime parseStartDate(RelationType relationType, String startDateString) {
     if (relationType != RelationType.COUPLE) {
@@ -171,15 +171,15 @@ public class MatchService {
   }
 
   //가독성을 위한 private 헬퍼 메서드(매칭 조인 관련)
-  private void validateJoinAttempt(Match match, Long joinerId){
-    if (match.getStatus() != MatchStatus.WAITING){
+  private void validateJoinAttempt(Match match, Long joinerId) {
+    if (match.getStatus() != MatchStatus.WAITING) {
       throw new AlreadyInMatchException();
     }
     List<MatchMember> members = matchMemberRepository.findAllByMatch_Id(match.getId());
-    if (members.size() != 1){
+    if (members.size() != 1) {
       throw new AlreadyInMatchException(); // 꽉 찼거나 비정상적인 방
     }
-    if (members.get(0).getUser().getId().equals(joinerId)){
+    if (members.get(0).getUser().getId().equals(joinerId)) {
       throw new SelfMatchNotAllowedException();
     }
   }

--- a/back/src/main/java/com/qmate/domain/match/service/MatchService.java
+++ b/back/src/main/java/com/qmate/domain/match/service/MatchService.java
@@ -10,7 +10,7 @@ import com.qmate.domain.match.model.request.MatchJoinRequest;
 import com.qmate.domain.match.model.response.MatchCreationResponse;
 import com.qmate.domain.match.model.response.MatchInfoResponse;
 import com.qmate.domain.match.model.response.MatchJoinResponse;
-import com.qmate.domain.match.model.response.MatchMemberResponse;
+import com.qmate.domain.match.model.response.MatchMembersResponse;
 import com.qmate.domain.match.repository.MatchMemberRepository;
 import com.qmate.domain.match.repository.MatchRepository;
 import com.qmate.domain.user.User;
@@ -127,7 +127,7 @@ public class MatchService {
 
   //특정 매칭의 구성원 목록(상세 정보)을 조회합니다.
   @Transactional(readOnly = true)
-  public MatchMemberResponse getMatchMembers(Long matchId,Long userId){
+  public MatchMembersResponse getMatchMembers(Long matchId,Long userId){
     Match match = matchRepository.findWithMembersAndUsersById(matchId)
         .orElseThrow(MatchNotFoundException::new);
     boolean isMember = match.getMembers().stream()
@@ -135,7 +135,7 @@ public class MatchService {
     if (!isMember){
       throw new MatchForbiddenException();
     }
-    return new MatchMemberResponse(match);
+    return new MatchMembersResponse(match);
   }
 
 

--- a/back/src/main/java/com/qmate/domain/match/service/MatchService.java
+++ b/back/src/main/java/com/qmate/domain/match/service/MatchService.java
@@ -10,6 +10,7 @@ import com.qmate.domain.match.model.request.MatchJoinRequest;
 import com.qmate.domain.match.model.response.MatchCreationResponse;
 import com.qmate.domain.match.model.response.MatchInfoResponse;
 import com.qmate.domain.match.model.response.MatchJoinResponse;
+import com.qmate.domain.match.model.response.MatchMemberResponse;
 import com.qmate.domain.match.repository.MatchMemberRepository;
 import com.qmate.domain.match.repository.MatchRepository;
 import com.qmate.domain.user.User;
@@ -122,6 +123,19 @@ public class MatchService {
       throw new MatchForbiddenException();
     }
     return new MatchInfoResponse(match);
+  }
+
+  //특정 매칭의 구성원 목록(상세 정보)을 조회합니다.
+  @Transactional(readOnly = true)
+  public MatchMemberResponse getMatchMembers(Long matchId,Long userId){
+    Match match = matchRepository.findWithMembersAndUsersById(matchId)
+        .orElseThrow(MatchNotFoundException::new);
+    boolean isMember = match.getMembers().stream()
+        .anyMatch(matchMember -> matchMember.getUser().getId().equals(userId));
+    if (!isMember){
+      throw new MatchForbiddenException();
+    }
+    return new MatchMemberResponse(match);
   }
 
 

--- a/back/src/test/java/com/qmate/api/MatchControllerTest.java
+++ b/back/src/test/java/com/qmate/api/MatchControllerTest.java
@@ -10,11 +10,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.qmate.config.SecurityConfig;
 import com.qmate.domain.match.RelationType;
 import com.qmate.domain.match.model.request.MatchJoinRequest;
 import com.qmate.domain.match.model.response.MatchInfoResponse;
 import com.qmate.domain.match.Match;
+import com.qmate.domain.match.model.response.MatchMembersResponse;
 import com.qmate.domain.match.service.MatchService;
 
 import com.qmate.exception.custom.matchinstance.InviteAttemptLockedException;
@@ -24,14 +24,14 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(controllers = MatchController.class)
-@Import(SecurityConfig.class) // SecurityConfig를 테스트에 포함
+@AutoConfigureMockMvc(addFilters = false) // SecurityConfig를 테스트에 포함
 class MatchControllerTest {
 
   @Autowired
@@ -42,6 +42,41 @@ class MatchControllerTest {
 
   @MockitoBean // 가짜 MatchService를 Spring에 등록
   private MatchService matchService;
+
+
+  @Test
+  @DisplayName("매칭 멤버 상세 조회 실패: 권한 없는 접근 시 403 Forbidden 응답")
+  void getMatchMembers_fail_403forbidden() throws Exception {
+    // given: 서비스가 MatchForbiddenException을 던지는 상황을 가정
+    Long matchId = 4L;
+
+    // "만약 matchService의 getMatchMembers가 어떤 ID로든 호출되면, 이 예외를 던져라"
+    willThrow(new MatchForbiddenException())
+        .given(matchService).getMatchMembers(anyLong(), anyLong());
+
+    // expect: API를 호출하면, 403 Forbidden 응답과 MATCH_008 에러 코드가 와야 함
+    mockMvc.perform(get("/api/matches/{matchId}/members", matchId))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.errorCode").value("MATCH_008"));
+  }
+
+  @Test
+  @DisplayName("매칭 멤버 상세 조회 성공 시 200 OK와 DTO를 응답한다")
+  void getMatchMembers_success_200ok() throws Exception {
+    // given: 서비스가 정상적으로 MatchMembersResponse DTO를 반환하는 상황
+    Long matchId = 1L;
+    // 서비스가 반환할 가짜 응답 DTO를 미리 만들어둠
+    var fakeResponse = new MatchMembersResponse(
+        Match.builder().id(matchId).members(List.of()).build()
+    );
+
+    given(matchService.getMatchMembers(anyLong(), anyLong())).willReturn(fakeResponse);
+
+    // expect: API를 호출하면, 200 OK 응답과 DTO 내용이 정확히 와야 함
+    mockMvc.perform(get("/api/matches/{matchId}/members", matchId)) // GET 요청
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.matchId").value(matchId));
+  }
 
   @Test
   @DisplayName("매칭 정보 조회 성공 시 200 OK와 DTO를 응답한다")

--- a/back/src/test/java/com/qmate/api/MatchControllerTest.java
+++ b/back/src/test/java/com/qmate/api/MatchControllerTest.java
@@ -65,9 +65,12 @@ class MatchControllerTest {
   void getMatchMembers_success_200ok() throws Exception {
     // given: 서비스가 정상적으로 MatchMembersResponse DTO를 반환하는 상황
     Long matchId = 1L;
+    Long requesterId = 1L;
+
     // 서비스가 반환할 가짜 응답 DTO를 미리 만들어둠
     var fakeResponse = new MatchMembersResponse(
-        Match.builder().id(matchId).members(List.of()).build()
+        Match.builder().id(matchId).members(List.of()).build(),
+        requesterId
     );
 
     given(matchService.getMatchMembers(anyLong(), anyLong())).willReturn(fakeResponse);
@@ -83,6 +86,8 @@ class MatchControllerTest {
   void getMatchInfo_success_200ok() throws Exception {
     // given: 서비스가 정상적으로 MatchInfoResponse DTO를 반환하는 상황
     Long matchId = 1L;
+    Long requesterId = 3L;
+
     // 서비스가 반환할 가짜 응답 DTO를 미리 만들어둠
     var fakeResponse = new MatchInfoResponse(
         Match.builder()
@@ -90,7 +95,8 @@ class MatchControllerTest {
             .relationType(RelationType.COUPLE)
             .startDate(LocalDateTime.now())
             .members(List.of()) // 테스트에서는 멤버 리스트가 비어있어도 괜찮습니다.
-            .build()
+            .build(),
+        requesterId
     );
 
     // matchService.getMatchInfo가 어떤 ID로든 호출되면, 위에서 만든 가짜 응답을 반환하도록 설정

--- a/back/src/test/java/com/qmate/domain/match/service/MatchServiceTest.java
+++ b/back/src/test/java/com/qmate/domain/match/service/MatchServiceTest.java
@@ -13,12 +13,14 @@ import com.qmate.domain.match.MatchStatus;
 import com.qmate.domain.match.RelationType;
 import com.qmate.domain.match.model.request.MatchJoinRequest;
 import com.qmate.domain.match.model.response.MatchInfoResponse;
+import com.qmate.domain.match.model.response.MatchMembersResponse;
 import com.qmate.domain.match.repository.MatchMemberRepository;
 import com.qmate.domain.match.repository.MatchRepository;
 import com.qmate.domain.user.User;
 import com.qmate.domain.user.UserRepository;
 import com.qmate.exception.custom.matchinstance.InviteAttemptLockedException;
 import com.qmate.exception.custom.matchinstance.MatchForbiddenException;
+import java.time.LocalDate;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -28,7 +30,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class MatchServiceJoinTest {
+class MatchServiceTest {
 
   @InjectMocks
   private MatchService sut; // sut: System Under Test (테스트 대상 시스템)
@@ -41,6 +43,51 @@ class MatchServiceJoinTest {
   private UserRepository userRepository;
   @Mock
   private RedisHelper redisHelper;
+
+
+  @Test
+  @DisplayName("매칭 멤버 상세 조회 실패: 멤버가 아닌 사용자의 접근")
+  void getMatchMembers_fail_forbidden() {
+    // given: 3번 매칭에 3번, 4번 유저가 속해있는데, 상관없는 99번 유저가 조회를 요청한 상황
+    Long matchId = 3L;
+    Long outsiderId = 99L; // 외부인 ID
+
+    User user3 = User.builder().id(3L).build();
+    User user4 = User.builder().id(4L).build();
+    Match match = Match.builder().id(matchId).build();
+    match.addMember(MatchMember.create(user3, match));
+    match.addMember(MatchMember.create(user4, match));
+
+    // "matchRepository에서 3번 매칭을 찾아달라고 하면, 이 가짜 match 객체를 돌려줘"
+    given(matchRepository.findWithMembersAndUsersById(matchId)).willReturn(Optional.of(match));
+
+    // expect: getMatchMembers를 호출하면 MatchForbiddenException 예외가 발생해야 함
+    assertThatThrownBy(() -> sut.getMatchMembers(matchId, outsiderId))
+        .isInstanceOf(MatchForbiddenException.class);
+  }
+
+  @Test
+  @DisplayName("매칭 멤버 상세 조회 성공")
+  void getMatchMembers_success() {
+    // given: 1번 매칭에 1번, 2번 유저가 속해있고, 1번 유저가 조회를 요청한 상황
+    Long matchId = 1L;
+    Long requesterId = 1L;
+    User user1 = User.builder().id(1L).nickname("유저1").birthDate(LocalDate.of(2000, 1, 1)).build();
+    User user2 = User.builder().id(2L).nickname("유저2").birthDate(LocalDate.of(2001, 2, 2)).build();
+    Match match = Match.builder().id(matchId).build();
+    match.addMember(MatchMember.create(user1, match));
+    match.addMember(MatchMember.create(user2, match));
+
+    given(matchRepository.findWithMembersAndUsersById(matchId)).willReturn(Optional.of(match));
+
+    // when: 서비스 메서드를 실행하면
+    MatchMembersResponse response = sut.getMatchMembers(matchId, requesterId);
+
+    // then: 반환된 DTO의 내용이 정확한지 검증
+    assertThat(response.getMatchId()).isEqualTo(matchId);
+    assertThat(response.getMembers()).hasSize(2);
+    assertThat(response.getMembers().get(0).getBirthDate()).isEqualTo(LocalDate.of(2000, 1, 1));
+  }
 
 
   @Test

--- a/back/src/test/java/com/qmate/questioninstance/QIServiceListTest.java
+++ b/back/src/test/java/com/qmate/questioninstance/QIServiceListTest.java
@@ -12,7 +12,7 @@ import com.qmate.domain.questioninstance.repository.QuestionInstanceQueryReposit
 import com.qmate.domain.questioninstance.repository.QuestionInstanceRepository;
 import com.qmate.domain.questioninstance.service.QuestionInstanceService;
 import com.qmate.domain.user.UserRepository;
-import com.qmate.exception.custom.UserNotFoundException;
+import com.qmate.exception.custom.matchinstance.UserNotFoundException;
 import com.qmate.exception.custom.questioninstance.QuestionInstanceForbiddenException;
 import java.time.LocalDateTime;
 import java.util.Optional;


### PR DESCRIPTION
### 개요
매칭된 사용자가 자신과 파트너의 상세 정보(생년월일 포함)를 조회할 수 있는 **매칭 구성원 상세 목록 조회 API** (`GET /api/matches/{matchId}/members`)를 구현했습니다.

### 변경 사항

#### API
- **`GET /api/matches/{matchId}/members`** 엔드포인트를 신규 추가했습니다.

#### 제약/상태코드
- **성공:** `200 OK`
- **실패:**
    - **`403 Forbidden` (`MATCH_008`):** 요청을 보낸 사용자가 해당 매칭의 멤버가 아닐 경우
    - **`404 Not Found` (`MATCH_002`):** 해당 `matchId`가 존재하지 않을 경우

#### DTO
- `MatchMemberDetailResponse.java`: 멤버 1명의 상세 정보(`userId`, `nickname`, `birthDate`)를 담는 DTO를 추가했습니다.
- `MatchMembersResponse.java`: API의 최종 응답을 위한 DTO를 추가했습니다. `matchId`와 `MatchMemberDetailResponse` 리스트를 포함합니다.

#### Service
- **`MatchService#getMatchMembers(matchId, userId)`**
    - **(성능 최적화)** N+1 문제를 방지하기 위해, 이전에 구현한 `@EntityGraph`가 적용된 `findWithMembersAndUsersById` Repository 메서드를 재사용하여 한 번의 쿼리로 모든 정보를 조회하도록 구현했습니다.
    - **(권한 검증)** 요청한 `userId`가 조회된 `Match`의 멤버가 맞는지 확인하여, 멤버가 아닐 경우 `MatchForbiddenException`을 발생시키는 로직을 추가했습니다.

#### Controller
- `MatchController`에 `GET /api/matches/{matchId}/members` 엔드포인트를 추가했습니다.

### Tests
- **[X] 서비스 단위 테스트 (BDD + Mockito)**
    - `MatchServiceTest.java`에 2개의 테스트 케이스를 추가했습니다.
    - **성공 케이스:** 매칭 멤버가 정상적으로 멤버 목록을 조회하는 경우
    - **실패 케이스:** 매칭 멤버가 아닌 사용자가 조회를 시도하여 `MatchForbiddenException`이 발생하는 경우
- **[X] 컨트롤러 단위 테스트 (@WebMvcTest)**
    - `MatchControllerTest.java`에 2개의 테스트 케이스를 추가했습니다.
    - **성공 케이스:** 서비스가 DTO를 정상 반환했을 때, 컨트롤러가 `200 OK` 응답을 하는지 검증했습니다.
    - **실패 케이스:** 서비스가 `MatchForbiddenException`을 발생시켰을 때, 컨트롤러가 `403 Forbidden` 응답을 하는지 검증했습니다.
- **[X] API 테스트**
    - Postman을 통해 수동으로 API 성공 및 실패(권한 없음) 케이스를 모두 테스트 완료했습니다.