### PR TITLE
Feature/update match info

### DIFF
--- a/back/src/main/java/com/qmate/api/MatchController.java
+++ b/back/src/main/java/com/qmate/api/MatchController.java
@@ -2,6 +2,7 @@ package com.qmate.api;
 
 import com.qmate.domain.match.model.request.MatchCreationRequest;
 import com.qmate.domain.match.model.request.MatchJoinRequest;
+import com.qmate.domain.match.model.request.MatchUpdateRequest;
 import com.qmate.domain.match.model.response.MatchCreationResponse;
 import com.qmate.domain.match.model.response.MatchInfoResponse;
 import com.qmate.domain.match.model.response.MatchJoinResponse;
@@ -12,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -58,7 +60,6 @@ public class MatchController {
 
 
   }
-
   /**
    * 특정 매칭의 상세 정보를 조회합니다.
    *
@@ -88,4 +89,24 @@ public class MatchController {
     MatchMembersResponse response = matchService.getMatchMembers(matchId, currentUserId);
     return ResponseEntity.ok(response);
   }
+  /**특정 매칭의 정보를 업데이트(기념일, 질문 받는 시간 등)
+   * @param matchId URL 경로에서 받아온 매칭 ID
+   * @param request 업데이트할 정보가 담긴 DTO
+   * @return 200 OK 상태 코드와 함께 성공 메시지를 반환
+   */
+   @PatchMapping("/{matchId}/info")
+  public ResponseEntity<Void> updateMatchInfo(
+      @PathVariable Long matchId,
+       @RequestBody @Valid MatchUpdateRequest request
+       // @AuthenticationPrincipal UserDetailsImpl userDetails
+   ){
+     // 임시로 요청을 보낸 사용자의 ID를 3L로 가정합니다.
+     Long currentUserId = 3L;
+     // Long currentUserId = userDetails.getUser().getId();
+
+     matchService.updateMatchInfo(matchId, currentUserId,request);
+
+     // 성공적으로 처리되었지만, 별도의 응답 본문은 없다는 의미로 204 No Content를 반환
+     return ResponseEntity.noContent().build();
+   }
 }

--- a/back/src/main/java/com/qmate/common/constants/match/MatchConstants.java
+++ b/back/src/main/java/com/qmate/common/constants/match/MatchConstants.java
@@ -1,0 +1,17 @@
+package com.qmate.common.constants.match;
+
+public class MatchConstants {
+
+  // MatchUpdateRequest
+  public static final String HOUR_MIN_MESSAGE = "질문 시간은 0 이상이어야 합니다.";
+  public static final String HOUR_MAX_MESSAGE = "질문 시간은 23 이하여야 합니다.";
+
+  // MatchJoinRequest
+  public static final String INVITE_CODE_NOT_BLANK = "초대 코드를 입력해주세요.";
+  public static final String INVITE_CODE_SIZE = "초대 코드는 6자리 숫자입니다.";
+
+  // MatchCreationRequest
+  public static final String RELATION_TYPE_NOT_NULL = "관계 유형을 선택해주세요.";
+  public static final String VALID_START_DATE_DEFAULT = "연인(COUPLE) 관계는 기념일(startDate)을 필수로 입력해야 합니다.";
+
+}

