### PR TITLE
feat: 질문 평가 작성 API 및 집계 파이프라인 구축 (작성/검증/집계/관리자 재빌드 + 테스트)

### DIFF
--- a/back/src/main/java/com/qmate/api/question/QuestionRatingController.java
+++ b/back/src/main/java/com/qmate/api/question/QuestionRatingController.java
@@ -2,7 +2,9 @@ package com.qmate.api.question;
 
 import com.qmate.domain.questionrating.model.request.QuestionRatingRequest;
 import com.qmate.domain.questionrating.model.response.QuestionRatingResponse;
+import com.qmate.domain.questionrating.service.AdminRatingRebuildService;
 import com.qmate.domain.questionrating.service.QuestionRatingService;
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -23,6 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class QuestionRatingController {
 
   private final QuestionRatingService questionRatingService;
+  private final AdminRatingRebuildService questionRatingRebuildService;
 
   @Operation(summary = "질문 평가 생성", description = "특정 질문에 대한 평가를 생성합니다.",
       responses = {
@@ -44,5 +47,19 @@ public class QuestionRatingController {
   ) {
     QuestionRatingResponse res = questionRatingService.create(questionId, request);
     return ResponseEntity.status(HttpStatus.CREATED).body(res);
+  }
+
+  @Operation(summary = "질문 평가 집계 재생성 (관리자 전용)", description = "모든 질문에 대한 평가 집계를 재생성합니다.",
+      responses = {
+          @ApiResponse(responseCode = "204", description = "재생성 성공"),
+          @ApiResponse(responseCode = "401", description = "인증 실패"),
+          @ApiResponse(responseCode = "403", description = "권한 없음"),
+          @ApiResponse(responseCode = "500", description = "재생성 중 오류 발생"),
+      }
+  )
+  @PostMapping("/admin/questions/ratings/rebuild")
+  public ResponseEntity<Void> rebuildAll() {
+    questionRatingRebuildService.rebuildAll();
+    return ResponseEntity.noContent().build();
   }
 }

--- a/back/src/main/java/com/qmate/api/question/QuestionRatingController.java
+++ b/back/src/main/java/com/qmate/api/question/QuestionRatingController.java
@@ -1,0 +1,48 @@
+package com.qmate.api.question;
+
+import com.qmate.domain.questionrating.model.request.QuestionRatingRequest;
+import com.qmate.domain.questionrating.model.response.QuestionRatingResponse;
+import com.qmate.domain.questionrating.service.QuestionRatingService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import jakarta.validation.Valid;
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class QuestionRatingController {
+
+  private final QuestionRatingService questionRatingService;
+
+  @Operation(summary = "질문 평가 생성", description = "특정 질문에 대한 평가를 생성합니다.",
+      responses = {
+          @ApiResponse(responseCode = "201", description = "평가 생성 성공"),
+          @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+          @ApiResponse(responseCode = "401", description = "인증 실패"),
+          @ApiResponse(responseCode = "404", description = "리소스 없음"),
+          @ApiResponse(responseCode = "409", description = "중복된 평가"),
+      },
+      parameters = {
+          @Parameter(name = "questionId", description = "평가할 질문의 ID", required = true)
+      }
+  )
+  @PostMapping("/questions/{questionId}/ratings")
+  // @PostMapping("/questions/{questionId}/ratings")
+  public ResponseEntity<QuestionRatingResponse> create(
+      @PathVariable Long questionId,
+      @Valid @RequestBody QuestionRatingRequest request
+  ) {
+    QuestionRatingResponse res = questionRatingService.create(questionId, request);
+    return ResponseEntity.status(HttpStatus.CREATED).body(res);
+  }
+}

--- a/back/src/main/java/com/qmate/common/audit/AuditorAwareImpl.java
+++ b/back/src/main/java/com/qmate/common/audit/AuditorAwareImpl.java
@@ -1,0 +1,26 @@
+package com.qmate.common.audit;
+
+import com.qmate.security.UserPrincipal;
+import java.util.Optional;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class AuditorAwareImpl implements AuditorAware<Long> {
+
+  @Override
+  public Optional<Long> getCurrentAuditor() {
+    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+    if (auth == null || !auth.isAuthenticated()) {
+      return Optional.empty();
+    }
+
+    Object principal = auth.getPrincipal();
+
+    if (principal instanceof UserPrincipal up) {
+      return Optional.ofNullable(up.userId());
+    }
+
+    return Optional.empty();
+  }
+}

--- a/back/src/main/java/com/qmate/common/redis/rating/QuestionRatingDeltaFlushScheduler.java
+++ b/back/src/main/java/com/qmate/common/redis/rating/QuestionRatingDeltaFlushScheduler.java
@@ -1,0 +1,94 @@
+package com.qmate.common.redis.rating;
+
+import com.qmate.domain.question.repository.QuestionRepository;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class QuestionRatingDeltaFlushScheduler {
+
+  private final StringRedisTemplate redis;
+  private final QuestionRepository questionRepository;
+
+  @Scheduled(
+      fixedDelayString = "${rating.flush.delay-ms:1800000}",        // 30분
+      initialDelayString = "${rating.flush.initial-delay-ms:120000}" // 2분
+  )
+  @Transactional
+  public void flushDeltas_create() {
+    Set<String> dirty = redis.opsForSet().members(QuestionRatingRedisKeys.dirtySet());
+    if (dirty == null || dirty.isEmpty()) {
+      return;
+    }
+
+    Map<Long, long[]> backUp = new HashMap<>();
+
+    try {
+      for (String qidStr : dirty) {
+        final long qid;
+        try {
+          qid = Long.parseLong(qidStr);
+        } catch (NumberFormatException nfe) {
+          redis.opsForSet().remove(QuestionRatingRedisKeys.dirtySet(), qidStr);
+          continue;
+        }
+        long likeDelta = getAndDel(QuestionRatingRedisKeys.likeDelta(qid));
+        long dislikeDelta = getAndDel(QuestionRatingRedisKeys.dislikeDelta(qid));
+        if (likeDelta == 0 && dislikeDelta == 0) {
+          redis.opsForSet().remove(QuestionRatingRedisKeys.dirtySet(), qidStr);
+          continue;
+        }
+        // 백업: 롤백 대비
+        backUp.put(qid, new long[]{likeDelta, dislikeDelta});
+
+        questionRepository.findById(qid).ifPresent(q -> q.applyRatingDelta(likeDelta, dislikeDelta));
+        log.info("질문 평가 카운팅 업데이트 - qid: {}, likeDelta: {}, dislikeDelta: {}", qid, likeDelta, dislikeDelta);
+
+        // 처리 완료: 더티셋에서 제거
+        redis.opsForSet().remove(QuestionRatingRedisKeys.dirtySet(), qidStr);
+      }
+
+    } catch (Exception e) {
+      log.error("질문 평가 카운팅 업데이트 중 오류 발생하여 롤백 작업 수행", e);
+      // 롤백: 델타 복원
+      for (Map.Entry<Long, long[]> entry : backUp.entrySet()) {
+        long qid = entry.getKey();
+        long[] deltas = entry.getValue();
+        if (deltas[0] != 0) {
+          redis.opsForValue().increment(QuestionRatingRedisKeys.likeDelta(qid), deltas[0]);
+        }
+        if (deltas[1] != 0) {
+          redis.opsForValue().increment(QuestionRatingRedisKeys.dislikeDelta(qid), deltas[1]);
+        }
+        redis.opsForSet().add(QuestionRatingRedisKeys.dirtySet(), String.valueOf(qid));
+        log.info("롤백 완료 - qid: {}, likeDelta: {}, dislikeDelta: {}", qid, deltas[0], deltas[1]);
+      }
+      throw e;
+    }
+  }
+
+  private long getAndDel(String key) throws DataAccessException {
+    Long val = redis.execute((RedisCallback<Long>) connection -> {
+      byte[] k = key.getBytes(StandardCharsets.UTF_8);
+      byte[] v = connection.stringCommands().getDel(k);
+      if (v == null) {
+        return 0L;
+      }
+      return Long.parseLong(new String(v, StandardCharsets.UTF_8));
+    });
+    return val == null ? 0L : val;
+  }
+
+}

--- a/back/src/main/java/com/qmate/common/redis/rating/QuestionRatingRedisKeys.java
+++ b/back/src/main/java/com/qmate/common/redis/rating/QuestionRatingRedisKeys.java
@@ -1,0 +1,10 @@
+package com.qmate.common.redis.rating;
+
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
+public final class QuestionRatingRedisKeys {
+  public static String likeDelta(long qid)    { return "q:%d:like_delta".formatted(qid); }
+  public static String dislikeDelta(long qid) { return "q:%d:dislike_delta".formatted(qid); }
+  public static String dirtySet()             { return "q:dirty"; }
+}

--- a/back/src/main/java/com/qmate/common/redis/rating/RedisQuestionRatingCounter.java
+++ b/back/src/main/java/com/qmate/common/redis/rating/RedisQuestionRatingCounter.java
@@ -1,0 +1,21 @@
+package com.qmate.common.redis.rating;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisQuestionRatingCounter {
+
+  private final StringRedisTemplate redis;
+
+  public void addDelta(long questionId, boolean isLike) {
+    if (isLike) {
+      redis.opsForValue().increment(QuestionRatingRedisKeys.likeDelta(questionId));
+    } else {
+      redis.opsForValue().increment(QuestionRatingRedisKeys.dislikeDelta(questionId));
+    }
+    redis.opsForSet().add(QuestionRatingRedisKeys.dirtySet(), String.valueOf(questionId));
+  }
+}

--- a/back/src/main/java/com/qmate/config/JpaConfig.java
+++ b/back/src/main/java/com/qmate/config/JpaConfig.java
@@ -1,10 +1,17 @@
 package com.qmate.config;
 
+import com.qmate.common.audit.AuditorAwareImpl;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @Configuration
-@EnableJpaAuditing
+@EnableJpaAuditing(auditorAwareRef = "auditorAware")
 public class JpaConfig {
 
+  @Bean
+  public AuditorAware<Long> auditorAware() {
+    return new AuditorAwareImpl();
+  }
 }

--- a/back/src/main/java/com/qmate/domain/question/entity/Question.java
+++ b/back/src/main/java/com/qmate/domain/question/entity/Question.java
@@ -43,6 +43,7 @@ public class Question {
 
   @Enumerated(EnumType.STRING)
   @Column(name = "relation_type", nullable = false, length = 10)
+  @Builder.Default
   private RelationType relationType = RelationType.BOTH;
 
   @Column(nullable = false, length = 500)
@@ -67,5 +68,10 @@ public class Question {
   @LastModifiedDate
   @Column(name = "updated_at", nullable = false)
   private LocalDateTime updatedAt;
+
+  public void applyRatingDelta(long likeDelta, long dislikeDelta) {
+    this.likeCount += likeDelta;
+    this.dislikeCount += dislikeDelta;
+  }
 
 }

--- a/back/src/main/java/com/qmate/domain/question/entity/QuestionCategory.java
+++ b/back/src/main/java/com/qmate/domain/question/entity/QuestionCategory.java
@@ -33,9 +33,11 @@ public class QuestionCategory {
 
   @Enumerated(EnumType.STRING)
   @Column(nullable = false, length = 10)
+  @Builder.Default
   private RelationType relationType = RelationType.BOTH;
 
   @Column(nullable = false)
+  @Builder.Default
   private boolean isActive = true;
 
 }

--- a/back/src/main/java/com/qmate/domain/questionrating/entity/QuestionRating.java
+++ b/back/src/main/java/com/qmate/domain/questionrating/entity/QuestionRating.java
@@ -46,7 +46,7 @@ public class QuestionRating {
   private Long userId;
 
   @Column(name = "is_like", nullable = false)
-  private boolean liked;
+  private boolean isLike;
 
   @CreatedDate
   @Column(name = "created_at", nullable = false, updatable = false)

--- a/back/src/main/java/com/qmate/domain/questionrating/entity/QuestionRating.java
+++ b/back/src/main/java/com/qmate/domain/questionrating/entity/QuestionRating.java
@@ -1,0 +1,54 @@
+package com.qmate.domain.questionrating.entity;
+
+import com.qmate.domain.question.entity.Question;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Setter
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "question_rating")
+@EntityListeners(AuditingEntityListener.class)
+public class QuestionRating {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "question_rating_id")
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "question_id", nullable = false)
+  private Question question;
+
+  // DB는 FK. 엔티티에선 값만 보유
+  @CreatedBy
+  @Column(name = "user_id", nullable = false)
+  private Long userId;
+
+  @Column(name = "is_like", nullable = false)
+  private boolean liked;
+
+  @CreatedDate
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+}

--- a/back/src/main/java/com/qmate/domain/questionrating/mapper/QuestionRatingMapper.java
+++ b/back/src/main/java/com/qmate/domain/questionrating/mapper/QuestionRatingMapper.java
@@ -1,0 +1,28 @@
+package com.qmate.domain.questionrating.mapper;
+
+import com.qmate.domain.question.entity.Question;
+import com.qmate.domain.questionrating.entity.QuestionRating;
+import com.qmate.domain.questionrating.model.request.QuestionRatingRequest;
+import com.qmate.domain.questionrating.model.response.QuestionRatingResponse;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
+public class QuestionRatingMapper {
+
+  public static QuestionRating toEntity(QuestionRatingRequest request, Question question) {
+    return QuestionRating.builder()
+        .question(question)
+        .isLike(request.getIsLike())
+        .build();
+  }
+
+  public static QuestionRatingResponse toResponse(QuestionRating questionRating) {
+    return QuestionRatingResponse.builder()
+        .ratingId(questionRating.getId())
+        .questionId(questionRating.getQuestion().getId())
+        .userId(questionRating.getUserId())
+        .isLike(questionRating.isLike())
+        .createdAt(questionRating.getCreatedAt())
+        .build();
+  }
+}

--- a/back/src/main/java/com/qmate/domain/questionrating/model/request/QuestionRatingRequest.java
+++ b/back/src/main/java/com/qmate/domain/questionrating/model/request/QuestionRatingRequest.java
@@ -2,11 +2,13 @@ package com.qmate.domain.questionrating.model.request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class QuestionRatingRequest {
 
   @NotNull

--- a/back/src/main/java/com/qmate/domain/questionrating/model/request/QuestionRatingRequest.java
+++ b/back/src/main/java/com/qmate/domain/questionrating/model/request/QuestionRatingRequest.java
@@ -1,0 +1,15 @@
+package com.qmate.domain.questionrating.model.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class QuestionRatingRequest {
+
+  @NotNull
+  @JsonProperty("isLike")
+  private Boolean isLike;
+}

--- a/back/src/main/java/com/qmate/domain/questionrating/model/response/QuestionRatingResponse.java
+++ b/back/src/main/java/com/qmate/domain/questionrating/model/response/QuestionRatingResponse.java
@@ -1,0 +1,24 @@
+package com.qmate.domain.questionrating.model.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class QuestionRatingResponse {
+  private Long ratingId;
+  private Long questionId;
+  private Long userId;
+
+  @JsonProperty("isLike")
+  private boolean isLike;
+
+  private LocalDateTime createdAt;
+
+}

--- a/back/src/main/java/com/qmate/domain/questionrating/repository/QuestionRatingRepository.java
+++ b/back/src/main/java/com/qmate/domain/questionrating/repository/QuestionRatingRepository.java
@@ -1,0 +1,8 @@
+package com.qmate.domain.questionrating.repository;
+
+import com.qmate.domain.questionrating.entity.QuestionRating;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface QuestionRatingRepository extends JpaRepository<QuestionRating, Long> {
+
+}

--- a/back/src/main/java/com/qmate/domain/questionrating/repository/QuestionRatingRepository.java
+++ b/back/src/main/java/com/qmate/domain/questionrating/repository/QuestionRatingRepository.java
@@ -1,8 +1,20 @@
 package com.qmate.domain.questionrating.repository;
 
 import com.qmate.domain.questionrating.entity.QuestionRating;
+import com.qmate.domain.questionrating.repository.projection.RatingAgg;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface QuestionRatingRepository extends JpaRepository<QuestionRating, Long> {
   boolean existsByQuestion_IdAndUserId(Long questionId, Long userId);
+
+  @Query("""
+      select qr.question.id as questionId,
+             sum(case when qr.isLike = true  then 1 else 0 end) as likeCount,
+             sum(case when qr.isLike = false then 1 else 0 end) as dislikeCount
+        from QuestionRating qr
+       group by qr.question.id
+      """)
+  List<RatingAgg> aggregateAll();
 }

--- a/back/src/main/java/com/qmate/domain/questionrating/repository/QuestionRatingRepository.java
+++ b/back/src/main/java/com/qmate/domain/questionrating/repository/QuestionRatingRepository.java
@@ -4,5 +4,5 @@ import com.qmate.domain.questionrating.entity.QuestionRating;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface QuestionRatingRepository extends JpaRepository<QuestionRating, Long> {
-
+  boolean existsByQuestion_IdAndUserId(Long questionId, Long userId);
 }

--- a/back/src/main/java/com/qmate/domain/questionrating/repository/projection/RatingAgg.java
+++ b/back/src/main/java/com/qmate/domain/questionrating/repository/projection/RatingAgg.java
@@ -1,0 +1,7 @@
+package com.qmate.domain.questionrating.repository.projection;
+
+public interface RatingAgg {
+  Long getQuestionId();
+  Long getLikeCount();
+  Long getDislikeCount();
+}

--- a/back/src/main/java/com/qmate/domain/questionrating/service/AdminRatingRebuildService.java
+++ b/back/src/main/java/com/qmate/domain/questionrating/service/AdminRatingRebuildService.java
@@ -1,0 +1,77 @@
+package com.qmate.domain.questionrating.service;
+
+import com.qmate.common.redis.rating.QuestionRatingRedisKeys;
+import com.qmate.domain.question.entity.Question;
+import com.qmate.domain.question.repository.QuestionRepository;
+import com.qmate.domain.questionrating.repository.QuestionRatingRepository;
+import com.qmate.domain.questionrating.repository.projection.RatingAgg;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AdminRatingRebuildService {
+
+  private final StringRedisTemplate redis;
+  private final QuestionRepository questionRepository;
+  private final QuestionRatingRepository questionRatingRepository;
+
+  /**
+   * 1) Redis의 rating 관련 키 전부 삭제
+   * 2) DB의 question_rating에서 전수 집계
+   * 3) 모든 Question like/dislike 카운트 최신화(없으면 0)
+   */
+  @Transactional
+  public void rebuildAll() {
+    clearRedisRatingKeys();
+
+    // DB 집계
+    List<RatingAgg> rows = questionRatingRepository.aggregateAll();
+    Map<Long, long[]> aggMap = new HashMap<>(rows.size());
+    for (RatingAgg r : rows) {
+      aggMap.put(r.getQuestionId(), new long[]{
+          Optional.ofNullable(r.getLikeCount()).orElse(0L),
+          Optional.ofNullable(r.getDislikeCount()).orElse(0L)
+      });
+    }
+
+    // 모든 질문을 순회하며 세팅(없으면 0)
+    for (Question q : questionRepository.findAll()) {
+      long[] v = aggMap.getOrDefault(q.getId(), new long[]{0L, 0L});
+      q.setLikeCount(v[0]);
+      q.setDislikeCount(v[1]);
+    }
+  }
+
+  /**
+   * Redis rating 관련 키만 안전하게 스캔하여 삭제
+   */
+  void clearRedisRatingKeys() throws DataAccessException {
+    final String likePattern = QuestionRatingRedisKeys.likeDelta(0).replace("0", "*");
+    final String dislikePattern = QuestionRatingRedisKeys.dislikeDelta(0).replace("0", "*");
+    final String dirtyKey = QuestionRatingRedisKeys.dirtySet();
+
+    Set<String> likes = redis.keys(likePattern);
+    if (likes != null && !likes.isEmpty()) {
+      redis.delete(likes);
+    }
+
+    Set<String> dislikes = redis.keys(dislikePattern);
+    if (dislikes != null && !dislikes.isEmpty()) {
+      redis.delete(dislikes);
+    }
+
+    redis.delete(dirtyKey);
+  }
+
+}

--- a/back/src/main/java/com/qmate/domain/questionrating/service/QuestionRatingService.java
+++ b/back/src/main/java/com/qmate/domain/questionrating/service/QuestionRatingService.java
@@ -1,0 +1,44 @@
+package com.qmate.domain.questionrating.service;
+
+import com.qmate.domain.question.entity.Question;
+import com.qmate.domain.question.repository.QuestionRepository;
+import com.qmate.domain.questionrating.entity.QuestionRating;
+import com.qmate.domain.questionrating.mapper.QuestionRatingMapper;
+import com.qmate.domain.questionrating.model.request.QuestionRatingRequest;
+import com.qmate.domain.questionrating.model.response.QuestionRatingResponse;
+import com.qmate.domain.questionrating.repository.QuestionRatingRepository;
+import com.qmate.exception.BusinessGlobalException;
+import com.qmate.exception.CommonErrorCode;
+import com.qmate.exception.custom.question.DuplicateQuestionRatingException;
+import com.qmate.exception.custom.question.QuestionNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class QuestionRatingService {
+
+  private final QuestionRatingRepository questionRatingRepository;
+  private final QuestionRepository questionRepository;
+  private final AuditorAware<Long> auditorAware;
+
+  public QuestionRatingResponse create(Long questionId, QuestionRatingRequest req) {
+    Question q = questionRepository.findById(questionId)
+        .orElseThrow(QuestionNotFoundException::new);
+
+    Long userId = auditorAware.getCurrentAuditor()
+        .orElseThrow(() -> new BusinessGlobalException(CommonErrorCode.unauthorized()));
+
+    if (questionRatingRepository.existsByQuestion_IdAndUserId(questionId, userId)) {
+      throw new DuplicateQuestionRatingException();
+    }
+
+    QuestionRating entity = QuestionRatingMapper.toEntity(req, q);
+    QuestionRating saved = questionRatingRepository.save(entity);
+    return QuestionRatingMapper.toResponse(saved);
+  }
+}

--- a/back/src/main/java/com/qmate/domain/questionrating/service/QuestionRatingService.java
+++ b/back/src/main/java/com/qmate/domain/questionrating/service/QuestionRatingService.java
@@ -1,5 +1,6 @@
 package com.qmate.domain.questionrating.service;
 
+import com.qmate.common.redis.rating.RedisQuestionRatingCounter;
 import com.qmate.domain.question.entity.Question;
 import com.qmate.domain.question.repository.QuestionRepository;
 import com.qmate.domain.questionrating.entity.QuestionRating;
@@ -25,6 +26,7 @@ public class QuestionRatingService {
   private final QuestionRatingRepository questionRatingRepository;
   private final QuestionRepository questionRepository;
   private final AuditorAware<Long> auditorAware;
+  private final RedisQuestionRatingCounter redisQuestionRatingCounter;
 
   public QuestionRatingResponse create(Long questionId, QuestionRatingRequest req) {
     Question q = questionRepository.findById(questionId)
@@ -39,6 +41,7 @@ public class QuestionRatingService {
 
     QuestionRating entity = QuestionRatingMapper.toEntity(req, q);
     QuestionRating saved = questionRatingRepository.save(entity);
+    redisQuestionRatingCounter.addDelta(questionId, req.getIsLike());
     return QuestionRatingMapper.toResponse(saved);
   }
 }

--- a/back/src/main/java/com/qmate/domain/user/User.java
+++ b/back/src/main/java/com/qmate/domain/user/User.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
@@ -26,6 +27,7 @@ import org.hibernate.annotations.UpdateTimestamp;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Table(name = "`user`")
 public class User {
   @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "user_id", nullable = false)

--- a/back/src/main/java/com/qmate/exception/custom/question/DuplicateQuestionRatingException.java
+++ b/back/src/main/java/com/qmate/exception/custom/question/DuplicateQuestionRatingException.java
@@ -1,0 +1,12 @@
+package com.qmate.exception.custom.question;
+
+import com.qmate.exception.BusinessGlobalException;
+import com.qmate.exception.errorcode.QuestionErrorCode;
+
+public class DuplicateQuestionRatingException extends BusinessGlobalException {
+
+  public DuplicateQuestionRatingException() {
+    super(QuestionErrorCode.duplicateQuestionRating());
+  }
+
+}

--- a/back/src/main/java/com/qmate/exception/custom/question/QuestionNotFoundException.java
+++ b/back/src/main/java/com/qmate/exception/custom/question/QuestionNotFoundException.java
@@ -1,0 +1,12 @@
+package com.qmate.exception.custom.question;
+
+import com.qmate.exception.BusinessGlobalException;
+import com.qmate.exception.errorcode.QuestionErrorCode;
+
+public class QuestionNotFoundException extends BusinessGlobalException {
+
+  public QuestionNotFoundException() {
+    super(QuestionErrorCode.questionNotFound());
+  }
+
+}

--- a/back/src/main/java/com/qmate/exception/errorcode/QuestionErrorCode.java
+++ b/back/src/main/java/com/qmate/exception/errorcode/QuestionErrorCode.java
@@ -1,0 +1,22 @@
+package com.qmate.exception.errorcode;
+
+import com.qmate.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class QuestionErrorCode extends ErrorCode {
+
+  public static final String QUESTION_NOT_FOUND_MESSAGE = "해당 질문을 찾을 수 없습니다.";
+  // 해당 질문에 이미 평가를 남겼습니다.
+  public static final String DUPLICATE_QUESTION_RATING_MESSAGE = "해당 질문에 이미 평가를 남겼습니다.";
+
+  public static ErrorCode questionNotFound() {
+    return new QuestionErrorCode(HttpStatus.NOT_FOUND, "Q_001", QUESTION_NOT_FOUND_MESSAGE);
+  }
+  public static ErrorCode duplicateQuestionRating() {
+    return new QuestionErrorCode(HttpStatus.CONFLICT, "Q_002", DUPLICATE_QUESTION_RATING_MESSAGE);
+  }
+
+  private QuestionErrorCode(HttpStatus httpStatus, String code, String message) {
+    super(httpStatus, code, message);
+  }
+}

--- a/back/src/test/java/com/qmate/api/question/QuestionRatingControllerCreateTest.java
+++ b/back/src/test/java/com/qmate/api/question/QuestionRatingControllerCreateTest.java
@@ -1,0 +1,104 @@
+package com.qmate.api.question;
+
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.qmate.domain.questionrating.model.request.QuestionRatingRequest;
+import com.qmate.domain.questionrating.model.response.QuestionRatingResponse;
+import com.qmate.domain.questionrating.service.QuestionRatingService;
+import com.qmate.exception.custom.question.DuplicateQuestionRatingException;
+import com.qmate.exception.custom.question.QuestionNotFoundException;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = QuestionRatingController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class QuestionRatingControllerCreateTest {
+
+  @Autowired
+  MockMvc mockMvc;
+  @Autowired
+  ObjectMapper objectMapper;
+
+  @MockitoBean
+  QuestionRatingService questionRatingService;
+
+  @Test
+  @DisplayName("create_success: 201과 응답 DTO를 반환")
+  void create_success() throws Exception {
+    Long qid = 777L;
+    QuestionRatingResponse body = QuestionRatingResponse.builder()
+        .ratingId(890L)
+        .questionId(qid)
+        .userId(99L)
+        .isLike(true)
+        .createdAt(LocalDateTime.of(2025, 9, 11, 13, 30))
+        .build();
+
+    given(questionRatingService.create(any(Long.class), any(QuestionRatingRequest.class)))
+        .willReturn(body);
+
+    String json = """
+        { "isLike": true }
+        """;
+
+    mockMvc.perform(post("/api/questions/{questionId}/ratings", qid)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(json))
+        .andExpect(status().isCreated())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.ratingId", is(890)))
+        .andExpect(jsonPath("$.questionId", is(777)))
+        .andExpect(jsonPath("$.userId", is(99)))
+        .andExpect(jsonPath("$.isLike", is(true)))
+        .andExpect(jsonPath("$.createdAt", is("2025-09-11T13:30:00")));
+  }
+
+  @Test
+  @DisplayName("404 : 질문 없음이면 404")
+  void create_fail_whenQuestionNotFound() throws Exception {
+    Long qid = 777L;
+    given(questionRatingService.create(any(Long.class), any(QuestionRatingRequest.class)))
+        .willThrow(new QuestionNotFoundException());
+
+    String json = """
+        { "isLike": true }
+        """;
+
+    mockMvc.perform(post("/api/questions/{questionId}/ratings", qid)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(json))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  @DisplayName("409 : 중복이면 409")
+  void create_fail_whenDuplicate() throws Exception {
+    Long qid = 777L;
+    given(questionRatingService.create(any(Long.class), any(QuestionRatingRequest.class)))
+        .willThrow(new DuplicateQuestionRatingException());
+
+    String json = """
+        { "isLike": true }
+        """;
+
+    mockMvc.perform(post("/api/questions/{questionId}/ratings", qid)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(json))
+        .andExpect(status().isConflict());
+  }
+
+}

--- a/back/src/test/java/com/qmate/common/redis/rating/QuestionRatingDeltaFlushSchedulerTest.java
+++ b/back/src/test/java/com/qmate/common/redis/rating/QuestionRatingDeltaFlushSchedulerTest.java
@@ -1,0 +1,111 @@
+package com.qmate.common.redis.rating;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doThrow;
+
+import com.qmate.domain.question.entity.Question;
+import com.qmate.domain.question.entity.QuestionCategory;
+import com.qmate.domain.question.repository.QuestionCategoryRepository;
+import com.qmate.domain.question.repository.QuestionRepository;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+
+@ActiveProfiles("test")
+@Tag("local")
+@SpringBootTest
+class QuestionRatingDeltaFlushSchedulerTest {
+
+  @Autowired
+  StringRedisTemplate redis;
+  @MockitoSpyBean
+  QuestionRepository questionRepository;
+  @Autowired
+  QuestionCategoryRepository questionCategoryRepository;
+
+  @Autowired
+  QuestionRatingDeltaFlushScheduler scheduler;
+  @Autowired
+  EntityManager em;
+
+  @BeforeEach
+  void cleanBefore() {
+    flushDb(redis);
+  }
+
+  @AfterEach
+  void cleanAfter() {
+    flushDb(redis);
+  }
+
+  @Test
+  void flush_success() {
+    // given: 질문 한 건 + 델타 적재
+    QuestionCategory category = QuestionCategory.builder().name("카테고리").build();
+    questionCategoryRepository.save(category);
+    Question saved = questionRepository.save(
+        Question.builder().category(category).text("질문").likeCount(0L).dislikeCount(0L).build()
+    );
+    long qid = saved.getId();
+
+    redis.opsForValue().increment(QuestionRatingRedisKeys.likeDelta(qid), 5);
+    redis.opsForSet().add(QuestionRatingRedisKeys.dirtySet(), String.valueOf(qid));
+
+    // when
+    scheduler.flushDeltas_create();
+
+    // then: DB 반영 + Redis 정리 확인
+    Question q = questionRepository.findById(qid).orElseThrow();
+    assertThat(q.getLikeCount()).isEqualTo(5L);
+    assertThat(redis.opsForValue().get(QuestionRatingRedisKeys.likeDelta(qid))).isNull();
+    assertThat(redis.opsForSet().isMember(QuestionRatingRedisKeys.dirtySet(), String.valueOf(qid))).isFalse();
+  }
+
+  @Test
+  void flush_fail_then_restore_deltas_and_keep_dirty() {
+    // given
+    QuestionCategory category = QuestionCategory.builder().name("카테고리").build();
+    questionCategoryRepository.save(category);
+    Question saved = questionRepository.save(
+        Question.builder().category(category).text("질문").likeCount(0L).dislikeCount(0L).build()
+    );
+    long qid = saved.getId();
+
+    // 델타 적재(혼합 케이스)
+    redis.opsForValue().increment(QuestionRatingRedisKeys.likeDelta(qid), 3);
+    redis.opsForValue().increment(QuestionRatingRedisKeys.dislikeDelta(qid), 2);
+    redis.opsForSet().add(QuestionRatingRedisKeys.dirtySet(), String.valueOf(qid));
+
+    // DB 접근 시 예외를 던지도록 스텁 → 스케줄러가 catch로 진입해야 함
+    doThrow(new RuntimeException("DB down")).when(questionRepository).findById(qid);
+
+    // when & then: 예외를 다시 던지는 것이 정상 동작
+    assertThrows(RuntimeException.class, () -> scheduler.flushDeltas_create());
+
+    // 복원 검증: Redis 델타가 원래 값으로 되돌아와야 함
+    assertThat(redis.opsForValue().get(QuestionRatingRedisKeys.likeDelta(qid))).isEqualTo("3");
+    assertThat(redis.opsForValue().get(QuestionRatingRedisKeys.dislikeDelta(qid))).isEqualTo("2");
+    assertThat(redis.opsForSet().isMember(QuestionRatingRedisKeys.dirtySet(), String.valueOf(qid))).isTrue();
+
+    // DB는 트랜잭션 롤백 → 카운트 변화 없음
+    Question q = em.find(Question.class, qid);
+    assertThat(q.getLikeCount()).isEqualTo(0L);
+    assertThat(q.getDislikeCount()).isEqualTo(0L);
+  }
+
+  private static void flushDb(StringRedisTemplate redis) {
+    redis.execute((RedisCallback<Object>) conn -> {
+      conn.serverCommands().flushDb();
+      return null;
+    });
+  }
+}

--- a/back/src/test/java/com/qmate/domain/questionrating/repository/QuestionRatingRepositoryTest.java
+++ b/back/src/test/java/com/qmate/domain/questionrating/repository/QuestionRatingRepositoryTest.java
@@ -1,0 +1,91 @@
+package com.qmate.domain.questionrating.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.qmate.config.JpaConfig;
+import com.qmate.domain.question.entity.Question;
+import com.qmate.domain.questionrating.entity.QuestionRating;
+import com.qmate.security.UserPrincipal;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@Tag("local")
+@DataJpaTest
+@Import(JpaConfig.class) // @EnableJpaAuditing(auditorAwareRef = "auditorAware")
+class QuestionRatingRepositoryTest {
+
+  @TestConfiguration
+  static class QuerydslTestConfig {
+    @Bean
+    JPAQueryFactory jpaQueryFactory(EntityManager em) {
+      return new JPAQueryFactory(em);
+    }
+  }
+
+  @Autowired
+  QuestionRatingRepository repository;
+  @Autowired
+  EntityManager em;
+
+  private static final long TEST_USER_ID = 99L;
+
+  @BeforeEach
+  void setUpSecurityContext() {
+    UserPrincipal principal = new UserPrincipal(TEST_USER_ID, "tester@example.com", "ROLE_USER");
+    Authentication auth = new UsernamePasswordAuthenticationToken(principal, null, List.of());
+    SecurityContextHolder.getContext().setAuthentication(auth);
+  }
+
+  @AfterEach
+  void clearSecurityContext() {
+    SecurityContextHolder.clearContext();
+  }
+
+  @BeforeEach
+  void disableFk() {
+    em.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate(); // H2 only
+  }
+
+  @AfterEach
+  void enableFk() {
+    em.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();
+  }
+
+  @Test
+  @DisplayName("@CreatedBy 로 user_id 자동 주입 확인")
+  void createdBy_setsUserId_onPersist() {
+    // 사전조건: question 테이블에 ID=1 인 레코드 1건 존재
+    Question questionRef = em.getReference(Question.class, 1L);
+
+    QuestionRating rating = new QuestionRating();
+    rating.setQuestion(questionRef);
+    rating.setLiked(true); // is_like = 1
+
+    QuestionRating saved = repository.saveAndFlush(rating);
+
+    assertThat(saved.getId()).isNotNull();
+    assertThat(saved.getUserId()).isEqualTo(TEST_USER_ID);
+    assertThat(saved.getCreatedAt()).isNotNull();
+    assertThat(saved.isLiked()).isTrue();
+  }
+}

--- a/back/src/test/java/com/qmate/domain/questionrating/repository/QuestionRatingRepositoryTest.java
+++ b/back/src/test/java/com/qmate/domain/questionrating/repository/QuestionRatingRepositoryTest.java
@@ -79,13 +79,13 @@ class QuestionRatingRepositoryTest {
 
     QuestionRating rating = new QuestionRating();
     rating.setQuestion(questionRef);
-    rating.setLiked(true); // is_like = 1
+    rating.setLike(true); // is_like = 1
 
     QuestionRating saved = repository.saveAndFlush(rating);
 
     assertThat(saved.getId()).isNotNull();
     assertThat(saved.getUserId()).isEqualTo(TEST_USER_ID);
     assertThat(saved.getCreatedAt()).isNotNull();
-    assertThat(saved.isLiked()).isTrue();
+    assertThat(saved.isLike()).isTrue();
   }
 }

--- a/back/src/test/java/com/qmate/domain/questionrating/service/AdminRatingRebuildServiceTest.java
+++ b/back/src/test/java/com/qmate/domain/questionrating/service/AdminRatingRebuildServiceTest.java
@@ -1,0 +1,143 @@
+package com.qmate.domain.questionrating.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.qmate.common.redis.rating.QuestionRatingRedisKeys;
+import com.qmate.domain.question.entity.Question;
+import com.qmate.domain.question.entity.QuestionCategory;
+import com.qmate.domain.question.repository.QuestionCategoryRepository;
+import com.qmate.domain.question.repository.QuestionRepository;
+import com.qmate.domain.questionrating.entity.QuestionRating;
+import com.qmate.domain.questionrating.repository.QuestionRatingRepository;
+import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@Tag("local")
+@SpringBootTest
+public class AdminRatingRebuildServiceTest {
+
+  @Autowired
+  AdminRatingRebuildService service;
+  @Autowired
+  StringRedisTemplate redis;
+  @Autowired
+  QuestionRepository questionRepository;
+  @Autowired
+  QuestionRatingRepository questionRatingRepository;
+  @Autowired
+  QuestionCategoryRepository questionCategoryRepository;
+
+  @BeforeEach
+  void setUp() {
+    // DB clean (FK 순서 주의: rating -> question -> category)
+    questionRatingRepository.deleteAllInBatch();
+    questionRepository.deleteAllInBatch();
+    questionCategoryRepository.deleteAllInBatch();
+    // Redis clean
+    flushDb(redis);
+  }
+
+  @AfterEach
+  void tearDown() {
+    flushDb(redis);
+  }
+
+  @Test
+  @DisplayName("rebuildAll: DB 전수 집계로 Question 카운트 최신화 + Redis 키 정리")
+  void rebuildAll_updates_from_db_and_clears_redis() {
+    // given
+    QuestionCategory cat = questionCategoryRepository.save(
+        QuestionCategory.builder().name("카테고리").build()
+    );
+
+    Question q1 = questionRepository.save(
+        Question.builder().category(cat).text("Q1").likeCount(999L).dislikeCount(999L).build()
+    );
+    Question q2 = questionRepository.save(
+        Question.builder().category(cat).text("Q2").likeCount(999L).dislikeCount(999L).build()
+    );
+    Question q3 = questionRepository.save(
+        Question.builder().category(cat).text("Q3").likeCount(5L).dislikeCount(7L).build()
+    );
+
+    // rating 원장 데이터 (DB가 진실)
+    // q1: like 3, dislike 1
+    questionRatingRepository.save(QuestionRating.builder().question(q1).userId(1L).isLike(true).build());
+    questionRatingRepository.save(QuestionRating.builder().question(q1).userId(2L).isLike(true).build());
+    questionRatingRepository.save(QuestionRating.builder().question(q1).userId(3L).isLike(true).build());
+    questionRatingRepository.save(QuestionRating.builder().question(q1).userId(4L).isLike(false).build());
+    // q2: like 0, dislike 2
+    questionRatingRepository.save(QuestionRating.builder().question(q2).userId(5L).isLike(false).build());
+    questionRatingRepository.save(QuestionRating.builder().question(q2).userId(6L).isLike(false).build());
+    // q3: rating 없음 → 0,0 이어야 함
+
+    // Redis에 남아있던 임의의 델타/dirty (rebuild가 비워야 함)
+    redis.opsForValue().increment(QuestionRatingRedisKeys.likeDelta(q1.getId()), 10);
+    redis.opsForValue().increment(QuestionRatingRedisKeys.dislikeDelta(q2.getId()), 20);
+    redis.opsForSet().add(QuestionRatingRedisKeys.dirtySet(),
+        String.valueOf(q1.getId()), String.valueOf(q2.getId()), String.valueOf(q3.getId()));
+
+    // when
+    service.rebuildAll();
+
+    // then — DB 최신화 검증
+    Question rq1 = questionRepository.findById(q1.getId()).orElseThrow();
+    Question rq2 = questionRepository.findById(q2.getId()).orElseThrow();
+    Question rq3 = questionRepository.findById(q3.getId()).orElseThrow();
+
+    assertThat(rq1.getLikeCount()).isEqualTo(3L);
+    assertThat(rq1.getDislikeCount()).isEqualTo(1L);
+
+    assertThat(rq2.getLikeCount()).isEqualTo(0L);
+    assertThat(rq2.getDislikeCount()).isEqualTo(2L);
+
+    assertThat(rq3.getLikeCount()).isEqualTo(0L);
+    assertThat(rq3.getDislikeCount()).isEqualTo(0L);
+
+    // Redis 정리 검증
+    assertThat(redis.opsForValue().get(QuestionRatingRedisKeys.likeDelta(q1.getId()))).isNull();
+    assertThat(redis.opsForValue().get(QuestionRatingRedisKeys.dislikeDelta(q2.getId()))).isNull();
+    Set<String> dirty = redis.opsForSet().members(QuestionRatingRedisKeys.dirtySet());
+    assertThat(dirty == null || dirty.isEmpty()).isTrue();
+  }
+
+  @Test
+  @DisplayName("rebuildAll: 여러 번 호출해도 결과는 동일(멱등)")
+  void rebuild_is_idempotent() {
+    // given
+    QuestionCategory cat = questionCategoryRepository.save(
+        QuestionCategory.builder().name("카테고리").build()
+    );
+    Question q = questionRepository.save(
+        Question.builder().category(cat).text("Q").likeCount(100L).dislikeCount(100L).build()
+    );
+    questionRatingRepository.save(QuestionRating.builder().question(q).userId(1L).isLike(true).build());
+    questionRatingRepository.save(QuestionRating.builder().question(q).userId(2L).isLike(false).build());
+    // when
+    service.rebuildAll();
+    long like1 = questionRepository.findById(q.getId()).orElseThrow().getLikeCount();
+    long dislike1 = questionRepository.findById(q.getId()).orElseThrow().getDislikeCount();
+    service.rebuildAll();
+    long like2 = questionRepository.findById(q.getId()).orElseThrow().getLikeCount();
+    long dislike2 = questionRepository.findById(q.getId()).orElseThrow().getDislikeCount();
+    // then
+    assertThat(like1).isEqualTo(1L);
+    assertThat(dislike1).isEqualTo(1L);
+    assertThat(like2).isEqualTo(1L);
+    assertThat(dislike2).isEqualTo(1L);
+  }
+
+  private static void flushDb(StringRedisTemplate redis) {
+    redis.execute((RedisCallback<Object>) conn -> { conn.serverCommands().flushDb(); return null; });
+  }
+}

--- a/back/src/test/java/com/qmate/domain/questionrating/service/QuestionRatingServiceCreateTest.java
+++ b/back/src/test/java/com/qmate/domain/questionrating/service/QuestionRatingServiceCreateTest.java
@@ -1,0 +1,139 @@
+package com.qmate.domain.questionrating.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import com.qmate.domain.question.entity.Question;
+import com.qmate.domain.question.repository.QuestionRepository;
+import com.qmate.domain.questionrating.entity.QuestionRating;
+import com.qmate.domain.questionrating.model.request.QuestionRatingRequest;
+import com.qmate.domain.questionrating.model.response.QuestionRatingResponse;
+import com.qmate.domain.questionrating.repository.QuestionRatingRepository;
+import com.qmate.exception.BusinessGlobalException;
+import com.qmate.exception.CommonErrorCode;
+import com.qmate.exception.custom.question.DuplicateQuestionRatingException;
+import com.qmate.exception.custom.question.QuestionNotFoundException;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.AuditorAware;
+
+@ExtendWith(MockitoExtension.class)
+class QuestionRatingServiceCreateTest {
+
+  @Mock
+  QuestionRepository questionRepository;
+  @Mock
+  QuestionRatingRepository questionRatingRepository;
+  @Mock
+  AuditorAware<Long> auditorAware;
+
+  @InjectMocks
+  QuestionRatingService service;
+
+  @Test
+  @DisplayName("201 : 정상 생성 시 DTO가 기대값으로 반환된다")
+  void create_success() {
+    // given
+    Long qid = 777L;
+    Long uid = 99L;
+
+    // 엔티티는 전부 빌더로 생성
+    Question question = Question.builder()
+        .id(qid)
+        .build();
+
+    given(questionRepository.findById(qid)).willReturn(Optional.of(question));
+    given(auditorAware.getCurrentAuditor()).willReturn(Optional.of(uid));
+    given(questionRatingRepository.existsByQuestion_IdAndUserId(qid, uid)).willReturn(false);
+
+    // save 후 반환될 엔티티 (빌더)
+    QuestionRating saved = QuestionRating.builder()
+        .id(890L)
+        .question(question)
+        .userId(uid)
+        .isLike(true)
+        .createdAt(LocalDateTime.of(2025, 9, 11, 13, 30))
+        .build();
+
+    given(questionRatingRepository.save(any(QuestionRating.class))).willReturn(saved);
+
+    QuestionRatingRequest req = new QuestionRatingRequest(true);
+
+    // when
+    QuestionRatingResponse res = service.create(qid, req);
+
+    // then
+    assertThat(res.getRatingId()).isEqualTo(890L);
+    assertThat(res.getQuestionId()).isEqualTo(777L);
+    assertThat(res.getUserId()).isEqualTo(99L);
+    assertThat(res.isLike()).isTrue();
+    assertThat(res.getCreatedAt()).isEqualTo(LocalDateTime.of(2025, 9, 11, 13, 30));
+
+    then(questionRepository).should().findById(qid);
+    then(auditorAware).should().getCurrentAuditor();
+    then(questionRatingRepository).should().existsByQuestion_IdAndUserId(qid, uid);
+    then(questionRatingRepository).should().save(any(QuestionRating.class));
+  }
+
+  @Test
+  @DisplayName("404 : 질문이 없으면 QuestionNotFoundException")
+  void create_fail_whenQuestionNotFound() {
+    // given
+    Long qid = 777L;
+    given(questionRepository.findById(qid)).willReturn(Optional.empty());
+
+    QuestionRatingRequest req = new QuestionRatingRequest(true);
+
+    // expect
+    assertThatThrownBy(() -> service.create(qid, req))
+        .isInstanceOf(QuestionNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("401 : Auditor가 비어있으면 BusinessGlobalException(unauthorized)")
+  void create_fail_whenUnauthorized() {
+    // given
+    Long qid = 777L;
+
+    Question question = Question.builder().id(qid).build();
+
+    given(questionRepository.findById(qid)).willReturn(Optional.of(question));
+    given(auditorAware.getCurrentAuditor()).willReturn(Optional.empty());
+
+    QuestionRatingRequest req = new QuestionRatingRequest(true);
+
+    // expect
+    assertThatThrownBy(() -> service.create(qid, req))
+        .isInstanceOf(BusinessGlobalException.class)
+        .hasMessageContaining(CommonErrorCode.unauthorized().getMessage());
+  }
+
+  @Test
+  @DisplayName("409 : 동일 사용자가 이미 평가했다면 DuplicateQuestionRatingException")
+  void create_fail_whenDuplicate() {
+    // given
+    Long qid = 777L;
+    Long uid = 99L;
+
+    Question question = Question.builder().id(qid).build();
+
+    given(questionRepository.findById(qid)).willReturn(Optional.of(question));
+    given(auditorAware.getCurrentAuditor()).willReturn(Optional.of(uid));
+    given(questionRatingRepository.existsByQuestion_IdAndUserId(qid, uid)).willReturn(true);
+
+    QuestionRatingRequest req = new QuestionRatingRequest(true);
+
+    // expect
+    assertThatThrownBy(() -> service.create(qid, req))
+        .isInstanceOf(DuplicateQuestionRatingException.class);
+  }
+}


### PR DESCRIPTION
## 요약
질문에 대한 **좋아요/싫어요 작성 API**와, 작성 시 **Redis 델타 누적 → 주기적 DB 반영 스케줄러**를 구현했습니다.  
운영/장애 대응을 위해 **관리자 재빌드 API**(Redis 초기화 후 DB 원장 재집계)도 추가했습니다. 전 구간에 대해 단위/통합 테스트를 포함합니다.

---

## 주요 변경 사항

### 1) 도메인 & 스키마
- `question_rating` 스키마 컬럼을 `is_like`(BOOLEAN)로 일관화.
- 엔티티
  - `QuestionRating(id, question, userId, isLike, createdAt, createdBy)`
  - `Question(… likeCount, dislikeCount, applyRatingDelta)`
- 감사 설정
  - `@EnableJpaAuditing(auditorAwareRef = "auditorAware")`
  - `AuditorAwareImpl`로 `SecurityContext`의 `UserPrincipal.userId()` 주입.
- DDL: `is_like` boolean 기준 테이블 생성(재생성 시 한 줄 변경).

### 2) API (작성)
- `POST /api/questions/{questionId}/ratings`
  - Request: `{"isLike": true|false}`
  - Response(201): `{"ratingId","questionId","userId","isLike","createdAt"}`
- DTO/매퍼
  - `QuestionRatingRequest(Boolean isLike)`
  - `QuestionRatingResponse(… isLike, createdAt)`
  - `QuestionRatingMapper` (request→entity, entity→response)
- 서비스 (`QuestionRatingService#create`)
  - 질문 미존재 시 `QuestionNotFoundException`(404)
  - 인증 없음 시 `BusinessGlobalException(unauthorized)`(401)
  - 중복 작성 방지: `existsByQuestion_IdAndUserId` → `DuplicateQuestionRatingException`(409)

### 3) Redis 델타 누적 & 스케줄러 반영
- 키 규칙 (`QuestionRatingRedisKeys`)
  - `q:{qid}:like_delta`
  - `q:{qid}:dislike_delta`
  - `q:dirty`(SET; 변경된 qid 모음)
- 작성 시 `addDelta(questionId, isLike)`로 델타 + dirty 등록.
- 스케줄러 `QuestionRatingDeltaFlushScheduler`
  - 주기: **fixedDelay=30분**, initialDelay=2분
  - 처리: `GETDEL`로 델타 수집 → `applyRatingDelta` → dirty 제거
  - **백업/복원**: 루프 중 예외 시 이미 가져간 델타를 Redis로 복원 + dirty 재등록 후 예외 재전파

### 4) 관리자 재빌드(API)
- 목적: Redis 무시하고 **DB 원장(question_rating)** 기준 **전수 재집계**
- 서비스 `AdminRatingRebuildService#rebuildAll`
  1) Redis rating 키 삭제(`q:*:like_delta`, `q:*:dislike_delta`, `q:dirty`) — `keys + delete` 사용
  2) `QuestionRatingRepository.aggregateAll()`로 전수 집계
  3) 모든 `Question`의 `likeCount/dislikeCount` 갱신
- 컨트롤러
  - `POST /api/admin/questions/ratings/rebuild` → **204 No Content**
  - (권한) 관리자 전용

---

## 테스트

### 단위/슬라이스
- **서비스**: `QuestionRatingServiceCreateTest`
  - 정상 생성(201 DTO)
  - 질문 없음(404), 인증 없음(401), 중복(409)
- **컨트롤러**: `QuestionRatingControllerCreateTest` (WebMvcTest)
  - 성공(201), 질문 없음(404), 중복(409)

### 통합 (Redis/JPA)
- `QuestionRatingDeltaFlushSchedulerTest`
  - 성공 경로: 델타→DB 반영 & Redis 정리
  - 실패/복원 경로: `QuestionRepository.findById` 예외 시 델타 복원 + dirty 유지, DB 카운트 롤백
- `AdminRatingRebuildServiceTest`
  - 전수 재집계로 Question 최신화 + Redis 키 정리 확인
  - **멱등성** 재호출 동일 결과 검증