### PR TITLE
Feature/calendar

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -10,6 +10,7 @@
     "mock:list": "json-server --watch src/mocks/db.json --port 3003",
     "mock:today": "json-server --watch src/mocks/db_today.json --port 4000",
     "mock:scheduleList": "json-server --watch src/mocks/db_scheduleList.json --port 3005",
+    "mock:calendarMonth": "json-server --watch src/mocks/db_calendarMonth.json --port 3006",
     "mock:invited": "json-server --watch src/mocks/db_invited.json --port 3004"
   },
   "dependencies": {

--- a/front/src/api/schedule.ts
+++ b/front/src/api/schedule.ts
@@ -7,8 +7,8 @@ export const fetchScheduleList = async (): Promise<ScheduleResponse> => {
 };
 
 export const fetchEventMonth = async (year: number, month: number): Promise<EventMonthResponse> => {
-  const res = await axios.get<EventMonthResponse>(
-    `http://localhost:3005/schedule/month?year=${year}&month=${month}`,
-  );
+  const res = await axios.get<EventMonthResponse>(`http://localhost:3006/calendarMonth`, {
+    params: { year, month },
+  });
   return res.data;
 };

--- a/front/src/app/schedule/page.tsx
+++ b/front/src/app/schedule/page.tsx
@@ -1,9 +1,8 @@
 import BellBtn from '@/components/common/BellBtn';
 import ScheduleListWeb from '@/components/schedule/ScheduleListWeb';
 import ScheduleView from '@/components/schedule/ScheduleView';
-import AddBtn from '@/components/schedule/ui/AddBtn';
 import { CalendarDays } from 'lucide-react';
-import Image from 'next/image';
+
 import Link from 'next/link';
 import React from 'react';
 
@@ -18,7 +17,7 @@ export default function page() {
         <img alt="큐메이트" width={109} height={35} className="site-logo" />
         <BellBtn />
       </div>
-      <div className="w-full h-full flex flex-row gap-10 justify-center">
+      <div className="w-full h-full flex flex-row gap-10 justify-center sm:pb-[70px]">
         <ScheduleListWeb />
         <ScheduleView />
       </div>

--- a/front/src/components/schedule/ScheduleView.tsx
+++ b/front/src/components/schedule/ScheduleView.tsx
@@ -9,6 +9,27 @@ import AddBtn from './ui/AddBtn';
 
 export default function ScheduleView() {
   const [selected, setSelected] = useState<Date | undefined>(new Date());
+
+  const currentMonth = selected ? selected.getMonth() + 1 : new Date().getMonth() + 1;
+  const currentYear = selected ? selected.getFullYear() : new Date().getFullYear();
+  const { data: monthData } = useEventMonth(currentYear, currentMonth);
+
+  const anniversarySet = useMemo(() => {
+    const s = new Set<string>();
+    monthData?.days.forEach((d) => {
+      if (d.isAnniversary) s.add(d.eventAt);
+    });
+    return s;
+  }, [monthData]);
+
+  const scheduleSet = useMemo(() => {
+    const s = new Set<string>();
+    monthData?.days.forEach((d) => {
+      if (!d.isAnniversary && !anniversarySet.has(d.eventAt)) s.add(d.eventAt);
+    });
+    return s;
+  }, [monthData, anniversarySet]);
+
   const { data, isLoading, isError } = useScheduleList();
 
   const dayItems = useMemo(() => {
@@ -17,9 +38,14 @@ export default function ScheduleView() {
   }, [data, selected]);
 
   return (
-    <div className="w-full h-full flex justify-center">
-      <div className="relative flex flex-col justify-center rounded-t-lg border shadow-sm w-full h-full sm:w-[500px] md:w-[600px] lg:w-[700px]">
-        <MainCalendar selected={selected} onSelect={(date) => date && setSelected(date)} />
+    <div className="w-full h-full flex justify-center rounded-lg">
+      <div className="relative flex flex-col justify-center rounded-lg w-full h-full sm:w-[500px] md:w-[600px] lg:w-[700px]">
+        <MainCalendar
+          selected={selected}
+          onSelect={(date) => date && setSelected(date)}
+          anniversarySet={anniversarySet}
+          scheduleSet={scheduleSet}
+        />
         <EventList
           date={selected ?? new Date()}
           items={dayItems}

--- a/front/src/components/schedule/calendar/MainCalendar.tsx
+++ b/front/src/components/schedule/calendar/MainCalendar.tsx
@@ -2,20 +2,23 @@
 
 import React from 'react';
 import { Calendar } from '../ui/CustomCalendar';
+import { toKey } from '@/utils/date';
 
 type Props = {
   selected?: Date;
   onSelect: (date: Date | undefined) => void;
+  anniversarySet: Set<string>;
+  scheduleSet: Set<string>;
 };
-export default function MainCalendar({ selected, onSelect }: Props) {
+export default function MainCalendar({ selected, onSelect, anniversarySet, scheduleSet }: Props) {
   return (
-    <div className="flex flex-1.5 justify-center rounded-lg border shadow-sm w-full lg:flex-1">
+    <div className="flex flex-1 justify-center w-full lg:flex-1">
       <Calendar
         mode="single"
         defaultMonth={selected}
         selected={selected}
         onSelect={onSelect}
-        className="w-full"
+        className="w-full rounded-lg"
         components={{
           MonthCaption: ({ calendarMonth }) => {
             const year = calendarMonth.date.getFullYear();
@@ -26,6 +29,31 @@ export default function MainCalendar({ selected, onSelect }: Props) {
                 <span className="text-24 font-semibold">{month}</span>
               </div>
             );
+          },
+          Day: ({ className, children, day, ...props }) => {
+            const key = toKey(day.date);
+            const dot = anniversarySet.has(key)
+              ? 'bg-anniversary'
+              : scheduleSet.has(key)
+              ? 'bg-calendar'
+              : '';
+
+            return (
+              <td {...props} className={`relative p-0 ${className ?? ''}`}>
+                {children}
+                {dot && (
+                  <span
+                    aria-hidden
+                    className={`pointer-events-none absolute bottom-0 left-1/2 -translate-x-1/2 inline-block w-1.5 h-1.5 rounded-full ${dot}`}
+                  />
+                )}
+              </td>
+            );
+          },
+        }}
+        formatters={{
+          formatWeekdayName: (date) => {
+            return date.toLocaleDateString('en-US', { weekday: 'short' }).toUpperCase();
           },
         }}
       />

--- a/front/src/components/schedule/list/EventList.tsx
+++ b/front/src/components/schedule/list/EventList.tsx
@@ -26,19 +26,19 @@ function EventList({ date, items, isLoading, isError }: Props) {
   }
 
   return (
-    <div className="flex-1 border-t border-text-text-primary bg-secondary shadow-sm h-full px-4 overflow-hidden">
+    <div className="flex-1 border-t border-text-text-primary rounded-b-lg bg-secondary shadow-sm h-full px-4 overflow-hidden">
       <h2 className="font-extrabold text-16 mt-4">
         {date.getDate()}. {date.toLocaleString('ko-kR', { weekday: 'narrow' })}
       </h2>
       {/* 리스트 내부에 스크롤 추가 */}
-      <ul className="max-h-60 flex-1 overflow-y-auto">
+      <ul className="max-h-50 flex-1 overflow-y-auto">
         {items.length === 0 && <li>표시할 일정이 없어요.</li>}
 
         {items.map(({ eventId, title, isAnniversary, repeatType }) => (
           <li key={eventId} className="flex items-center py-2 border-y">
             <span
               className={`inline-block w-1 h-12 mr-2 ${
-                isAnniversary ? 'bg-yellow-400' : 'bg-primary'
+                isAnniversary ? 'bg-anniversary' : 'bg-calendar'
               }`}
             />
             <div>

--- a/front/src/components/schedule/ui/CustomCalendar.tsx
+++ b/front/src/components/schedule/ui/CustomCalendar.tsx
@@ -36,11 +36,12 @@ function Calendar({
         ...formatters,
       }}
       classNames={{
+        month_grid: cn('h-full', defaultClassNames.month_grid),
         root: cn('w-fit', defaultClassNames.root),
         months: cn('flex gap-4 flex-col md:flex-row relative', defaultClassNames.months),
         month: cn('flex flex-col w-full gap-4', defaultClassNames.month),
         nav: cn(
-          'flex items-center gap-1 w-full absolute top-0 inset-x-0 justify-between',
+          'flex items-center gap-1 w-full absolute top-4 inset-x-0 justify-between',
           defaultClassNames.nav,
         ),
         button_previous: cn(
@@ -79,14 +80,17 @@ function Calendar({
           'text-muted-foreground font-normal text-[0.8rem] select-none h-9 grid place-items-center',
           defaultClassNames.weekday,
         ),
-        week: cn('grid grid-cols-7 w-full gap-1', defaultClassNames.week),
+        week: cn(
+          'grid grid-cols-7 w-full place-items-center justify-center',
+          defaultClassNames.week,
+        ),
         week_number_header: cn('select-none w-(--cell-size)', defaultClassNames.week_number_header),
         week_number: cn(
           'text-[0.8rem] select-none text-muted-foreground',
           defaultClassNames.week_number,
         ),
         day: cn(
-          'relative p-0 text-center group/day select-none grid place-items-center aspect-square',
+          'relative p-0 text-center group/day select-none grid place-items-center w-full aspect-square',
           defaultClassNames.day,
         ),
         range_start: cn('bg-accent', defaultClassNames.range_start),
@@ -163,7 +167,7 @@ function CalendarDayButton({
       data-range-middle={modifiers.range_middle}
       className={cn(
         'cursor-pointer',
-        'data-[selected-single=true]:bg-primary data-[selected-single=true]:text-white',
+        'data-[selected-single=true]:bg-calendar data-[selected-single=true]:text-theme-primary',
 
         'flex w-8 h-8 lg:w-12 lg:h-12 p-0 flex-col gap-1 leading-none font-normal text-sm',
         'rounded-full',

--- a/front/src/hooks/useSchedule.ts
+++ b/front/src/hooks/useSchedule.ts
@@ -1,6 +1,6 @@
 'use client';
 import { fetchEventMonth, fetchScheduleList } from '@/api/schedule';
-import { ScheduleResponse } from '@/types/scheduleType';
+import { EventMonthResponse, ScheduleResponse } from '@/types/scheduleType';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 
 export const useScheduleList = () => {
@@ -13,9 +13,10 @@ export const useScheduleList = () => {
 };
 
 export const useEventMonth = (year: number, month: number) => {
-  return useQuery({
-    queryKey: ['eventMonth', year, month],
+  return useQuery<EventMonthResponse>({
+    queryKey: ['calendarMonth', year, month],
     queryFn: () => fetchEventMonth(year, month),
+
     placeholderData: keepPreviousData,
     staleTime: 1000 * 60 * 10,
     gcTime: 1000 * 60 * 60,

--- a/front/src/mocks/db_calendarMonth.json
+++ b/front/src/mocks/db_calendarMonth.json
@@ -1,16 +1,28 @@
 {
-  "year": 2025,
-  "month": 9,
-  "days": [
-    {
-      "eventId": 1,
-      "eventAt": "2025-09-03",
-      "isAnniversary": false
-    },
-    {
-      "eventId": 2,
-      "eventAt": "2025-09-10",
-      "isAnniversary": true
-    }
-  ]
+  "calendarMonth": {
+    "year": 2025,
+    "month": 9,
+    "days": [
+      {
+        "eventId": 1,
+        "eventAt": "2025-09-03",
+        "isAnniversary": false
+      },
+      {
+        "eventId": 2,
+        "eventAt": "2025-09-10",
+        "isAnniversary": true
+      },
+      {
+        "eventId": 3,
+        "eventAt": "2025-09-27",
+        "isAnniversary": false
+      },
+      {
+        "eventId": 4,
+        "eventAt": "2025-09-27",
+        "isAnniversary": true
+      }
+    ]
+  }
 }

--- a/front/src/mocks/db_scheduleList.json
+++ b/front/src/mocks/db_scheduleList.json
@@ -10,14 +10,14 @@
     {
       "eventId": "123",
       "title": "저녁 약속",
-      "eventAt": "2025-09-27",
+      "eventAt": "2025-09-3",
       "repeatType": "none",
       "isAnniversary": false
     },
     {
       "eventId": "124",
       "title": "저녁 약속",
-      "eventAt": "2025-09-27",
+      "eventAt": "2025-09-10",
       "repeatType": "none",
       "isAnniversary": false
     },

--- a/front/src/styles/calendar.css
+++ b/front/src/styles/calendar.css
@@ -1,0 +1,36 @@
+@theme inline {
+  --anniversary: var(--color-anniversary);
+}
+
+@layer utilities {
+  .bg-calendar {
+    background-color: var(--color-day-calendar) !important;
+    color: var(--color-secondary);
+  }
+  html[data-theme='sunset'] .bg-calendar {
+    background-color: var(--color-sunset-calendar) !important;
+  }
+  html[data-theme='night'] .bg-calendar {
+    background-color: var(--color-night-calendar) !important;
+  }
+
+  button[data-selected-single='true'],
+  button[data-selected-single='true']:hover {
+    background-color: var(--color-day-calendar) !important;
+    color: var(--color-secondary) !important;
+  }
+
+  /* sunset 테마 */
+  html[data-theme='sunset'] button[data-selected-single='true'],
+  html[data-theme='sunset'] button[data-selected-single='true']:hover {
+    background-color: var(--color-sunset-calendar) !important;
+    color: var(--color-secondary) !important;
+  }
+
+  /* night 테마 */
+  html[data-theme='night'] button[data-selected-single='true'],
+  html[data-theme='night'] button[data-selected-single='true']:hover {
+    background-color: var(--color-night-calendar) !important;
+    color: var(--color-secondary) !important;
+  }
+}

--- a/front/src/styles/globals.css
+++ b/front/src/styles/globals.css
@@ -8,6 +8,7 @@
 @import './nav.css';
 @import './button.css';
 @import './question.css';
+@import './calendar.css';
 
 @font-face {
   font-family: 'RomanticGumi';

--- a/front/src/styles/theme.css
+++ b/front/src/styles/theme.css
@@ -44,6 +44,10 @@
   --color-night-active: #020433;
   --color-night-active2: #8f93cf;
   --color-night-list: #d3d5ff;
+  --color-day-calendar: #68c5f3;
+  --color-sunset-calendar: #f3a968;
+  --color-night-calendar: #424e97;
+  --color-anniversary: #fddd69;
 
   /* shadcn 토큰 */
   --color-sidebar-ring: var(--sidebar-ring);


### PR DESCRIPTION
## 📝 작업 내용

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [x] 기타 (설명)

## 🔍 변경 사항
### calendar 
- 내부 selected상태일 시 theme에 맞춘 색상 적용
- 날짜 하단 기념일 및 일정에 따른 도트추가 
  - 기념일+일정 =기념일으로 표시 | 일정만 존재하면 일정으로 표시
- 요일표기 2글자 -> 3글자
- next prev 버튼 위치 수정

### mock data
- mock data 형태 수정
- fetch 내용 수정
- hooks 수정
- package.json 월별이벤트 조회 json-server실행 추가

## 💬 기타 공유 사항
- 캘린더 하단 일정 클릭 시 일정 수정 화면 추가 예정
- 반복일 및 알림주기 추가 예정
- calendar height값이나 몇 개의 component는 수정하였으나 전체calendar 조절 실패 -> 원래 형태 유지
<img width="978" height="847" alt="스크린샷 2025-09-26 오전 12 24 33" src="https://github.com/user-attachments/assets/62d5a407-2053-4319-8680-5b84cf2fa0c0" />