--- a/back/src/main/java/com/qmate/common/constants/redis/RedisKeyConstants.java
+++ b/back/src/main/java/com/qmate/common/constants/redis/RedisKeyConstants.java
@@ -1,4 +1,4 @@
-package com.qmate.common.constants;
+package com.qmate.common.constants.redis;
 
 
 public class RedisKeyConstants {

--- a/back/src/main/java/com/qmate/common/redis/RedisHelper.java
+++ b/back/src/main/java/com/qmate/common/redis/RedisHelper.java
@@ -1,6 +1,6 @@
 package com.qmate.common.redis;
 
-import com.qmate.common.constants.RedisKeyConstants;
+import com.qmate.common.constants.redis.RedisKeyConstants;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;

--- a/back/src/main/java/com/qmate/common/validation/ValidStartDate.java
+++ b/back/src/main/java/com/qmate/common/validation/ValidStartDate.java
@@ -1,5 +1,6 @@
 package com.qmate.common.validation;
 
+import com.qmate.common.constants.match.MatchConstants;
 import jakarta.validation.Constraint;
 import jakarta.validation.Payload;
 import java.lang.annotation.ElementType;
@@ -11,8 +12,11 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Constraint(validatedBy = StartDateValidator.class)
 public @interface ValidStartDate {
-  String message() default "연인(COUPLE) 관계는 기념일(startDate)을 필수로 입력해야 합니다.";
-  Class<?> [] groups() default {};
+
+  String message() default MatchConstants.VALID_START_DATE_DEFAULT;
+
+  Class<?>[] groups() default {};
+
   Class<? extends Payload>[] payload() default {};
 
 }

--- a/back/src/main/java/com/qmate/config/SecurityConfig.java
+++ b/back/src/main/java/com/qmate/config/SecurityConfig.java
@@ -64,11 +64,10 @@ public class SecurityConfig {
             })
         )
         .authorizeHttpRequests(auth -> auth
-//            .requestMatchers("/auth/**").permitAll()
-//            .requestMatchers(SWAGGER_WHITELIST).permitAll()
-//            .requestMatchers("/api/admin/**").hasRole("ADMIN")
-//            .anyRequest().authenticated()  // 나머지 모든 요청은 인증 필요
-                .anyRequest().permitAll()
+            .requestMatchers("/auth/**").permitAll()
+            .requestMatchers(SWAGGER_WHITELIST).permitAll()
+            .requestMatchers("/api/admin/**").hasRole("ADMIN")
+            .anyRequest().authenticated()  // 나머지 모든 요청은 인증 필요
         )
         .addFilterBefore(new JwtAuthenticationFilter(jwtService), UsernamePasswordAuthenticationFilter.class);  // JWT 필터 추가
 

--- a/back/src/main/java/com/qmate/config/SecurityConfig.java
+++ b/back/src/main/java/com/qmate/config/SecurityConfig.java
@@ -64,10 +64,11 @@ public class SecurityConfig {
             })
         )
         .authorizeHttpRequests(auth -> auth
-            .requestMatchers("/auth/**").permitAll()
-            .requestMatchers(SWAGGER_WHITELIST).permitAll()
-            .requestMatchers("/api/admin/**").hasRole("ADMIN")
-            .anyRequest().authenticated()  // 나머지 모든 요청은 인증 필요
+//            .requestMatchers("/auth/**").permitAll()
+//            .requestMatchers(SWAGGER_WHITELIST).permitAll()
+//            .requestMatchers("/api/admin/**").hasRole("ADMIN")
+//            .anyRequest().authenticated()  // 나머지 모든 요청은 인증 필요
+                .anyRequest().permitAll()
         )
         .addFilterBefore(new JwtAuthenticationFilter(jwtService), UsernamePasswordAuthenticationFilter.class);  // JWT 필터 추가
 

