### PR TITLE
refactor: Answer/QI 리팩토링 + Swagger JWT 버튼 + Controller 테스트에서 principal 주입

### DIFF
--- a/back/src/main/java/com/qmate/api/questioninstance/AnswerController.java
+++ b/back/src/main/java/com/qmate/api/questioninstance/AnswerController.java
@@ -3,10 +3,12 @@ package com.qmate.api.questioninstance;
 import com.qmate.domain.questioninstance.model.request.AnswerContentRequest;
 import com.qmate.domain.questioninstance.model.response.AnswerResponse;
 import com.qmate.domain.questioninstance.service.AnswerService;
+import com.qmate.security.UserPrincipal;
 import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -24,10 +26,10 @@ public class AnswerController {
   @PostMapping("/question-instances/{questionInstanceId}/answers")
   public ResponseEntity<AnswerResponse> create(
       @PathVariable Long questionInstanceId,
-      // TODO: @AuthenticationPrincipal CustomUserDetails principal
+      @AuthenticationPrincipal UserPrincipal principal,
       @Valid @RequestBody AnswerContentRequest request
   ) {
-    Long userId = 1L; // TODO: principal.getUserId();
+    Long userId = principal.userId();
 
     AnswerResponse response = answerService.create(questionInstanceId, userId, request);
 
@@ -39,10 +41,10 @@ public class AnswerController {
   @PatchMapping("/answers/{answerId}")
   public ResponseEntity<AnswerResponse> update(
       @PathVariable Long answerId,
-      // TODO: @AuthenticationPrincipal CustomUserDetails principal
+      @AuthenticationPrincipal UserPrincipal principal,
       @Valid @RequestBody AnswerContentRequest request
   ) {
-    Long userId = 1L; // TODO: principal.getUserId();
+    Long userId = principal.userId();
 
     AnswerResponse response = answerService.update(answerId, userId, request);
     return ResponseEntity.ok(response);

--- a/back/src/main/java/com/qmate/api/questioninstance/AnswerController.java
+++ b/back/src/main/java/com/qmate/api/questioninstance/AnswerController.java
@@ -3,7 +3,17 @@ package com.qmate.api.questioninstance;
 import com.qmate.domain.questioninstance.model.request.AnswerContentRequest;
 import com.qmate.domain.questioninstance.model.response.AnswerResponse;
 import com.qmate.domain.questioninstance.service.AnswerService;
+import com.qmate.exception.ErrorResponse;
 import com.qmate.security.UserPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
@@ -19,11 +29,43 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
+@Tag(name = "Answer", description = "답변 제출/수정 API")
 public class AnswerController {
 
   private final AnswerService answerService;
 
   @PostMapping("/question-instances/{questionInstanceId}/answers")
+  @Operation(
+      summary = "답변 제출 (최초 1회)",
+      description = "특정 질문 인스턴스(QI)에 대해 사용자가 자신의 답변을 1회 제출합니다. 성공 시 Location 헤더로 QI 상세 리소스를 반환합니다.",
+      security = @SecurityRequirement(name = "bearerAuth"),
+      responses = {
+          @ApiResponse(
+              responseCode = "201",
+              description = "생성 성공",
+              headers = {
+                  @Header(name = "Location", description = "생성 결과가 반영된 QI 상세 리소스 URL", schema = @Schema(type = "string"))
+              },
+              content = @Content(mediaType = "application/json", schema = @Schema(implementation = AnswerResponse.class))
+          ),
+          @ApiResponse(responseCode = "400", description = "유효성 오류", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = "403", description = "해당 QI의 구성원 아님", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = "404", description = "questionInstance 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = "409", description = "중복 제출", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = "432", description = "QI가 COMPLETED/EXPIRED 상태", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
+      },
+      parameters = {
+          @Parameter(name = "questionInstanceId", in = ParameterIn.PATH, description = "답변을 제출할 질문 인스턴스 ID", required = true, example = "123")
+      },
+      requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+          description = "제출할 답변 내용",
+          required = true,
+          content = @Content(mediaType = "application/json", schema = @Schema(implementation = AnswerContentRequest.class))
+      )
+  )
+  //@PostMapping("/question-instances/{questionInstanceId}/answers")
   public ResponseEntity<AnswerResponse> create(
       @PathVariable Long questionInstanceId,
       @AuthenticationPrincipal UserPrincipal principal,
@@ -39,6 +81,33 @@ public class AnswerController {
   }
 
   @PatchMapping("/answers/{answerId}")
+  @Operation(
+      summary = "답변 수정 (완료 이전 한정)",
+      description = "본인이 제출한 답변을 수정합니다. 완료된 답변은 수정할 수 없습니다.",
+      security = @SecurityRequirement(name = "bearerAuth"),
+      responses = {
+          @ApiResponse(
+              responseCode = "200",
+              description = "수정 성공",
+              content = @Content(mediaType = "application/json", schema = @Schema(implementation = AnswerResponse.class))
+          ),
+          @ApiResponse(responseCode = "400", description = "유효성 오류", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = "403", description = "해당 QI의 구성원 아님", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = "404", description = "해당 답변 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = "423", description = "QI가 COMPLETED/EXPIRED 상태", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
+      },
+      parameters = {
+          @Parameter(name = "answerId", in = ParameterIn.PATH, description = "수정할 답변 ID", required = true, example = "456"),
+      },
+      requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+          description = "수정할 답변 내용",
+          required = true,
+          content = @Content(mediaType = "application/json", schema = @Schema(implementation = AnswerContentRequest.class))
+      )
+  )
+  //@PatchMapping("/answers/{answerId}")
   public ResponseEntity<AnswerResponse> update(
       @PathVariable Long answerId,
       @AuthenticationPrincipal UserPrincipal principal,

--- a/back/src/main/java/com/qmate/api/questioninstance/QuestionInstanceController.java
+++ b/back/src/main/java/com/qmate/api/questioninstance/QuestionInstanceController.java
@@ -29,7 +29,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-// TODO 유저 권한: 일반 사용자 (인증된 사용자)
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
@@ -61,10 +60,10 @@ public class QuestionInstanceController {
   @GetMapping("/question-instances/{questionInstanceId}")
   // @GetMapping("/question-instances/{questionInstanceId}")
   public ResponseEntity<QIDetailResponse> getDetail(
-      @PathVariable Long questionInstanceId
-      // TODO: @AuthenticationPrincipal CustomUserDetails principal
+      @PathVariable Long questionInstanceId,
+      @AuthenticationPrincipal UserPrincipal principal
   ) {
-    Long requesterId = 1L; // TODO: principal.getUserId();
+    Long requesterId = principal.userId();
     return ResponseEntity.ok(
         questionInstanceService.getDetail(questionInstanceId, requesterId)
     );
@@ -73,11 +72,11 @@ public class QuestionInstanceController {
   @Operation(
       summary = "오늘 질문 조회(가장 최근 notified 인스턴스)",
       description = """
-        해당 매칭에서 가장 최근에 알림(notified)된 질문 인스턴스를 상세 형태로 반환합니다.
-        - 의미: 엔드포인트 명은 today지만, 날짜 경계와 무관하게 `notified_at`이 가장 최신인 1건을 반환
-        - 필터: `notified_at IS NOT NULL` 인 레코드만 대상
-        - 권한: 요청자의 currentMatchId(또는 소속)가 path의 matchId와 일치해야 함
-        """,
+          해당 매칭에서 가장 최근에 알림(notified)된 질문 인스턴스를 상세 형태로 반환합니다.
+          - 의미: 엔드포인트 명은 today지만, 날짜 경계와 무관하게 `notified_at`이 가장 최신인 1건을 반환
+          - 필터: `notified_at IS NOT NULL` 인 레코드만 대상
+          - 권한: 요청자의 currentMatchId(또는 소속)가 path의 matchId와 일치해야 함
+          """,
       responses = {
           @ApiResponse(responseCode = "200", description = "성공",
               content = @Content(schema = @Schema(implementation = QIDetailResponse.class))),
@@ -131,14 +130,14 @@ public class QuestionInstanceController {
           @Parameter(
               name = "sort",
               description = """
-              정렬 키와 방향(여러 개 지정 가능).
-              - 형식: sort=`key`[,`dir`]  (dir 기본값: asc)
-              - 허용 key: deliveredAt | completedAt | status
-              - 예: sort=deliveredAt,desc&sort=status,asc
-              """,
+                  정렬 키와 방향(여러 개 지정 가능).
+                  - 형식: sort=`key`[,`dir`]  (dir 기본값: asc)
+                  - 허용 key: deliveredAt | completedAt | status
+                  - 예: sort=deliveredAt,desc&sort=status,asc
+                  """,
               array = @ArraySchema(
                   schema = @Schema(implementation = String.class,
-                      allowableValues = {"deliveredAt","completedAt","status"})
+                      allowableValues = {"deliveredAt", "completedAt", "status"})
               ),
               example = "deliveredAt,desc"
           ),
@@ -154,10 +153,10 @@ public class QuestionInstanceController {
       @RequestParam(required = false)
       @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime to,
       @PageableDefault(size = 20, sort = "deliveredAt", direction = Sort.Direction.DESC)
-      @ParameterObject Pageable pageable
-      // TODO: @AuthenticationPrincipal CustomUserDetails principal
+      @ParameterObject Pageable pageable,
+      @AuthenticationPrincipal UserPrincipal principal
   ) {
-    Long userId = 1L; // TODO: principal.getUserId();
+    Long userId = principal.userId();
     Page<QIListItem> page = questionInstanceService.list(userId, matchId, status, from, to, pageable);
     return ResponseEntity.ok(page);
   }

--- a/back/src/main/java/com/qmate/api/questioninstance/QuestionInstanceController.java
+++ b/back/src/main/java/com/qmate/api/questioninstance/QuestionInstanceController.java
@@ -1,6 +1,6 @@
 package com.qmate.api.questioninstance;
 
-import com.qmate.domain.questioninstance.entity.InstanceStatus;
+import com.qmate.domain.questioninstance.entity.QuestionInstanceStatus;
 import com.qmate.domain.questioninstance.model.response.QIDetailResponse;
 import com.qmate.domain.questioninstance.model.response.QIListItem;
 import com.qmate.domain.questioninstance.service.QuestionInstanceService;
@@ -114,7 +114,7 @@ public class QuestionInstanceController {
       parameters = {
           @Parameter(name = "matchId", description = "매치 ID", required = true),
           @Parameter(name = "status", description = "질문 인스턴스 상태 (optional)",
-              schema = @Schema(implementation = InstanceStatus.class)),
+              schema = @Schema(implementation = QuestionInstanceStatus.class)),
           @Parameter(name = "from", description = "deliveredAt 시작 범위 (inclusive, optional)",
               example = "2025-09-01T00:00:00"),
           @Parameter(name = "to", description = "deliveredAt 종료 범위 (exclusive, optional)",
@@ -139,7 +139,7 @@ public class QuestionInstanceController {
   // @GetMapping("/matches/{matchId}/question-instances")
   public ResponseEntity<Page<QIListItem>> list(
       @PathVariable Long matchId,
-      @RequestParam(required = false) InstanceStatus status,
+      @RequestParam(required = false) QuestionInstanceStatus status,
       @RequestParam(required = false)
       @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime from,
       @RequestParam(required = false)

--- a/back/src/main/java/com/qmate/api/questioninstance/QuestionInstanceController.java
+++ b/back/src/main/java/com/qmate/api/questioninstance/QuestionInstanceController.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
@@ -43,15 +44,12 @@ public class QuestionInstanceController {
           단일 질문 인스턴스의 상세 정보를 반환합니다.
           - 권한: 요청자의 currentMatchId와 해당 인스턴스의 matchId가 일치해야 함
           """,
+      security = @SecurityRequirement(name = "bearerAuth"),
       responses = {
-          @ApiResponse(responseCode = "200", description = "성공",
-              content = @Content(schema = @Schema(implementation = QIDetailResponse.class))),
-          @ApiResponse(responseCode = "401", description = "인증 실패",
-              content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-          @ApiResponse(responseCode = "403", description = "권한 없음",
-              content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-          @ApiResponse(responseCode = "404", description = "리소스 없음",
-              content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+          @ApiResponse(responseCode = "200", description = "성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = QIDetailResponse.class))),
+          @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = "404", description = "리소스 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
       },
       parameters = {
           @Parameter(name = "questionInstanceId", description = "질문 인스턴스 ID", required = true)
@@ -77,15 +75,12 @@ public class QuestionInstanceController {
           - 필터: `notified_at IS NOT NULL` 인 레코드만 대상
           - 권한: 요청자의 currentMatchId(또는 소속)가 path의 matchId와 일치해야 함
           """,
+      security = @SecurityRequirement(name = "bearerAuth"),
       responses = {
-          @ApiResponse(responseCode = "200", description = "성공",
-              content = @Content(schema = @Schema(implementation = QIDetailResponse.class))),
-          @ApiResponse(responseCode = "401", description = "인증 실패",
-              content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-          @ApiResponse(responseCode = "403", description = "권한 없음",
-              content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-          @ApiResponse(responseCode = "404", description = "리소스 없음(발송 이력 없음 등)",
-              content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+          @ApiResponse(responseCode = "200", description = "성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = QIDetailResponse.class))),
+          @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = "404", description = "리소스 없음(발송 이력 없음 등)", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
       },
       parameters = {
           @Parameter(name = "matchId", description = "매칭 ID", required = true)
@@ -109,15 +104,12 @@ public class QuestionInstanceController {
           - 정렬: 기본 deliveredAt 내림차순
           - 권한: 요청자의 currentMatchId와 matchId가 일치해야 함
           """,
+      security = @SecurityRequirement(name = "bearerAuth"),
       responses = {
-          @ApiResponse(responseCode = "200", description = "성공",
-              content = @Content(schema = @Schema(implementation = QIListItem.class))),
-          @ApiResponse(responseCode = "400", description = "미지원 sort 키 사용",
-              content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-          @ApiResponse(responseCode = "401", description = "인증 실패",
-              content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-          @ApiResponse(responseCode = "403", description = "권한 없음",
-              content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = "200", description = "성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = QIListItem.class))),
+          @ApiResponse(responseCode = "400", description = "미지원 sort 키 사용", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
       },
       parameters = {
           @Parameter(name = "matchId", description = "매치 ID", required = true),

--- a/back/src/main/java/com/qmate/config/OpenApiSecurityConfig.java
+++ b/back/src/main/java/com/qmate/config/OpenApiSecurityConfig.java
@@ -1,0 +1,16 @@
+package com.qmate.config;
+
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@SecurityScheme(
+    name = "bearerAuth",
+    type = SecuritySchemeType.HTTP,
+    scheme = "bearer",
+    bearerFormat = "JWT" // UI 설명용
+)
+public class OpenApiSecurityConfig {
+
+}

--- a/back/src/main/java/com/qmate/domain/questioninstance/entity/QuestionInstance.java
+++ b/back/src/main/java/com/qmate/domain/questioninstance/entity/QuestionInstance.java
@@ -65,7 +65,7 @@ public class QuestionInstance {
   @Enumerated(EnumType.STRING)
   @Column(name = "status", nullable = false, length = 20)
   @Builder.Default
-  private InstanceStatus status = InstanceStatus.PENDING;
+  private QuestionInstanceStatus status = QuestionInstanceStatus.PENDING;
 
   @Column(name = "completed_at")
   private LocalDateTime completedAt;
@@ -106,7 +106,7 @@ public class QuestionInstance {
   }
 
   public void markCompleted(LocalDateTime now) {
-    this.status = InstanceStatus.COMPLETED;
+    this.status = QuestionInstanceStatus.COMPLETED;
     this.completedAt = now;
   }
 }

--- a/back/src/main/java/com/qmate/domain/questioninstance/entity/QuestionInstanceStatus.java
+++ b/back/src/main/java/com/qmate/domain/questioninstance/entity/QuestionInstanceStatus.java
@@ -1,6 +1,5 @@
 package com.qmate.domain.questioninstance.entity;
 
-// TODO QuestionInstanceStatus로 리팩토링 필요
-public enum InstanceStatus {
+public enum QuestionInstanceStatus {
   PENDING, COMPLETED, EXPIRED
 }

--- a/back/src/main/java/com/qmate/domain/questioninstance/model/response/QIDetailResponse.java
+++ b/back/src/main/java/com/qmate/domain/questioninstance/model/response/QIDetailResponse.java
@@ -1,7 +1,7 @@
 package com.qmate.domain.questioninstance.model.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.qmate.domain.questioninstance.entity.InstanceStatus;
+import com.qmate.domain.questioninstance.entity.QuestionInstanceStatus;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -18,7 +18,7 @@ public class QIDetailResponse {
   private Long questionInstanceId;
   private Long matchId;
   private LocalDateTime deliveredAt;
-  private InstanceStatus status;     // PENDING | COMPLETED | EXPIRED
+  private QuestionInstanceStatus status;     // PENDING | COMPLETED | EXPIRED
   private LocalDateTime completedAt; // COMPLETED 시각(없으면 null)
   private QuestionInfo question;         // 질문 본문(ADMIN/CUSTOM)
   private List<AnswerView> answers;  // [내 답변, 상대 답변] 순서 권장

--- a/back/src/main/java/com/qmate/domain/questioninstance/model/response/QIListItem.java
+++ b/back/src/main/java/com/qmate/domain/questioninstance/model/response/QIListItem.java
@@ -1,6 +1,6 @@
 package com.qmate.domain.questioninstance.model.response;
 
-import com.qmate.domain.questioninstance.entity.InstanceStatus;
+import com.qmate.domain.questioninstance.entity.QuestionInstanceStatus;
 import com.querydsl.core.annotations.QueryProjection;
 import java.time.LocalDateTime;
 import lombok.Getter;
@@ -10,12 +10,12 @@ public class QIListItem {
 
   private Long questionInstanceId;
   private LocalDateTime deliveredAt;
-  private InstanceStatus status;
+  private QuestionInstanceStatus status;
   private String text;
   private LocalDateTime completedAt;
 
   @QueryProjection
-  public QIListItem(Long questionInstanceId, LocalDateTime deliveredAt, InstanceStatus status,
+  public QIListItem(Long questionInstanceId, LocalDateTime deliveredAt, QuestionInstanceStatus status,
       String text, LocalDateTime completedAt) {
     this.questionInstanceId = questionInstanceId;
     this.deliveredAt = deliveredAt;

--- a/back/src/main/java/com/qmate/domain/questioninstance/repository/QuestionInstanceQueryRepository.java
+++ b/back/src/main/java/com/qmate/domain/questioninstance/repository/QuestionInstanceQueryRepository.java
@@ -1,6 +1,6 @@
 package com.qmate.domain.questioninstance.repository;
 
-import com.qmate.domain.questioninstance.entity.InstanceStatus;
+import com.qmate.domain.questioninstance.entity.QuestionInstanceStatus;
 import com.qmate.domain.questioninstance.entity.QuestionInstance;
 import com.qmate.domain.questioninstance.model.response.QIListItem;
 import java.time.LocalDateTime;
@@ -16,7 +16,7 @@ public interface QuestionInstanceQueryRepository {
 
   Page<QIListItem> findList(
       Long matchId,
-      InstanceStatus status,
+      QuestionInstanceStatus status,
       LocalDateTime from,
       LocalDateTime to,
       Pageable pageable

--- a/back/src/main/java/com/qmate/domain/questioninstance/repository/QuestionInstanceQueryRepositoryImpl.java
+++ b/back/src/main/java/com/qmate/domain/questioninstance/repository/QuestionInstanceQueryRepositoryImpl.java
@@ -7,7 +7,7 @@ import static com.qmate.domain.question.entity.QQuestionCategory.questionCategor
 import static com.qmate.domain.questioninstance.entity.QQuestionInstance.questionInstance;
 import static com.qmate.domain.match.QMatch.match;
 
-import com.qmate.domain.questioninstance.entity.InstanceStatus;
+import com.qmate.domain.questioninstance.entity.QuestionInstanceStatus;
 import com.qmate.domain.questioninstance.entity.QuestionInstance;
 import com.qmate.domain.questioninstance.model.response.QIListItem;
 import com.qmate.domain.questioninstance.model.response.QQIListItem;
@@ -17,7 +17,6 @@ import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Path;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.PathBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -95,7 +94,7 @@ public class QuestionInstanceQueryRepositoryImpl implements QuestionInstanceQuer
   @Override
   public Page<QIListItem> findList(
       Long matchId,
-      InstanceStatus status,         // optional
+      QuestionInstanceStatus status,         // optional
       LocalDateTime from,            // optional: deliveredAt >= from
       LocalDateTime to,              // optional: deliveredAt <  to
       Pageable pageable
@@ -139,7 +138,7 @@ public class QuestionInstanceQueryRepositoryImpl implements QuestionInstanceQuer
   }
 
   // ---- Predicates (nullable → 무시) ----
-  private BooleanExpression statusEq(InstanceStatus status) {
+  private BooleanExpression statusEq(QuestionInstanceStatus status) {
     return status == null ? null : questionInstance.status.eq(status);
   }
 

--- a/back/src/main/java/com/qmate/domain/questioninstance/service/AnswerService.java
+++ b/back/src/main/java/com/qmate/domain/questioninstance/service/AnswerService.java
@@ -1,7 +1,7 @@
 package com.qmate.domain.questioninstance.service;
 
 import com.qmate.domain.questioninstance.entity.Answer;
-import com.qmate.domain.questioninstance.entity.InstanceStatus;
+import com.qmate.domain.questioninstance.entity.QuestionInstanceStatus;
 import com.qmate.domain.questioninstance.entity.QuestionInstance;
 import com.qmate.domain.questioninstance.mapper.AnswerMapper;
 import com.qmate.domain.questioninstance.model.request.AnswerContentRequest;
@@ -49,9 +49,9 @@ public class AnswerService {
     }
 
     // 3) 상태 검증
-    InstanceStatus status = qi.getStatus();
+    QuestionInstanceStatus status = qi.getStatus();
     // PENDING만 통과
-    if (status != InstanceStatus.PENDING) {
+    if (status != QuestionInstanceStatus.PENDING) {
       throw new AnswerCannotModifyException();
     }
 
@@ -90,9 +90,9 @@ public class AnswerService {
     }
 
     // 3) 상태 검증
-    InstanceStatus status = answer.getQuestionInstance().getStatus();
+    QuestionInstanceStatus status = answer.getQuestionInstance().getStatus();
     // PENDING만 통과
-    if (status != InstanceStatus.PENDING) {
+    if (status != QuestionInstanceStatus.PENDING) {
       throw new AnswerCannotModifyException();
     }
 

--- a/back/src/main/java/com/qmate/domain/questioninstance/service/QuestionInstanceService.java
+++ b/back/src/main/java/com/qmate/domain/questioninstance/service/QuestionInstanceService.java
@@ -2,7 +2,7 @@ package com.qmate.domain.questioninstance.service;
 
 import com.qmate.domain.match.Match;
 import com.qmate.domain.questioninstance.entity.Answer;
-import com.qmate.domain.questioninstance.entity.InstanceStatus;
+import com.qmate.domain.questioninstance.entity.QuestionInstanceStatus;
 import com.qmate.domain.questioninstance.entity.QuestionInstance;
 import com.qmate.domain.questioninstance.mapper.QIDetailMapper;
 import com.qmate.domain.questioninstance.model.response.QIDetailResponse;
@@ -15,7 +15,6 @@ import com.qmate.exception.custom.matchinstance.UserNotFoundException;
 import com.qmate.exception.custom.questioninstance.QuestionInstanceForbiddenException;
 import com.qmate.exception.custom.questioninstance.QuestionInstanceNotFoundException;
 import java.time.LocalDateTime;
-import java.util.NoSuchElementException;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -74,9 +73,9 @@ public class QuestionInstanceService {
         .orElse(null);
 
     // 5) 가시성 결정 (정책)
-    InstanceStatus status = qi.getStatus();
-    boolean myVisible = status != InstanceStatus.EXPIRED;        // EXPIRED면 내 답변도 비공개/삭제
-    boolean partnerVisible = status == InstanceStatus.COMPLETED; // 완료일 때만 상대 공개
+    QuestionInstanceStatus status = qi.getStatus();
+    boolean myVisible = status != QuestionInstanceStatus.EXPIRED;        // EXPIRED면 내 답변도 비공개/삭제
+    boolean partnerVisible = status == QuestionInstanceStatus.COMPLETED; // 완료일 때만 상대 공개
 
     // 6) DTO 변환 (매퍼는 순수 변환)
     return QIDetailMapper.toResponse(
@@ -114,7 +113,7 @@ public class QuestionInstanceService {
    * @throws QuestionInstanceForbiddenException   권한 없음 (현재 매치 != 조회 매치)
    */
   @Transactional(readOnly = true)
-  public Page<QIListItem> list(Long userId, Long matchId, InstanceStatus status,
+  public Page<QIListItem> list(Long userId, Long matchId, QuestionInstanceStatus status,
       LocalDateTime from, LocalDateTime to, Pageable pageable) {
 
     // 1) 요청자 조회 및 권한 확인: 현재 매치 == 조회 매치

--- a/back/src/test/java/com/qmate/AuthTestUtils.java
+++ b/back/src/test/java/com/qmate/AuthTestUtils.java
@@ -1,0 +1,28 @@
+package com.qmate;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+
+import com.qmate.security.UserPrincipal;
+import java.util.List;
+import lombok.NoArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+@NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
+public final class AuthTestUtils {
+
+  public static RequestPostProcessor userPrincipal(long userId) {
+    UserPrincipal principal = new UserPrincipal(userId, "user" + userId + "@test.com", "USER");
+    var auth = new UsernamePasswordAuthenticationToken(
+        principal, null, List.of(new SimpleGrantedAuthority("ROLE_USER")));
+    return authentication(auth);
+  }
+
+  public static RequestPostProcessor adminPrincipal(long adminId) {
+    UserPrincipal principal = new UserPrincipal(adminId, "admin" + adminId + "@test.com", "ADMIN");
+    var auth = new UsernamePasswordAuthenticationToken(
+        principal, null, List.of(new SimpleGrantedAuthority("ROLE_ADMIN")));
+    return authentication(auth);
+  }
+}

--- a/back/src/test/java/com/qmate/SecuritySliceTestConfig.java
+++ b/back/src/test/java/com/qmate/SecuritySliceTestConfig.java
@@ -1,0 +1,24 @@
+package com.qmate;
+
+import java.util.List;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@TestConfiguration
+public class SecuritySliceTestConfig implements WebMvcConfigurer {
+  @Bean
+  SecurityFilterChain testFilterChain(HttpSecurity http) throws Exception {
+    // 테스트에 불필요한 것만 끄고 최소 체인만
+    return http.csrf(csrf -> csrf.disable()).build();
+  }
+
+  // @AuthenticationPrincipal이 동작하도록 리졸버 등록
+  @Override
+  public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+    resolvers.add(new org.springframework.security.web.method.annotation.AuthenticationPrincipalArgumentResolver());
+  }
+}

--- a/back/src/test/java/com/qmate/api/questioninstance/AnswerControllerCreateTest.java
+++ b/back/src/test/java/com/qmate/api/questioninstance/AnswerControllerCreateTest.java
@@ -11,6 +11,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.qmate.AuthTestUtils;
+import com.qmate.SecuritySliceTestConfig;
 import com.qmate.domain.questioninstance.model.request.AnswerContentRequest;
 import com.qmate.domain.questioninstance.model.response.AnswerResponse;
 import com.qmate.domain.questioninstance.service.AnswerService;
@@ -19,17 +21,26 @@ import com.qmate.exception.custom.questioninstance.AnswerCannotModifyException;
 import com.qmate.exception.custom.questioninstance.QuestionInstanceForbiddenException;
 import com.qmate.exception.custom.questioninstance.QuestionInstanceNotFoundException;
 import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @WebMvcTest(controllers = AnswerController.class)
-@AutoConfigureMockMvc(addFilters = false)
+@AutoConfigureMockMvc
+@Import(SecuritySliceTestConfig.class)
 class AnswerControllerCreateTest {
 
   @Autowired
@@ -58,6 +69,7 @@ class AnswerControllerCreateTest {
 
     // expect
     mockMvc.perform(post("/api/question-instances/{qiId}/answers", qiId)
+            .with(AuthTestUtils.userPrincipal(1L))
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(req)))
         .andExpect(status().isCreated())
@@ -76,6 +88,7 @@ class AnswerControllerCreateTest {
 
     // expect
     mockMvc.perform(post("/api/question-instances/{qiId}/answers", 1L)
+            .with(AuthTestUtils.userPrincipal(1L))
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(bad)))
         .andExpect(status().isBadRequest());
@@ -92,6 +105,7 @@ class AnswerControllerCreateTest {
 
     // expect
     mockMvc.perform(post("/api/question-instances/{qiId}/answers", qiId)
+            .with(AuthTestUtils.userPrincipal(1L))
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(req)))
         .andExpect(status().isForbidden());
@@ -108,6 +122,7 @@ class AnswerControllerCreateTest {
 
     // expect
     mockMvc.perform(post("/api/question-instances/{qiId}/answers", qiId)
+            .with(AuthTestUtils.userPrincipal(1L))
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(req)))
         .andExpect(status().isLocked());
@@ -124,6 +139,7 @@ class AnswerControllerCreateTest {
 
     // expect
     mockMvc.perform(post("/api/question-instances/{qiId}/answers", qiId)
+            .with(AuthTestUtils.userPrincipal(1L))
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(req)))
         .andExpect(status().isConflict());
@@ -140,6 +156,7 @@ class AnswerControllerCreateTest {
 
     // expect
     mockMvc.perform(post("/api/question-instances/{qiId}/answers", qiId)
+            .with(AuthTestUtils.userPrincipal(1L))
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(req)))
         .andExpect(status().isNotFound());

--- a/back/src/test/java/com/qmate/api/questioninstance/AnswerControllerUpdateTest.java
+++ b/back/src/test/java/com/qmate/api/questioninstance/AnswerControllerUpdateTest.java
@@ -12,6 +12,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.qmate.AuthTestUtils;
+import com.qmate.SecuritySliceTestConfig;
 import com.qmate.domain.questioninstance.model.request.AnswerContentRequest;
 import com.qmate.domain.questioninstance.model.response.AnswerResponse;
 import com.qmate.domain.questioninstance.service.AnswerService;
@@ -25,12 +27,14 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(controllers = AnswerController.class)
-@AutoConfigureMockMvc(addFilters = false)
+@AutoConfigureMockMvc
+@Import(SecuritySliceTestConfig.class)
 class AnswerControllerUpdateTest {
 
   @Autowired
@@ -56,6 +60,7 @@ class AnswerControllerUpdateTest {
         .willReturn(res);
 
     mockMvc.perform(patch("/api/answers/{answerId}", answerId)
+            .with(AuthTestUtils.userPrincipal(1L))
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(req)))
         .andExpect(status().isOk())
@@ -77,6 +82,7 @@ class AnswerControllerUpdateTest {
 
     mockMvc.perform(
             patch("/api/answers/{answerId}", 1L)
+                .with(AuthTestUtils.userPrincipal(1L))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(body))
         .andExpect(status().isBadRequest());
@@ -95,6 +101,7 @@ class AnswerControllerUpdateTest {
 
     // expect
     mockMvc.perform(patch("/api/answers/{answerId}", answerId)
+            .with(AuthTestUtils.userPrincipal(1L))
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(req)))
         .andExpect(status().isLocked());
@@ -111,6 +118,7 @@ class AnswerControllerUpdateTest {
 
     // expect
     mockMvc.perform(patch("/api/answers/{answerId}", answerId)
+            .with(AuthTestUtils.userPrincipal(1L))
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(req)))
         .andExpect(status().isNotFound());
@@ -127,6 +135,7 @@ class AnswerControllerUpdateTest {
 
     // expect
     mockMvc.perform(patch("/api/answers/{answerId}", answerId)
+            .with(AuthTestUtils.userPrincipal(1L))
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(req)))
         .andExpect(status().isForbidden());

--- a/back/src/test/java/com/qmate/api/questioninstance/QIControllerListTest.java
+++ b/back/src/test/java/com/qmate/api/questioninstance/QIControllerListTest.java
@@ -10,6 +10,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.qmate.AuthTestUtils;
+import com.qmate.SecuritySliceTestConfig;
 import com.qmate.domain.questioninstance.entity.QuestionInstanceStatus;
 import com.qmate.domain.questioninstance.model.response.QIListItem;
 import com.qmate.domain.questioninstance.service.QuestionInstanceService;
@@ -23,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -33,7 +36,8 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(controllers = QuestionInstanceController.class)
-@AutoConfigureMockMvc(addFilters = false)
+@AutoConfigureMockMvc
+@Import(SecuritySliceTestConfig.class)
 class QIControllerListTest {
 
   @Autowired
@@ -67,6 +71,7 @@ class QIControllerListTest {
 
       // when & then
       mvc.perform(get("/api/matches/{matchId}/question-instances", matchId)
+              .with(AuthTestUtils.userPrincipal(1L))
               .accept(MediaType.APPLICATION_JSON))
           .andExpect(status().isOk())
           .andExpect(jsonPath("$.content[0].questionInstanceId").value(123))
@@ -96,6 +101,7 @@ class QIControllerListTest {
               .param("sort", "status,asc")
               .param("page", "0")
               .param("size", "20")
+              .with(AuthTestUtils.userPrincipal(1L))
               .accept(MediaType.APPLICATION_JSON))
           .andExpect(status().isOk())
           .andExpect(jsonPath("$.content", hasSize(0)));
@@ -115,6 +121,7 @@ class QIControllerListTest {
           .willThrow(new QuestionInstanceForbiddenException());
 
       mvc.perform(get("/api/matches/{matchId}/question-instances", matchId)
+              .with(AuthTestUtils.userPrincipal(1L))
               .accept(MediaType.APPLICATION_JSON))
           .andExpect(status().isForbidden());
     }
@@ -130,6 +137,7 @@ class QIControllerListTest {
         .willThrow(new QIInvalidSortKeyException());
 
     mvc.perform(get("/api/matches/{matchId}/question-instances", matchId)
+            .with(AuthTestUtils.userPrincipal(1L))
             .param("sort", "unknownKey,asc")
             .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isBadRequest());

--- a/back/src/test/java/com/qmate/api/questioninstance/QIControllerListTest.java
+++ b/back/src/test/java/com/qmate/api/questioninstance/QIControllerListTest.java
@@ -10,7 +10,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.qmate.domain.questioninstance.entity.InstanceStatus;
+import com.qmate.domain.questioninstance.entity.QuestionInstanceStatus;
 import com.qmate.domain.questioninstance.model.response.QIListItem;
 import com.qmate.domain.questioninstance.service.QuestionInstanceService;
 import com.qmate.exception.custom.questioninstance.QIInvalidSortKeyException;
@@ -52,7 +52,7 @@ class QIControllerListTest {
       Long matchId = 10L;
       QIListItem item = new QIListItem(123L,
           LocalDateTime.parse("2025-09-11T12:00:00"),
-          InstanceStatus.COMPLETED,
+          QuestionInstanceStatus.COMPLETED,
           "상대가 가장 좋아하는 음식은?",
           LocalDateTime.parse("2025-09-11T12:45:00"));
 
@@ -84,7 +84,7 @@ class QIControllerListTest {
       Page<QIListItem> empty = Page.empty();
 
       given(questionInstanceService.list(
-          anyLong(), eq(matchId), eq(InstanceStatus.COMPLETED),
+          anyLong(), eq(matchId), eq(QuestionInstanceStatus.COMPLETED),
           any(LocalDateTime.class), any(LocalDateTime.class), any(Pageable.class)))
           .willReturn(empty);
 

--- a/back/src/test/java/com/qmate/api/questioninstance/QuestionInstanceControllerTest.java
+++ b/back/src/test/java/com/qmate/api/questioninstance/QuestionInstanceControllerTest.java
@@ -10,7 +10,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.qmate.domain.questioninstance.entity.InstanceStatus;
+import com.qmate.domain.questioninstance.entity.QuestionInstanceStatus;
 import com.qmate.domain.questioninstance.model.response.QIDetailResponse;
 import com.qmate.domain.questioninstance.model.response.QIDetailResponse.AnswerView;
 import com.qmate.domain.questioninstance.model.response.QIDetailResponse.CategoryInfo;
@@ -68,7 +68,7 @@ class QuestionInstanceControllerTest {
         .questionInstanceId(qiId)
         .matchId(matchId)
         .deliveredAt(deliveredAt)
-        .status(InstanceStatus.COMPLETED)
+        .status(QuestionInstanceStatus.COMPLETED)
         .completedAt(completedAt)
         .question(
             QuestionInfo.builder()

--- a/back/src/test/java/com/qmate/api/questioninstance/QuestionInstanceControllerTest.java
+++ b/back/src/test/java/com/qmate/api/questioninstance/QuestionInstanceControllerTest.java
@@ -10,6 +10,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.qmate.AuthTestUtils;
+import com.qmate.SecuritySliceTestConfig;
 import com.qmate.domain.questioninstance.entity.QuestionInstanceStatus;
 import com.qmate.domain.questioninstance.model.response.QIDetailResponse;
 import com.qmate.domain.questioninstance.model.response.QIDetailResponse.AnswerView;
@@ -27,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -35,8 +38,10 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(controllers = QuestionInstanceController.class)
-@AutoConfigureMockMvc(addFilters = false)
+@AutoConfigureMockMvc
+@Import(SecuritySliceTestConfig.class)
 class QuestionInstanceControllerTest {
+
   @Autowired
   MockMvc mockMvc;
   @MockitoBean
@@ -45,7 +50,8 @@ class QuestionInstanceControllerTest {
   @BeforeEach
   void setUpSecurityContext() {
     UserPrincipal principal = new UserPrincipal(99L, "user@example.com", "USER");
-    var auth = new UsernamePasswordAuthenticationToken(principal, null, List.of(new SimpleGrantedAuthority("ROLE_USER")));
+    var auth = new UsernamePasswordAuthenticationToken(principal, null,
+        List.of(new SimpleGrantedAuthority("ROLE_USER")));
     SecurityContextHolder.getContext().setAuthentication(auth);
   }
 
@@ -105,7 +111,9 @@ class QuestionInstanceControllerTest {
     when(questionInstanceService.getDetail(qiId, 1L)).thenReturn(dto);
 
     // expect
-    mockMvc.perform(get("/api/question-instances/{id}", qiId))
+    mockMvc.perform(get("/api/question-instances/{id}", qiId)
+            .with(AuthTestUtils.userPrincipal(1L)))
+
         .andExpect(status().isOk())
 
         // top-level
@@ -155,6 +163,7 @@ class QuestionInstanceControllerTest {
     given(questionInstanceService.getLatestNotified(anyLong(), anyLong())).willReturn(stub);
 
     mockMvc.perform(get("/api/matches/{matchId}/questions/today", matchId)
+            .with(AuthTestUtils.userPrincipal(1L))
             .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.questionInstanceId").value(555))

--- a/back/src/test/java/com/qmate/domain/quetioninstance/service/AnswerServiceCreateTest.java
+++ b/back/src/test/java/com/qmate/domain/quetioninstance/service/AnswerServiceCreateTest.java
@@ -8,7 +8,7 @@ import static org.mockito.BDDMockito.given;
 
 import com.qmate.domain.match.Match;
 import com.qmate.domain.questioninstance.entity.Answer;
-import com.qmate.domain.questioninstance.entity.InstanceStatus;
+import com.qmate.domain.questioninstance.entity.QuestionInstanceStatus;
 import com.qmate.domain.questioninstance.entity.QuestionInstance;
 import com.qmate.domain.questioninstance.model.request.AnswerContentRequest;
 import com.qmate.domain.questioninstance.repository.AnswerRepository;
@@ -43,7 +43,7 @@ class AnswerServiceCreateTest {
   @InjectMocks
   AnswerService sut;
 
-  private QuestionInstance qi(Long qiId, Long matchId, InstanceStatus status) {
+  private QuestionInstance qi(Long qiId, Long matchId, QuestionInstanceStatus status) {
     return QuestionInstance.builder()
         .id(qiId)
         .status(status)
@@ -58,7 +58,7 @@ class AnswerServiceCreateTest {
     Long qiId = 123L; Long userId = 99L; Long matchId = 7L;
     var req = new AnswerContentRequest("  안녕\r\n하세요  ");
     var user = User.builder().id(userId).currentMatchId(matchId).build();
-    var qi = qi(qiId, matchId, InstanceStatus.PENDING);
+    var qi = qi(qiId, matchId, QuestionInstanceStatus.PENDING);
 
     given(qiRepo.findById(qiId)).willReturn(Optional.of(qi));
     given(userRepo.findById(userId)).willReturn(Optional.of(user));
@@ -80,14 +80,14 @@ class AnswerServiceCreateTest {
     assertThat(res.getSubmittedAt()).isEqualTo("2025-09-11T12:20:00");
 
     // 완료 전이 호출 확인(마커 메서드가 내부 상태만 바꾸면 상태만 검증)
-    assertThat(qi.getStatus()).isEqualTo(InstanceStatus.COMPLETED);
+    assertThat(qi.getStatus()).isEqualTo(QuestionInstanceStatus.COMPLETED);
   }
 
   @Test
   void create_권한불일치_403() {
     Long qiId = 1L; Long userId = 2L;
     var req = new AnswerContentRequest("a");
-    var qi = qi(qiId, 100L, InstanceStatus.PENDING);
+    var qi = qi(qiId, 100L, QuestionInstanceStatus.PENDING);
     var user = User.builder().id(userId).currentMatchId(200L).build();
 
     given(qiRepo.findById(qiId)).willReturn(Optional.of(qi));
@@ -102,7 +102,7 @@ class AnswerServiceCreateTest {
   void create_expired_423() {
     Long qiId = 1L; Long userId = 2L; Long matchId = 7L;
     var req = new AnswerContentRequest("a");
-    var qi = qi(qiId, matchId, InstanceStatus.EXPIRED);
+    var qi = qi(qiId, matchId, QuestionInstanceStatus.EXPIRED);
     var user = User.builder().id(userId).currentMatchId(matchId).build();
 
     given(qiRepo.findById(qiId)).willReturn(Optional.of(qi));
@@ -118,7 +118,7 @@ class AnswerServiceCreateTest {
     // given
     Long qiId = 1L, userId = 2L, matchId = 7L;
     var req = new AnswerContentRequest("a");
-    var qi = qi(qiId, matchId, InstanceStatus.COMPLETED);
+    var qi = qi(qiId, matchId, QuestionInstanceStatus.COMPLETED);
     var user = User.builder().id(userId).currentMatchId(matchId).build();
 
     given(qiRepo.findById(qiId)).willReturn(Optional.of(qi));
@@ -133,7 +133,7 @@ class AnswerServiceCreateTest {
   void create_중복답변_409() {
     Long qiId = 1L; Long userId = 2L; Long matchId = 7L;
     var req = new AnswerContentRequest("a");
-    var qi = qi(qiId, matchId, InstanceStatus.PENDING);
+    var qi = qi(qiId, matchId, QuestionInstanceStatus.PENDING);
     var user = User.builder().id(userId).currentMatchId(matchId).build();
 
     given(qiRepo.findById(qiId)).willReturn(Optional.of(qi));
@@ -152,7 +152,7 @@ class AnswerServiceCreateTest {
     assertThatThrownBy(() -> sut.create(qiId, userId, new AnswerContentRequest("a")))
         .isInstanceOf(QuestionInstanceNotFoundException.class);
 
-    given(qiRepo.findById(qiId)).willReturn(Optional.of(qi(qiId, 7L, InstanceStatus.PENDING)));
+    given(qiRepo.findById(qiId)).willReturn(Optional.of(qi(qiId, 7L, QuestionInstanceStatus.PENDING)));
     given(userRepo.findById(userId)).willReturn(Optional.empty());
     assertThatThrownBy(() -> sut.create(qiId, userId, new AnswerContentRequest("a")))
         .isInstanceOf(UserNotFoundException.class);

--- a/back/src/test/java/com/qmate/domain/quetioninstance/service/AnswerServiceUpdateTest.java
+++ b/back/src/test/java/com/qmate/domain/quetioninstance/service/AnswerServiceUpdateTest.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.*;
 
 import com.qmate.domain.questioninstance.entity.Answer;
-import com.qmate.domain.questioninstance.entity.InstanceStatus;
+import com.qmate.domain.questioninstance.entity.QuestionInstanceStatus;
 import com.qmate.domain.questioninstance.entity.QuestionInstance;
 import com.qmate.domain.questioninstance.model.request.AnswerContentRequest;
 import com.qmate.domain.questioninstance.model.response.AnswerResponse;
@@ -55,7 +55,7 @@ class AnswerServiceUpdateTest {
 
       QuestionInstance qi = QuestionInstance.builder()
           .id(10L)
-          .status(InstanceStatus.PENDING)
+          .status(QuestionInstanceStatus.PENDING)
           .build();
 
       Answer answer = Answer.builder()
@@ -123,7 +123,7 @@ class AnswerServiceUpdateTest {
           .build();
 
       QuestionInstance qi = QuestionInstance.builder()
-          .id(10L).status(InstanceStatus.PENDING).build();
+          .id(10L).status(QuestionInstanceStatus.PENDING).build();
 
       Answer answer = Answer.builder()
           .id(answerId).user(owner).questionInstance(qi).content("초기").build();
@@ -151,7 +151,7 @@ class AnswerServiceUpdateTest {
           .build();
 
       QuestionInstance qi = QuestionInstance.builder()
-          .id(10L).status(InstanceStatus.COMPLETED) // 수정 불가 상태
+          .id(10L).status(QuestionInstanceStatus.COMPLETED) // 수정 불가 상태
           .build();
 
       Answer answer = Answer.builder()

--- a/back/src/test/java/com/qmate/domain/quetioninstance/service/AnswerServiceUpdateTimestampTest.java
+++ b/back/src/test/java/com/qmate/domain/quetioninstance/service/AnswerServiceUpdateTimestampTest.java
@@ -8,7 +8,7 @@ import com.qmate.domain.question.entity.Question;
 import com.qmate.domain.question.entity.QuestionCategory;
 import com.qmate.domain.question.entity.RelationType;
 import com.qmate.domain.questioninstance.entity.Answer;
-import com.qmate.domain.questioninstance.entity.InstanceStatus;
+import com.qmate.domain.questioninstance.entity.QuestionInstanceStatus;
 import com.qmate.domain.questioninstance.entity.QuestionInstance;
 import com.qmate.domain.questioninstance.model.request.AnswerContentRequest;
 import com.qmate.domain.questioninstance.service.AnswerService;
@@ -72,7 +72,7 @@ class AnswerServiceUpdateTimestampTest {
         .match(match)
         .question(q)                 // custom_question은 null 유지 (CHECK 제약 충족)
         .deliveredAt(LocalDateTime.now()) // 필수
-        .status(InstanceStatus.PENDING)   // ‘PENDING|COMPLETED|EXPIRED’ 중 하나
+        .status(QuestionInstanceStatus.PENDING)   // ‘PENDING|COMPLETED|EXPIRED’ 중 하나
         .build();
     em.persist(qi);
 

--- a/back/src/test/java/com/qmate/domain/quetioninstance/service/QIServiceListTest.java
+++ b/back/src/test/java/com/qmate/domain/quetioninstance/service/QIServiceListTest.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 
-import com.qmate.domain.questioninstance.entity.InstanceStatus;
+import com.qmate.domain.questioninstance.entity.QuestionInstanceStatus;
 import com.qmate.domain.questioninstance.model.response.QIListItem;
 import com.qmate.domain.questioninstance.repository.QuestionInstanceRepository;
 import com.qmate.domain.questioninstance.service.QuestionInstanceService;
@@ -91,7 +91,7 @@ public class QIServiceListTest {
           .willReturn(Optional.of(999L));
 
       assertThrows(QuestionInstanceForbiddenException.class, () ->
-          service.list(userId, matchId, InstanceStatus.COMPLETED,
+          service.list(userId, matchId, QuestionInstanceStatus.COMPLETED,
               LocalDateTime.parse("2025-09-01T00:00:00"),
               LocalDateTime.parse("2025-09-30T23:59:59"),
               PageRequest.of(0, 20)));

--- a/back/src/test/java/com/qmate/domain/quetioninstance/service/QuestionInstanceServiceGetDetailTest.java
+++ b/back/src/test/java/com/qmate/domain/quetioninstance/service/QuestionInstanceServiceGetDetailTest.java
@@ -9,7 +9,7 @@ import static org.mockito.Mockito.when;
 
 import com.qmate.domain.match.Match;
 import com.qmate.domain.questioninstance.entity.Answer;
-import com.qmate.domain.questioninstance.entity.InstanceStatus;
+import com.qmate.domain.questioninstance.entity.QuestionInstanceStatus;
 import com.qmate.domain.questioninstance.entity.QuestionInstance;
 import com.qmate.domain.questioninstance.mapper.QIDetailMapper;
 import com.qmate.domain.questioninstance.model.response.QIDetailResponse;
@@ -60,7 +60,7 @@ class QuestionInstanceServiceGetDetailTest {
       QuestionInstance qi = QuestionInstance.builder()
           .id(qiId)
           .match(match)
-          .status(InstanceStatus.PENDING)
+          .status(QuestionInstanceStatus.PENDING)
           .build();
       User me = User.builder().id(meId).currentMatchId(matchId).build();
       User partner = User.builder().id(partnerId).currentMatchId(matchId).build();
@@ -78,7 +78,7 @@ class QuestionInstanceServiceGetDetailTest {
       QIDetailResponse expected = QIDetailResponse.builder()
           .questionInstanceId(qiId)
           .matchId(matchId)
-          .status(InstanceStatus.PENDING)
+          .status(QuestionInstanceStatus.PENDING)
           .build();
 
       try (MockedStatic<QIDetailMapper> mocked = mockStatic(QIDetailMapper.class)) {
@@ -104,7 +104,7 @@ class QuestionInstanceServiceGetDetailTest {
       QuestionInstance qi = QuestionInstance.builder()
           .id(qiId)
           .match(match)
-          .status(InstanceStatus.COMPLETED)
+          .status(QuestionInstanceStatus.COMPLETED)
           .build();
       User me = User.builder().id(meId).currentMatchId(matchId).build();
       User partner = User.builder().id(partnerId).currentMatchId(matchId).build();
@@ -123,7 +123,7 @@ class QuestionInstanceServiceGetDetailTest {
       QIDetailResponse expected = QIDetailResponse.builder()
           .questionInstanceId(qiId)
           .matchId(matchId)
-          .status(InstanceStatus.COMPLETED)
+          .status(QuestionInstanceStatus.COMPLETED)
           .build();
 
       try (MockedStatic<QIDetailMapper> mocked = mockStatic(QIDetailMapper.class)) {
@@ -149,7 +149,7 @@ class QuestionInstanceServiceGetDetailTest {
       QuestionInstance qi = QuestionInstance.builder()
           .id(qiId)
           .match(match)
-          .status(InstanceStatus.EXPIRED)
+          .status(QuestionInstanceStatus.EXPIRED)
           .build();
       User me = User.builder().id(meId).currentMatchId(matchId).build();
       User partner = User.builder().id(partnerId).currentMatchId(matchId).build();
@@ -166,7 +166,7 @@ class QuestionInstanceServiceGetDetailTest {
       QIDetailResponse expected = QIDetailResponse.builder()
           .questionInstanceId(qiId)
           .matchId(matchId)
-          .status(InstanceStatus.EXPIRED)
+          .status(QuestionInstanceStatus.EXPIRED)
           .build();
 
       try (MockedStatic<QIDetailMapper> mocked = mockStatic(QIDetailMapper.class)) {
@@ -205,7 +205,7 @@ class QuestionInstanceServiceGetDetailTest {
       QuestionInstance qi = QuestionInstance.builder()
           .id(qiId)
           .match(match)
-          .status(InstanceStatus.PENDING)
+          .status(QuestionInstanceStatus.PENDING)
           .build();
 
       when(qiRepository.findDetailWithQuestionAndMatch(qiId)).thenReturn(Optional.of(qi));
@@ -227,7 +227,7 @@ class QuestionInstanceServiceGetDetailTest {
       QuestionInstance qi = QuestionInstance.builder()
           .id(qiId)
           .match(match)
-          .status(InstanceStatus.PENDING)
+          .status(QuestionInstanceStatus.PENDING)
           .build();
 
       User me = User.builder().id(7L).currentMatchId(21L).build(); // mismatch


### PR DESCRIPTION
## 개요
- **리팩토링**: `InstanceStatus` → `QuestionInstanceStatus`로 타입명 명확화, Answer/QI 컨트롤러에 principal 관통 및 OpenAPI 문서 보강.
- **문서**: Swagger UI에 **JWT Authorize 버튼**을 추가하고, Answer/QI 스펙을 정리.
- **테스트**: 컨트롤러 슬라이스 테스트에서 `@AuthenticationPrincipal` NPE를 피하고 **원하는 userId**를 주입하는 방법 정리.

---

## 변경 사항
- 도메인
  - `InstanceStatus` → `QuestionInstanceStatus`로 이름 변경 (의도 명확화).
- API 문서(OpenAPI)
  - `@SecurityScheme` 등록으로 Swagger UI에 **Authorize(JWT)** 버튼 노출.
  - Answer/QI 컨트롤러에 `@Operation`/`@ApiResponse` 보강
- 테스트
  - `SecuritySliceTestConfig` 도입: `AuthenticationPrincipalArgumentResolver` 등록 + 최소 `SecurityFilterChain`.
  - `AuthTestUtils`: `authentication(...)` 기반으로 **커스텀 UserPrincipal 주입** 헬퍼 추가.

---

## 적용 방법

### 1) Swagger JWT 버튼 노출
- 설정에 **SecurityScheme 등록**:
  ```java
  @Configuration
  @SecurityScheme(name = "bearerAuth", type = SecuritySchemeType.HTTP, scheme = "bearer", bearerFormat = "JWT")
  public class OpenApiSecurityConfig {}
  ```
- 컨트롤러/메서드에 보안 요구 선언:
  ```java
  @Operation(security = @SecurityRequirement(name = "bearerAuth"))
  ```
- 토큰 유지:
  ```yaml
  springdoc:
    swagger-ui:
      persist-authorization: true
  ```

> 위 설정 후 Swagger UI에 **Authorize(JWT)** 버튼이 나타납니다. 버튼을 눌러 **순수 토큰 문자열만** 입력하면 됩니다.

---

### 2) Controller 테스트에서 principal NPE 방지 & userId 주입
- 슬라이스 테스트 설정 등록(**ArgumentResolver + 최소 SecurityFilterChain**):
  ```java
  @TestConfiguration
  public class SecuritySliceTestConfig implements WebMvcConfigurer {
    @Bean SecurityFilterChain testFilterChain(HttpSecurity http) throws Exception {
      return http.csrf(csrf -> csrf.disable()).build();
    }
    @Override public void addArgumentResolvers(List<HandlerMethodArgumentResolver> r) {
      r.add(new AuthenticationPrincipalArgumentResolver());
    }
  }
  ```
- 커스텀 principal 주입 유틸 사용:
  ```java
    @WebMvcTest(AnswerController.class)
    @Import(SecuritySliceTestConfig.class)
    class AnswerControllerTest {
      @Autowired MockMvc mvc;
      @Test void create_ok() throws Exception {
        mvc.perform(post("/api/question-instances/{id}/answers", 123L)
            .with(AuthTestUtils.userPrincipal(1L))  // 원하는 userId 주입
            .contentType(APPLICATION_JSON)
            .content("{\"content\":\"hi\"}"))
          .andExpect(status().isCreated());
      }
    }
  ```

> 요점: `@Import(SecuritySliceTestConfig.class)` 로 **@AuthenticationPrincipal 리졸버**를 등록하고, 요청에 `.with(AuthTestUtils.userPrincipal(1L))` 를 붙이면 NPE 없이 **원하는 userId**가 주입됩니다.