--- a/back/src/main/java/com/qmate/domain/match/Match.java
+++ b/back/src/main/java/com/qmate/domain/match/Match.java
@@ -10,6 +10,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -69,6 +70,9 @@ public class Match {
 
   public void setStatus(MatchStatus status) {
     this.status = status;
+  }
+  public void updateStartDate(LocalDate startDate) {
+    this.startDate = startDate.atStartOfDay();
   }
 
   //정적 팩토리 메서드 추가

--- a/back/src/main/java/com/qmate/domain/match/MatchSetting.java
+++ b/back/src/main/java/com/qmate/domain/match/MatchSetting.java
@@ -23,7 +23,7 @@ public class MatchSetting {
 
   @Id
   @Column(name = "match_id")
-  private Long matchId;
+  private Long id;
 
   @OneToOne(fetch = FetchType.LAZY)
   @MapsId
@@ -44,7 +44,7 @@ public class MatchSetting {
   // Match와 함께 처음 생성될 때 사용하는 생성자
   public MatchSetting(Match match) {
     this.match = match;
-    this.matchId = match.getId();
+    this.id = match.getId();
   }
 
   // 질문 시간을 업데이트하는 전용 메서드

--- a/back/src/main/java/com/qmate/domain/match/MatchSetting.java
+++ b/back/src/main/java/com/qmate/domain/match/MatchSetting.java
@@ -40,4 +40,15 @@ public class MatchSetting {
   @UpdateTimestamp
   @Column(name = "updated_at", nullable = false)
   private LocalDateTime updatedAt;
+
+  // Match와 함께 처음 생성될 때 사용하는 생성자
+  public MatchSetting(Match match) {
+    this.match = match;
+    this.matchId = match.getId();
+  }
+
+  // 질문 시간을 업데이트하는 전용 메서드
+  public void updateDailyQuestionHour(int hour) {
+    this.dailyQuestionHour = hour;
+  }
 }

--- a/back/src/main/java/com/qmate/domain/match/model/request/MatchCreationRequest.java
+++ b/back/src/main/java/com/qmate/domain/match/model/request/MatchCreationRequest.java
@@ -1,5 +1,6 @@
 package com.qmate.domain.match.model.request;
 
+import com.qmate.common.constants.match.MatchConstants;
 import com.qmate.common.validation.ValidStartDate;
 import com.qmate.domain.match.RelationType;
 import jakarta.validation.constraints.NotNull;
@@ -11,7 +12,7 @@ import lombok.Setter;
 @ValidStartDate
 public class MatchCreationRequest {
 
-  @NotNull(message = "관계 유형을 선택해주세요.")
+  @NotNull(message = MatchConstants.RELATION_TYPE_NOT_NULL)
   private RelationType relationType;
 
   private String startDate;

--- a/back/src/main/java/com/qmate/domain/match/model/request/MatchJoinRequest.java
+++ b/back/src/main/java/com/qmate/domain/match/model/request/MatchJoinRequest.java
@@ -1,5 +1,6 @@
 package com.qmate.domain.match.model.request;
 
+import com.qmate.common.constants.match.MatchConstants;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
@@ -9,8 +10,8 @@ import lombok.Setter;
 @Setter
 public class MatchJoinRequest {
 
-  @NotBlank(message = "초대 코드를 입력해주세요.")
-  @Size(min = 6, max = 6, message = "초대 코드는 6자리 숫자입니다.")
+  @NotBlank(message = MatchConstants.INVITE_CODE_NOT_BLANK)
+  @Size(min = 6, max = 6, message = MatchConstants.INVITE_CODE_SIZE)
   private String inviteCode;
 
 }

--- a/back/src/main/java/com/qmate/domain/match/model/request/MatchUpdateRequest.java
+++ b/back/src/main/java/com/qmate/domain/match/model/request/MatchUpdateRequest.java
@@ -1,0 +1,20 @@
+package com.qmate.domain.match.model.request;
+
+import com.qmate.common.constants.match.MatchConstants;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import java.time.LocalDate;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class MatchUpdateRequest {
+
+  @Min(value = 0, message = MatchConstants.HOUR_MIN_MESSAGE)
+  @Max(value = 23, message = MatchConstants.HOUR_MAX_MESSAGE)
+  private Integer dailyQuestionHour;
+
+  private LocalDate startDate;
+
+}

--- a/back/src/main/java/com/qmate/domain/match/repository/MatchSettingRepository.java
+++ b/back/src/main/java/com/qmate/domain/match/repository/MatchSettingRepository.java
@@ -6,5 +6,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MatchSettingRepository extends JpaRepository<MatchSetting, Long> {
 
-  Optional<MatchSetting> findByMatchId(Long matchId);
 }

--- a/back/src/main/java/com/qmate/domain/match/service/MatchService.java
+++ b/back/src/main/java/com/qmate/domain/match/service/MatchService.java
@@ -156,7 +156,7 @@ public class MatchService {
       match.updateStartDate(request.getStartDate());
     }
     if (request.getDailyQuestionHour() != null){
-      MatchSetting matchSetting = matchSettingRepository.findByMatchId(matchId)
+      MatchSetting matchSetting = matchSettingRepository.findById(matchId)
           .orElseGet(() ->{
             MatchSetting newSetting = new MatchSetting(match);
             return matchSettingRepository.save(newSetting);

--- a/back/src/main/java/com/qmate/domain/match/service/MatchService.java
+++ b/back/src/main/java/com/qmate/domain/match/service/MatchService.java
@@ -31,6 +31,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -149,19 +150,25 @@ public class MatchService {
 
     boolean isMember = match.getMembers().stream()
         .anyMatch(matchMember -> matchMember.getUser().getId().equals(userId));
-    if (!isMember){
+    if (!isMember) {
       throw new MatchForbiddenException();
     }
-    if (request.getStartDate() != null){
+    if (request.getStartDate() != null) {
       match.updateStartDate(request.getStartDate());
     }
-    if (request.getDailyQuestionHour() != null){
-      MatchSetting matchSetting = matchSettingRepository.findById(matchId)
-          .orElseGet(() ->{
-            MatchSetting newSetting = new MatchSetting(match);
-            return matchSettingRepository.save(newSetting);
-          });
-      matchSetting.updateDailyQuestionHour(request.getDailyQuestionHour());
+    if (request.getDailyQuestionHour() != null) {
+      Optional<MatchSetting> optMatchSetting = matchSettingRepository.findById(matchId);
+
+      if (optMatchSetting.isPresent()) {
+        //  이미 존재한다면, 찾은 객체의 값을 업데이트합니다.
+        MatchSetting matchSetting = optMatchSetting.get();
+        matchSetting.updateDailyQuestionHour(request.getDailyQuestionHour());
+      } else {
+        //  존재하지 않는다면, 새로운 객체를 만들어서 저장합니다.
+        MatchSetting newSetting = new MatchSetting(match);
+        newSetting.updateDailyQuestionHour(request.getDailyQuestionHour());
+        matchSettingRepository.save(newSetting);
+      }
     }
   }
 

--- a/back/src/main/java/com/qmate/domain/match/service/MatchService.java
+++ b/back/src/main/java/com/qmate/domain/match/service/MatchService.java
@@ -3,16 +3,19 @@ package com.qmate.domain.match.service;
 import com.qmate.common.redis.RedisHelper;
 import com.qmate.domain.match.Match;
 import com.qmate.domain.match.MatchMember;
+import com.qmate.domain.match.MatchSetting;
 import com.qmate.domain.match.MatchStatus;
 import com.qmate.domain.match.RelationType;
 import com.qmate.domain.match.model.request.MatchCreationRequest;
 import com.qmate.domain.match.model.request.MatchJoinRequest;
+import com.qmate.domain.match.model.request.MatchUpdateRequest;
 import com.qmate.domain.match.model.response.MatchCreationResponse;
 import com.qmate.domain.match.model.response.MatchInfoResponse;
 import com.qmate.domain.match.model.response.MatchJoinResponse;
 import com.qmate.domain.match.model.response.MatchMembersResponse;
 import com.qmate.domain.match.repository.MatchMemberRepository;
 import com.qmate.domain.match.repository.MatchRepository;
+import com.qmate.domain.match.repository.MatchSettingRepository;
 import com.qmate.domain.user.User;
 import com.qmate.domain.user.UserRepository;
 import com.qmate.exception.custom.matchinstance.AlreadyInMatchException;
@@ -40,6 +43,7 @@ public class MatchService {
   private final MatchMemberRepository matchMemberRepository;
   private final UserRepository userRepository;
   private final RedisHelper redisHelper;
+  private final MatchSettingRepository matchSettingRepository;
 
   //초대 코드 생성 로직
   @Transactional
@@ -137,6 +141,29 @@ public class MatchService {
     return new MatchMembersResponse(match, userId);
   }
 
+  //매칭 정보를 선택적으로 업데이트합니다.(기념일, 질문시간)
+  @Transactional
+  public void updateMatchInfo(Long matchId, Long userId, MatchUpdateRequest request) {
+    Match match = matchRepository.findWithMembersAndUsersById(matchId)
+        .orElseThrow(MatchNotFoundException::new);
+
+    boolean isMember = match.getMembers().stream()
+        .anyMatch(matchMember -> matchMember.getUser().getId().equals(userId));
+    if (!isMember){
+      throw new MatchForbiddenException();
+    }
+    if (request.getStartDate() != null){
+      match.updateStartDate(request.getStartDate());
+    }
+    if (request.getDailyQuestionHour() != null){
+      MatchSetting matchSetting = matchSettingRepository.findByMatchId(matchId)
+          .orElseGet(() ->{
+            MatchSetting newSetting = new MatchSetting(match);
+            return matchSettingRepository.save(newSetting);
+          });
+      matchSetting.updateDailyQuestionHour(request.getDailyQuestionHour());
+    }
+  }
 
   //가독성을 위한 private 헬퍼 메서드(초대 생성 관련)
   private void validateUserNotInActiveMatch(Long userId) {

--- a/back/src/test/java/com/qmate/api/MatchControllerTest.java
+++ b/back/src/test/java/com/qmate/api/MatchControllerTest.java
@@ -3,8 +3,10 @@ package com.qmate.api;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.BDDMockito.willThrow;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -12,6 +14,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.qmate.domain.match.RelationType;
 import com.qmate.domain.match.model.request.MatchJoinRequest;
+import com.qmate.domain.match.model.request.MatchUpdateRequest;
 import com.qmate.domain.match.model.response.MatchInfoResponse;
 import com.qmate.domain.match.Match;
 import com.qmate.domain.match.model.response.MatchMembersResponse;
@@ -43,6 +46,38 @@ class MatchControllerTest {
   @MockitoBean // 가짜 MatchService를 Spring에 등록
   private MatchService matchService;
 
+
+  @Test
+  @DisplayName("매칭 정보 업데이트 성공 시 204 No content 응답")
+  void updateMatchInfo_success_204noContent() throws Exception{
+    Long matchId = 3L;
+    var request = new MatchUpdateRequest();
+    request.setDailyQuestionHour(20);
+
+    // matchService.updateMatchInfo가 호출되어도 아무 일도 일어나지 않도록 설정 (void 메서드이므로)
+    willDoNothing().given(matchService).updateMatchInfo(anyLong(), anyLong(), any(MatchUpdateRequest.class));
+
+    // expect: API를 호출하면, 204 No Content 응답이 와야 함
+    mockMvc.perform(patch("/api/matches/{matchId}/info", matchId) // PATCH 요청
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isNoContent()); // 1. HTTP 상태 코드가 204 No Content인지 검증
+
+  }
+  @Test
+  @DisplayName("매칭 정보 업데이트 실패: 유효성 검증 실패 시 400 Bad Request 응답")
+  void updateMatchInfo_fail_400badRequest() throws Exception {
+    // given: @Max(23) 유효성 검증을 위반하는 요청
+    Long matchId = 3L;
+    var badRequest = new MatchUpdateRequest();
+    badRequest.setDailyQuestionHour(25); // 23을 초과하는 값
+
+    // expect: API를 호출하면, 400 Bad Request 응답이 와야 함
+    mockMvc.perform(patch("/api/matches/{matchId}/info", matchId)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(badRequest)))
+        .andExpect(status().isBadRequest());
+  }
 
   @Test
   @DisplayName("매칭 멤버 상세 조회 실패: 권한 없는 접근 시 403 Forbidden 응답")

--- a/back/src/test/java/com/qmate/api/MatchControllerUpdateTest.java
+++ b/back/src/test/java/com/qmate/api/MatchControllerUpdateTest.java
@@ -1,0 +1,75 @@
+package com.qmate.api;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.qmate.config.SecurityConfig;
+import com.qmate.domain.auth.JwtService;
+import com.qmate.domain.match.model.request.MatchUpdateRequest;
+import com.qmate.domain.match.service.MatchService;
+import com.qmate.exception.custom.matchinstance.MatchForbiddenException;
+import com.qmate.exception.custom.matchinstance.MatchNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = MatchController.class)
+@AutoConfigureMockMvc(addFilters = false) // Security 필터 비활성화
+class MatchControllerUpdateTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @MockitoBean
+  private MatchService matchService;
+
+  @Test
+  @DisplayName("매칭 정보 업데이트 실패: 존재하지 않는 매칭 ID 요청 시 404 Not Found 응답")
+  void updateMatchInfo_fail_404notFound() throws Exception {
+    // given: 서비스가 MatchNotFoundException을 던지는 상황
+    Long nonExistentMatchId = 404L;
+    var request = new MatchUpdateRequest();
+
+    willThrow(new MatchNotFoundException())
+        .given(matchService).updateMatchInfo(anyLong(), anyLong(), any(MatchUpdateRequest.class));
+
+    // expect: API를 호출하면, 404 Not Found 응답과 MATCH_002 에러 코드가 와야 함
+    mockMvc.perform(patch("/api/matches/{matchId}/info", nonExistentMatchId)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.errorCode").value("MATCH_002"));
+  }
+
+  @Test
+  @DisplayName("매칭 정보 업데이트 실패: 권한 없는 접근 시 403 Forbidden 응답")
+  void updateMatchInfo_fail_403forbidden() throws Exception {
+    // given: 서비스가 MatchForbiddenException을 던지는 상황
+    Long matchId = 100L;
+    var request = new MatchUpdateRequest();
+
+    willThrow(new MatchForbiddenException())
+        .given(matchService).updateMatchInfo(anyLong(), anyLong(), any(MatchUpdateRequest.class));
+
+    // expect: API를 호출하면, 403 Forbidden 응답과 MATCH_008 에러 코드가 와야 함
+    mockMvc.perform(patch("/api/matches/{matchId}/info", matchId)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.errorCode").value("MATCH_008"));
+  }
+}

--- a/back/src/test/java/com/qmate/domain/match/service/MatchServiceTest.java
+++ b/back/src/test/java/com/qmate/domain/match/service/MatchServiceTest.java
@@ -9,13 +9,16 @@ import static org.mockito.Mockito.verify;
 import com.qmate.common.redis.RedisHelper;
 import com.qmate.domain.match.Match;
 import com.qmate.domain.match.MatchMember;
+import com.qmate.domain.match.MatchSetting;
 import com.qmate.domain.match.MatchStatus;
 import com.qmate.domain.match.RelationType;
 import com.qmate.domain.match.model.request.MatchJoinRequest;
+import com.qmate.domain.match.model.request.MatchUpdateRequest;
 import com.qmate.domain.match.model.response.MatchInfoResponse;
 import com.qmate.domain.match.model.response.MatchMembersResponse;
 import com.qmate.domain.match.repository.MatchMemberRepository;
 import com.qmate.domain.match.repository.MatchRepository;
+import com.qmate.domain.match.repository.MatchSettingRepository;
 import com.qmate.domain.user.User;
 import com.qmate.domain.user.UserRepository;
 import com.qmate.exception.custom.matchinstance.InviteAttemptLockedException;
@@ -43,7 +46,37 @@ class MatchServiceTest {
   private UserRepository userRepository;
   @Mock
   private RedisHelper redisHelper;
+  @Mock
+  private MatchSettingRepository matchSettingRepository;
 
+  @Test
+  @DisplayName("매칭 정보 업데이트 성공")
+  void updateMatchInfo_success(){
+    // given: 4번 매칭에 3번, 4번 유저가 속해있고, 3번 유저가 정보 업데이트를 요청한 상황
+    Long matchId = 4L;
+    Long requesterId = 3L;
+    var request = new MatchUpdateRequest();
+    request.setDailyQuestionHour(22);
+    request.setStartDate(LocalDate.of(2023, 1, 1));
+
+    User user3 = User.builder().id(3L).build();
+    User user4 = User.builder().id(4L).build();
+    Match match = Match.builder().id(matchId).build();
+    match.addMember(MatchMember.create(user3, match));
+    match.addMember(MatchMember.create(user4, match));
+
+    MatchSetting matchSetting = new MatchSetting(match);
+
+    // findWithMembersAndUsersById가 호출되면 가짜 match 객체를 반환하도록 설정
+    given(matchRepository.findWithMembersAndUsersById(matchId)).willReturn(Optional.of(match));
+    // findById가 호출되면 가짜 matchSetting 객체를 반환하도록 설정
+    given(matchSettingRepository.findById(matchId)).willReturn(Optional.of(matchSetting));
+
+    sut.updateMatchInfo(matchId, requesterId, request);
+
+    assertThat(match.getStartDate()).isEqualTo(LocalDate.of(2023, 1, 1).atStartOfDay());
+    assertThat(matchSetting.getDailyQuestionHour()).isEqualTo(22);
+  }
 
   @Test
   @DisplayName("매칭 멤버 상세 조회 실패: 멤버가 아닌 사용자의 접근")

--- a/back/src/test/java/com/qmate/domain/match/service/MatchServiceUpdateTest.java
+++ b/back/src/test/java/com/qmate/domain/match/service/MatchServiceUpdateTest.java
@@ -1,0 +1,77 @@
+package com.qmate.domain.match.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.qmate.domain.match.Match;
+import com.qmate.domain.match.MatchMember;
+import com.qmate.domain.match.MatchSetting;
+import com.qmate.domain.match.model.request.MatchUpdateRequest;
+import com.qmate.domain.match.repository.MatchMemberRepository;
+import com.qmate.domain.match.repository.MatchRepository;
+import com.qmate.domain.match.repository.MatchSettingRepository;
+import com.qmate.domain.user.User;
+import com.qmate.exception.custom.matchinstance.MatchForbiddenException;
+import com.qmate.exception.custom.matchinstance.MatchNotFoundException;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MatchServiceUpdateTest {
+
+  @InjectMocks
+  private MatchService sut;
+
+  @Mock
+  private MatchRepository matchRepository;
+  @Mock
+  private MatchSettingRepository matchSettingRepository;
+
+  private User user1, user2;
+  private Match match;
+
+  @BeforeEach
+  void setUp() {
+    // 모든 테스트에서 공통으로 사용할 가짜 데이터 준비
+    user1 = User.builder().id(1L).build();
+    user2 = User.builder().id(2L).build();
+    match = Match.builder().id(100L).build();
+    match.addMember(MatchMember.create(user1, match));
+    match.addMember(MatchMember.create(user2, match));
+  }
+
+  @Test
+  @DisplayName("매칭 정보 업데이트 실패: 매칭이 존재하지 않을 경우(404)")
+  void updateMatchInfo_fail_matchNotFound() {
+    // given: Repository가 비어있는 Optional을 반환하는 상황
+    Long nonExistentMatchId = 404L;
+    given(matchRepository.findWithMembersAndUsersById(nonExistentMatchId)).willReturn(Optional.empty());
+
+    // expect: MatchNotFoundException 예외가 발생해야 함
+    assertThatThrownBy(() -> sut.updateMatchInfo(nonExistentMatchId, 1L, new MatchUpdateRequest()))
+        .isInstanceOf(MatchNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("매칭 정보 업데이트 실패: 멤버가 아닌 사용자의 접근(403)")
+  void updateMatchInfo_fail_forbidden() {
+    // given: 100번 매칭 정보를 상관없는 99번 유저가 수정을 요청한 상황
+    Long matchId = 100L;
+    Long outsiderId = 99L;
+
+    given(matchRepository.findWithMembersAndUsersById(matchId)).willReturn(Optional.of(match));
+
+    // expect: MatchForbiddenException 예외가 발생해야 함
+    assertThatThrownBy(() -> sut.updateMatchInfo(matchId, outsiderId, new MatchUpdateRequest()))
+        .isInstanceOf(MatchForbiddenException.class);
+  }
+}


### PR DESCRIPTION
### 개요
매칭된 사용자가 기념일(`startDate`)이나 매일 질문을 받는 시간(`dailyQuestionHour`)을 선택적으로 수정할 수 있는 **매칭 정보 업데이트 API** (`PATCH /api/matches/{matchId}/info`)를 구현했습니다.

### 변경 사항

#### API
- **`PATCH /api/matches/{matchId}/info`** 엔드포인트를 신규 추가했습니다.
- 성공 시, 별도의 본문 없이 `204 No Content` 상태 코드를 반환하여 RESTful 원칙을 준수했습니다.

#### DTO
- `MatchUpdateRequest.java`: `dailyQuestionHour`와 `startDate`를 선택적으로 받을 수 있는 Request DTO를 추가했습니다.

#### Service
- **`MatchService#updateMatchInfo(...)`**
    - `@Transactional`을 통해 데이터 변경의 원자성을 보장합니다.
    - 요청에 포함된 필드만 선택적으로 업데이트하는 로직을 구현했습니다.
    - `MatchSetting` 데이터가 없을 경우, 새로 생성하여 저장하는 로직을 포함했습니다.
    - JPA의 버전 충돌 문제를 해결하기 위해, `save` 호출 로직을 명확하게 분리했습니다.

### Tests
- **[X] 서비스 단위 테스트**
    - `MatchServiceUpdateTest.java`를 통해 '매칭 없음(404)', '권한 없음(403)' 실패 케이스를 검증했습니다.
- **[X] 컨트롤러 단위 테스트**
    - `MatchControllerUpdateTest.java`를 통해 `204 No Content` 성공 응답 및 `400`, `403`, `404` 실패 응답을 검증했습니다.
- **[X] API 테스트 (Postman)**
    - `startDate`만, `dailyQuestionHour`만, 그리고 두 필드 모두를 변경하는 모든 케이스에 대해 정상 동작을 확인했습니다.