### PR TITLE
refactor: API Doc + Principal 일원화 + 커스텀 예외 (question / question-category / custom-question)

### DIFF
--- a/back/src/main/java/com/qmate/api/question/CustomQuestionController.java
+++ b/back/src/main/java/com/qmate/api/question/CustomQuestionController.java
@@ -3,18 +3,18 @@ package com.qmate.api.question;
 import com.qmate.domain.question.model.request.CustomQuestionTextRequest;
 import com.qmate.domain.question.model.response.CustomQuestionResponse;
 import com.qmate.domain.question.service.CustomQuestionService;
+import com.qmate.security.UserPrincipal;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -27,36 +27,36 @@ public class CustomQuestionController {
 
   @PostMapping(path = "/matches/{matchId}/custom-questions")
   public ResponseEntity<CustomQuestionResponse> create(
-      // TODO: @AuthenticationPrincipal CustomUserDetails principal
+      @AuthenticationPrincipal UserPrincipal principal,
       @PathVariable Long matchId,
       @RequestBody @Valid CustomQuestionTextRequest request) {
-    Long userId = 1L; // TODO: principal.getUserId();
+    Long userId = principal.userId();
     return ResponseEntity.status(HttpStatus.CREATED).body(customQuestionService.create(userId, matchId, request));
   }
 
   @PatchMapping(path = "/custom-questions/{id}")
   public ResponseEntity<CustomQuestionResponse> update(
-      // TODO: @AuthenticationPrincipal CustomUserDetails principal
+      @AuthenticationPrincipal UserPrincipal principal,
       @PathVariable Long id,
       @RequestBody @Valid CustomQuestionTextRequest request) {
-    Long userId = 1L; // TODO: principal.getUserId();
+    Long userId = principal.userId();
     return ResponseEntity.ok(customQuestionService.update(userId, id, request));
   }
 
   @DeleteMapping(path = "/custom-questions/{id}")
   public ResponseEntity<Void> delete(
-      // TODO: @AuthenticationPrincipal CustomUserDetails principal
+      @AuthenticationPrincipal UserPrincipal principal,
       @PathVariable Long id) {
-    Long userId = 1L; // TODO: principal.getUserId();
+    Long userId = principal.userId();
     customQuestionService.delete(userId, id);
     return ResponseEntity.noContent().build();
   }
 
   @GetMapping(path = "/custom-questions/{id}")
   public ResponseEntity<CustomQuestionResponse> getOne(
-      // TODO: @AuthenticationPrincipal CustomUserDetails principal
+      @AuthenticationPrincipal UserPrincipal principal,
       @PathVariable Long id) {
-    Long userId = 1L; // TODO: principal.getUserId();
+    Long userId = principal.userId();
     return ResponseEntity.ok(customQuestionService.getOne(userId, id));
   }
 }

--- a/back/src/main/java/com/qmate/api/question/CustomQuestionController.java
+++ b/back/src/main/java/com/qmate/api/question/CustomQuestionController.java
@@ -3,7 +3,15 @@ package com.qmate.api.question;
 import com.qmate.domain.question.model.request.CustomQuestionTextRequest;
 import com.qmate.domain.question.model.response.CustomQuestionResponse;
 import com.qmate.domain.question.service.CustomQuestionService;
+import com.qmate.exception.ErrorResponse;
 import com.qmate.security.UserPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -21,11 +29,36 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
+@Tag(name = "Custom Question", description = "커스텀 질문 API")
+@SecurityRequirement(name = "bearerAuth")
 public class CustomQuestionController {
 
   private final CustomQuestionService customQuestionService;
 
+  /**
+   * 커스텀 질문 생성
+   */
   @PostMapping(path = "/matches/{matchId}/custom-questions")
+  @Operation(
+      summary = "커스텀 질문 생성",
+      description = "특정 매치에 대한 커스텀 질문을 생성합니다.",
+      responses = {
+          @ApiResponse(responseCode = "201", description = "생성 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = CustomQuestionResponse.class))),
+          @ApiResponse(responseCode = "400", description = "유효하지 않은 요청 값", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = "404", description = "매치를 찾을 수 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
+      },
+      requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+          required = true,
+          content = @Content(mediaType = "application/json", schema = @Schema(implementation = CustomQuestionTextRequest.class))
+      ),
+      parameters = {
+          @Parameter(name = "matchId", description = "커스텀 질문을 추가할 매치 ID", required = true)
+      }
+  )
+  //@PostMapping(path = "/matches/{matchId}/custom-questions")
   public ResponseEntity<CustomQuestionResponse> create(
       @AuthenticationPrincipal UserPrincipal principal,
       @PathVariable Long matchId,
@@ -34,7 +67,31 @@ public class CustomQuestionController {
     return ResponseEntity.status(HttpStatus.CREATED).body(customQuestionService.create(userId, matchId, request));
   }
 
+  /**
+   * 커스텀 질문 수정
+   */
   @PatchMapping(path = "/custom-questions/{id}")
+  @Operation(
+      summary = "커스텀 질문 수정",
+      description = "특정 커스텀 질문을 수정합니다.",
+      responses = {
+          @ApiResponse(responseCode = "200", description = "수정 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = CustomQuestionResponse.class))),
+          @ApiResponse(responseCode = "400", description = "유효하지 않은 요청 값", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = "404", description = "커스텀 질문을 찾을 수 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = "423", description = "수정 불가", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
+      },
+      requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+          required = true,
+          content = @Content(mediaType = "application/json", schema = @Schema(implementation = CustomQuestionTextRequest.class))
+      ),
+      parameters = {
+          @Parameter(name = "id", description = "수정할 커스텀 질문 ID", required = true)
+      }
+  )
+  //@PatchMapping(path = "/custom-questions/{id}")
   public ResponseEntity<CustomQuestionResponse> update(
       @AuthenticationPrincipal UserPrincipal principal,
       @PathVariable Long id,
@@ -43,7 +100,26 @@ public class CustomQuestionController {
     return ResponseEntity.ok(customQuestionService.update(userId, id, request));
   }
 
+  /**
+   * 커스텀 질문 삭제
+   */
   @DeleteMapping(path = "/custom-questions/{id}")
+  @Operation(
+      summary = "커스텀 질문 삭제",
+      description = "특정 커스텀 질문을 삭제합니다.",
+      responses = {
+          @ApiResponse(responseCode = "204", description = "삭제 성공"),
+          @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = "404", description = "커스텀 질문을 찾을 수 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = "423", description = "삭제 불가", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
+      },
+      parameters = {
+          @Parameter(name = "id", description = "삭제할 커스텀 질문 ID", required = true)
+      }
+  )
+  //@DeleteMapping(path = "/custom-questions/{id}")
   public ResponseEntity<Void> delete(
       @AuthenticationPrincipal UserPrincipal principal,
       @PathVariable Long id) {
@@ -52,7 +128,25 @@ public class CustomQuestionController {
     return ResponseEntity.noContent().build();
   }
 
+  /**
+   * 커스텀 질문 단일 조회
+   */
   @GetMapping(path = "/custom-questions/{id}")
+  @Operation(
+      summary = "커스텀 질문 단일 조회",
+      description = "특정 커스텀 질문을 조회합니다.",
+      responses = {
+          @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = CustomQuestionResponse.class))),
+          @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = "404", description = "커스텀 질문을 찾을 수 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
+      },
+      parameters = {
+          @Parameter(name = "id", description = "조회할 커스텀 질문 ID", required = true)
+      }
+  )
+  //@GetMapping(path = "/custom-questions/{id}")
   public ResponseEntity<CustomQuestionResponse> getOne(
       @AuthenticationPrincipal UserPrincipal principal,
       @PathVariable Long id) {

--- a/back/src/main/java/com/qmate/api/question/CustomQuestionController.java
+++ b/back/src/main/java/com/qmate/api/question/CustomQuestionController.java
@@ -45,10 +45,7 @@ public class CustomQuestionController {
       responses = {
           @ApiResponse(responseCode = "201", description = "생성 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = CustomQuestionResponse.class))),
           @ApiResponse(responseCode = "400", description = "유효하지 않은 요청 값", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
-          @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
-          @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
           @ApiResponse(responseCode = "404", description = "매치를 찾을 수 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
-          @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
       },
       requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
           required = true,
@@ -77,11 +74,8 @@ public class CustomQuestionController {
       responses = {
           @ApiResponse(responseCode = "200", description = "수정 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = CustomQuestionResponse.class))),
           @ApiResponse(responseCode = "400", description = "유효하지 않은 요청 값", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
-          @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
-          @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
           @ApiResponse(responseCode = "404", description = "커스텀 질문을 찾을 수 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
           @ApiResponse(responseCode = "423", description = "수정 불가", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
-          @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
       },
       requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
           required = true,
@@ -109,11 +103,8 @@ public class CustomQuestionController {
       description = "특정 커스텀 질문을 삭제합니다.",
       responses = {
           @ApiResponse(responseCode = "204", description = "삭제 성공"),
-          @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
-          @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
           @ApiResponse(responseCode = "404", description = "커스텀 질문을 찾을 수 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
           @ApiResponse(responseCode = "423", description = "삭제 불가", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
-          @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
       },
       parameters = {
           @Parameter(name = "id", description = "삭제할 커스텀 질문 ID", required = true)
@@ -137,10 +128,8 @@ public class CustomQuestionController {
       description = "특정 커스텀 질문을 조회합니다.",
       responses = {
           @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = CustomQuestionResponse.class))),
-          @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
           @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
           @ApiResponse(responseCode = "404", description = "커스텀 질문을 찾을 수 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
-          @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
       },
       parameters = {
           @Parameter(name = "id", description = "조회할 커스텀 질문 ID", required = true)

--- a/back/src/main/java/com/qmate/api/question/QuestionCategoryController.java
+++ b/back/src/main/java/com/qmate/api/question/QuestionCategoryController.java
@@ -33,6 +33,9 @@ public class QuestionCategoryController {
 
   private final QuestionCategoryService questionCategoryService;
 
+  /**
+   * 카테고리 생성
+   */
   @PostMapping
   @Operation(
       summary = "카테고리 생성",
@@ -44,10 +47,7 @@ public class QuestionCategoryController {
       responses = {
           @ApiResponse(responseCode = "201", description = "생성 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = QuestionCategoryResponse.class))),
           @ApiResponse(responseCode = "400", description = "유효하지 않은 요청 값", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
-          @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
-          @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
           @ApiResponse(responseCode = "409", description = "이미 존재하는 카테고리명", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
-          @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
       }
   )
   // @PostMapping
@@ -71,11 +71,8 @@ public class QuestionCategoryController {
       responses = {
           @ApiResponse(responseCode = "200", description = "수정 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = QuestionCategoryResponse.class))),
           @ApiResponse(responseCode = "400", description = "유효하지 않은 요청 값", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
-          @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
-          @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
           @ApiResponse(responseCode = "404", description = "대상 카테고리 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
           @ApiResponse(responseCode = "409", description = "이미 존재하는 카테고리명", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
-          @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
       }
   )
   // @PatchMapping("/{id}")
@@ -95,9 +92,6 @@ public class QuestionCategoryController {
       description = "모든 질문 카테고리를 조회합니다.",
       responses = {
           @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = QuestionCategoryResponse.class))),
-          @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
-          @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
-          @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
       }
   )
   //@GetMapping

--- a/back/src/main/java/com/qmate/api/question/QuestionCategoryController.java
+++ b/back/src/main/java/com/qmate/api/question/QuestionCategoryController.java
@@ -4,6 +4,13 @@ import com.qmate.domain.question.model.request.QuestionCategoryCreateRequest;
 import com.qmate.domain.question.model.request.QuestionCategoryUpdateRequest;
 import com.qmate.domain.question.model.response.QuestionCategoryResponse;
 import com.qmate.domain.question.service.QuestionCategoryService;
+import com.qmate.exception.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -20,14 +27,30 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/admin/question-categories")
 @RequiredArgsConstructor
+@Tag(name = "Question Category (Admin)", description = "질문 카테고리 관리 API")
+@SecurityRequirement(name = "bearerAuth")
 public class QuestionCategoryController {
 
   private final QuestionCategoryService questionCategoryService;
 
-  /**
-   * 카테고리 생성
-   */
   @PostMapping
+  @Operation(
+      summary = "카테고리 생성",
+      description = "새로운 질문 카테고리를 생성합니다.",
+      requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+          required = true,
+          content = @Content(mediaType = "application/json", schema = @Schema(implementation = QuestionCategoryCreateRequest.class))
+      ),
+      responses = {
+          @ApiResponse(responseCode = "201", description = "생성 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = QuestionCategoryResponse.class))),
+          @ApiResponse(responseCode = "400", description = "유효하지 않은 요청 값", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = "409", description = "이미 존재하는 카테고리명", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
+      }
+  )
+  // @PostMapping
   public ResponseEntity<QuestionCategoryResponse> createCategory(
       @RequestBody @Valid QuestionCategoryCreateRequest request) {
     QuestionCategoryResponse response = questionCategoryService.createCategory(request);
@@ -38,6 +61,24 @@ public class QuestionCategoryController {
    * 카테고리 수정
    */
   @PatchMapping("/{id}")
+  @Operation(
+      summary = "카테고리 수정",
+      description = "기존 질문 카테고리를 부분 수정합니다.",
+      requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+          required = true,
+          content = @Content(mediaType = "application/json", schema = @Schema(implementation = QuestionCategoryUpdateRequest.class))
+      ),
+      responses = {
+          @ApiResponse(responseCode = "200", description = "수정 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = QuestionCategoryResponse.class))),
+          @ApiResponse(responseCode = "400", description = "유효하지 않은 요청 값", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = "404", description = "대상 카테고리 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = "409", description = "이미 존재하는 카테고리명", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
+      }
+  )
+  // @PatchMapping("/{id}")
   public ResponseEntity<QuestionCategoryResponse> updateCategory(
       @PathVariable Long id,
       @RequestBody @Valid QuestionCategoryUpdateRequest request) {
@@ -49,6 +90,17 @@ public class QuestionCategoryController {
    * 카테고리 전체 조회
    */
   @GetMapping
+  @Operation(
+      summary = "카테고리 전체 조회",
+      description = "모든 질문 카테고리를 조회합니다.",
+      responses = {
+          @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = QuestionCategoryResponse.class))),
+          @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
+      }
+  )
+  //@GetMapping
   public ResponseEntity<List<QuestionCategoryResponse>> getAllCategories() {
     List<QuestionCategoryResponse> response = questionCategoryService.getAllCategories();
     return ResponseEntity.ok(response);

--- a/back/src/main/java/com/qmate/api/question/QuestionCategoryController.java
+++ b/back/src/main/java/com/qmate/api/question/QuestionCategoryController.java
@@ -9,7 +9,6 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -18,7 +17,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-// TODO 관리자 권한 설정 -> SecurityConfig에서 /admin/** 경로에 대해 관리자 권한 설정 필요
 @RestController
 @RequestMapping("/api/admin/question-categories")
 @RequiredArgsConstructor

--- a/back/src/main/java/com/qmate/api/question/QuestionController.java
+++ b/back/src/main/java/com/qmate/api/question/QuestionController.java
@@ -50,9 +50,6 @@ public class QuestionController {
       responses = {
           @ApiResponse(responseCode = "201", description = "생성 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = QuestionResponse.class))),
           @ApiResponse(responseCode = "400", description = "유효하지 않은 요청 값", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
-          @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
-          @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
-          @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
       },
       requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
           required = true,
@@ -75,10 +72,7 @@ public class QuestionController {
       responses = {
           @ApiResponse(responseCode = "200", description = "수정 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = QuestionResponse.class))),
           @ApiResponse(responseCode = "400", description = "유효하지 않은 요청 값", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
-          @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
-          @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
-          @ApiResponse(responseCode = "404", description = "리소스 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
-          @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
+          @ApiResponse(responseCode = "404", description = "해당 질문 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
       },
       requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
           required = true,
@@ -105,9 +99,6 @@ public class QuestionController {
       responses = {
           @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = QuestionResponse.class))),
           @ApiResponse(responseCode = "400", description = "유효하지 않은 요청 값", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
-          @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
-          @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
-          @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
       },
       parameters = {
           @Parameter(name = "relationType", description = "질문의 관계 타입", required = false, schema = @Schema(implementation = RelationType.class)),

--- a/back/src/main/java/com/qmate/api/question/QuestionController.java
+++ b/back/src/main/java/com/qmate/api/question/QuestionController.java
@@ -1,23 +1,17 @@
 package com.qmate.api.question;
 
 import com.qmate.domain.question.entity.RelationType;
-import com.qmate.domain.question.model.request.QuestionCategoryCreateRequest;
-import com.qmate.domain.question.model.request.QuestionCategoryUpdateRequest;
 import com.qmate.domain.question.model.request.QuestionCreateRequest;
 import com.qmate.domain.question.model.request.QuestionUpdateRequest;
-import com.qmate.domain.question.model.response.QuestionCategoryResponse;
 import com.qmate.domain.question.model.response.QuestionResponse;
-import com.qmate.domain.question.service.QuestionCategoryService;
 import com.qmate.domain.question.service.QuestionService;
 import jakarta.validation.Valid;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -28,7 +22,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-// TODO 관리자 권한 설정 -> SecurityConfig에서 /admin/** 경로에 대해 관리자 권한 설정 필요
 @RestController
 @RequestMapping("/api/admin/questions")
 @RequiredArgsConstructor

--- a/back/src/main/java/com/qmate/api/question/QuestionController.java
+++ b/back/src/main/java/com/qmate/api/question/QuestionController.java
@@ -5,8 +5,17 @@ import com.qmate.domain.question.model.request.QuestionCreateRequest;
 import com.qmate.domain.question.model.request.QuestionUpdateRequest;
 import com.qmate.domain.question.model.response.QuestionResponse;
 import com.qmate.domain.question.service.QuestionService;
+import com.qmate.exception.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -25,6 +34,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/admin/questions")
 @RequiredArgsConstructor
+@Tag(name = "Question (Admin)", description = "질문 관리 API")
+@SecurityRequirement(name = "bearerAuth")
 public class QuestionController {
 
   private final QuestionService questionService;
@@ -33,6 +44,22 @@ public class QuestionController {
    * 질문 생성
    */
   @PostMapping
+  @Operation(
+      summary = "질문 생성",
+      description = "새로운 질문을 생성합니다.",
+      responses = {
+          @ApiResponse(responseCode = "201", description = "생성 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = QuestionResponse.class))),
+          @ApiResponse(responseCode = "400", description = "유효하지 않은 요청 값", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
+      },
+      requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+          required = true,
+          content = @Content(mediaType = "application/json", schema = @Schema(implementation = QuestionCreateRequest.class))
+      )
+  )
+  // @PostMapping
   public ResponseEntity<QuestionResponse> createQuestion(
       @RequestBody @Valid QuestionCreateRequest request) {
     return ResponseEntity.status(HttpStatus.CREATED).body(questionService.createQuestion(request));
@@ -42,19 +69,59 @@ public class QuestionController {
    * 질문 수정
    */
   @PatchMapping("/{id}")
+  @Operation(
+      summary = "질문 수정",
+      description = "기존 질문을 부분 수정합니다.",
+      responses = {
+          @ApiResponse(responseCode = "200", description = "수정 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = QuestionResponse.class))),
+          @ApiResponse(responseCode = "400", description = "유효하지 않은 요청 값", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = "404", description = "리소스 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
+      },
+      requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+          required = true,
+          content = @Content(mediaType = "application/json", schema = @Schema(implementation = QuestionUpdateRequest.class))
+      ),
+      parameters = {
+          @Parameter(name = "id", description = "수정할 질문 ID", required = true)
+      }
+  )
+  //@PatchMapping("/{id}")
   public ResponseEntity<QuestionResponse> updateQuestion(
       @PathVariable Long id,
       @RequestBody @Valid QuestionUpdateRequest request) {
     return ResponseEntity.ok(questionService.updateQuestion(id, request));
   }
 
+  /**
+   * 질문 전체 조회 (필터링 및 페이징)
+   */
   @GetMapping
+  @Operation(
+      summary = "질문 전체 조회 (필터링 및 페이징)",
+      description = "질문을 필터링 조건에 따라 페이징하여 조회합니다.",
+      responses = {
+          @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = QuestionResponse.class))),
+          @ApiResponse(responseCode = "400", description = "유효하지 않은 요청 값", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
+      },
+      parameters = {
+          @Parameter(name = "relationType", description = "질문의 관계 타입", required = false, schema = @Schema(implementation = RelationType.class)),
+          @Parameter(name = "categoryId", description = "질문의 카테고리 ID", required = false),
+          @Parameter(name = "active", description = "활성화 여부 (true/false)", required = false),
+      }
+  )
+  //@GetMapping
   public ResponseEntity<Page<QuestionResponse>> getQuestions(
       @RequestParam(required = false) RelationType relationType,
       @RequestParam(required = false) Long categoryId,
       @RequestParam(name = "active", required = false) Boolean active,
       @PageableDefault(page = 0, size = 20, sort = "createdAt", direction = Sort.Direction.DESC)
-      Pageable pageable) {
+      @ParameterObject Pageable pageable) {
     Page<QuestionResponse> result = questionService.getQuestions(relationType, categoryId, active, pageable);
     return ResponseEntity.ok(result);
   }

--- a/back/src/main/java/com/qmate/domain/question/mapper/QuestionCategoryMapper.java
+++ b/back/src/main/java/com/qmate/domain/question/mapper/QuestionCategoryMapper.java
@@ -24,7 +24,7 @@ public class QuestionCategoryMapper {
     return new QuestionCategoryResponse(
         category.getId(),
         category.getName(),
-        category.getRelationType().name(),
+        category.getRelationType(),
         category.isActive()
     );
   }

--- a/back/src/main/java/com/qmate/domain/question/mapper/QuestionMapper.java
+++ b/back/src/main/java/com/qmate/domain/question/mapper/QuestionMapper.java
@@ -10,6 +10,7 @@ import com.qmate.domain.question.model.request.QuestionUpdateRequest;
 import com.qmate.domain.question.model.response.CategoryInfo;
 import com.qmate.domain.question.model.response.CustomQuestionResponse;
 import com.qmate.domain.question.model.response.QuestionResponse;
+import com.qmate.domain.question.model.response.SourceType;
 import java.time.format.DateTimeFormatter;
 import lombok.NoArgsConstructor;
 
@@ -54,8 +55,8 @@ public class QuestionMapper {
 
     return new QuestionResponse(
         q.getId(),
-        "ADMIN",
-        q.getRelationType().name(),
+        SourceType.ADMIN,
+        q.getRelationType(),
         categoryInfo,
         q.getText(),
         q.isActive(),
@@ -79,8 +80,8 @@ public class QuestionMapper {
     Match match = preloadedMatch != null ? preloadedMatch : cq.getMatch();
     return new CustomQuestionResponse(
         cq.getId(),
-        "CUSTOM",
-        match.getRelationType().name(),
+        SourceType.CUSTOM,
+        match.getRelationType(),
         match.getId(),
         cq.getText(),
         isEditable,

--- a/back/src/main/java/com/qmate/domain/question/model/request/QuestionCategoryCreateRequest.java
+++ b/back/src/main/java/com/qmate/domain/question/model/request/QuestionCategoryCreateRequest.java
@@ -2,7 +2,7 @@ package com.qmate.domain.question.model.request;
 
 import com.qmate.common.constants.question.QuestionCategoryConstants;
 import com.qmate.domain.question.entity.RelationType;
-import jakarta.validation.constraints.NotBlank;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
@@ -21,5 +21,6 @@ public class QuestionCategoryCreateRequest {
   private String name;
 
   @NotNull(message = QuestionCategoryConstants.RELATION_TYPE_NOT_BLANK_MESSAGE)
+  // @Schema(description = "카테고리의 관계 유형", implementation = RelationType.class)
   private RelationType relationType;
 }

--- a/back/src/main/java/com/qmate/domain/question/model/response/CustomQuestionResponse.java
+++ b/back/src/main/java/com/qmate/domain/question/model/response/CustomQuestionResponse.java
@@ -1,6 +1,7 @@
 package com.qmate.domain.question.model.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.qmate.domain.match.RelationType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,8 +14,8 @@ import lombok.Setter;
 public class CustomQuestionResponse {
 
   private Long customQuestionId;
-  private String sourceType;     // "ADMIN" | "CUSTOM"
-  private String relationType;   // "COUPLE" | "FRIEND" | "BOTH"
+  private SourceType sourceType;     // "ADMIN" | "CUSTOM"
+  private RelationType relationType;   // "COUPLE" | "FRIEND"
   private Long matchId;
 
   private String text;

--- a/back/src/main/java/com/qmate/domain/question/model/response/QuestionCategoryResponse.java
+++ b/back/src/main/java/com/qmate/domain/question/model/response/QuestionCategoryResponse.java
@@ -1,5 +1,6 @@
 package com.qmate.domain.question.model.response;
 
+import com.qmate.domain.question.entity.RelationType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,6 +14,6 @@ public class QuestionCategoryResponse {
 
   private Long id;
   private String name;
-  private String relationType;
+  private RelationType relationType;
   private boolean isActive;
 }

--- a/back/src/main/java/com/qmate/domain/question/model/response/QuestionResponse.java
+++ b/back/src/main/java/com/qmate/domain/question/model/response/QuestionResponse.java
@@ -1,6 +1,7 @@
 package com.qmate.domain.question.model.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.qmate.domain.question.entity.RelationType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,8 +14,8 @@ import lombok.Setter;
 public class QuestionResponse {
 
   private Long questionId;
-  private String sourceType;     // "ADMIN" | "CUSTOM"
-  private String relationType;   // "COUPLE" | "FRIEND" | "BOTH"
+  private SourceType sourceType;     // "ADMIN" | "CUSTOM"
+  private RelationType relationType;   // "COUPLE" | "FRIEND" | "BOTH"
 
   private CategoryInfo category;
 

--- a/back/src/main/java/com/qmate/domain/question/model/response/SourceType.java
+++ b/back/src/main/java/com/qmate/domain/question/model/response/SourceType.java
@@ -1,0 +1,5 @@
+package com.qmate.domain.question.model.response;
+
+public enum SourceType {
+  ADMIN, CUSTOM
+}

--- a/back/src/main/java/com/qmate/domain/question/service/CustomQuestionService.java
+++ b/back/src/main/java/com/qmate/domain/question/service/CustomQuestionService.java
@@ -28,7 +28,6 @@ public class CustomQuestionService {
    * @param request 질문 생성 요청
    * @return 생성된 커스텀 질문 정보
    */
-  @Transactional
   public CustomQuestionResponse create(Long userId, Long matchId, CustomQuestionTextRequest request) {
 
     // Match 존재 여부 확인 및 로드

--- a/back/src/main/java/com/qmate/domain/question/service/CustomQuestionService.java
+++ b/back/src/main/java/com/qmate/domain/question/service/CustomQuestionService.java
@@ -1,14 +1,13 @@
 package com.qmate.domain.question.service;
 
-import com.qmate.common.constants.question.QuestionConstants;
 import com.qmate.domain.match.Match;
 import com.qmate.domain.question.entity.CustomQuestion;
-import com.qmate.domain.question.entity.RelationType;
 import com.qmate.domain.question.mapper.QuestionMapper;
 import com.qmate.domain.question.model.request.CustomQuestionTextRequest;
 import com.qmate.domain.question.model.response.CustomQuestionResponse;
 import com.qmate.domain.question.repository.CustomQuestionRepository;
-import jakarta.persistence.EntityNotFoundException;
+import com.qmate.exception.custom.question.CustomQuestionForbiddenException;
+import com.qmate.exception.custom.question.CustomQuestionNotFoundException;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -59,12 +58,10 @@ public class CustomQuestionService {
 
     // 본인 질문인지 확인
     if (!Objects.equals(entity.getCreatedBy().getId(), userId)) {
-      // TODO 커스텀 예외 처리
-      throw new RuntimeException(QuestionConstants.CUSTOM_QUESTION_FORBIDDEN_MESSAGE);
+      throw new CustomQuestionForbiddenException();
     }
 
     // TODO 수정 가능한 상태인지 확인 : QuestionInstance 존재 여부로 판단
-
 
     entity.setText(request.getText().trim());
 
@@ -83,8 +80,7 @@ public class CustomQuestionService {
     CustomQuestion entity = loadOrThrow(id);
     // 본인 질문인지 확인
     if (!Objects.equals(entity.getCreatedBy().getId(), userId)) {
-      // TODO 커스텀 예외 처리
-      throw new RuntimeException(QuestionConstants.CUSTOM_QUESTION_FORBIDDEN_MESSAGE);
+      throw new CustomQuestionForbiddenException();
     }
     // TODO 삭제 가능한 상태인지 확인 : QuestionInstance 존재 여부로 판단
     customQuestionRepository.delete(entity);
@@ -100,8 +96,7 @@ public class CustomQuestionService {
     CustomQuestion entity = loadWithMatchOrThrow(id);
     // 본인 질문인지 확인
     if (!Objects.equals(entity.getCreatedBy().getId(), userId)) {
-      // TODO 커스텀 예외 처리
-      throw new RuntimeException(QuestionConstants.CUSTOM_QUESTION_FORBIDDEN_MESSAGE);
+      throw new CustomQuestionForbiddenException();
     }
     boolean editable = true; // TODO QuestionInstance 존재 여부로 판단
     return QuestionMapper.toResponse(entity, editable, entity.getMatch());
@@ -114,13 +109,11 @@ public class CustomQuestionService {
 
   private CustomQuestion loadOrThrow(Long id) {
     return customQuestionRepository.findById(id)
-        // TODO 커스텀 예외 처리
-        .orElseThrow(() -> new EntityNotFoundException(QuestionConstants.CUSTOM_QUESTION_NOT_FOUND_MESSAGE));
+        .orElseThrow(CustomQuestionNotFoundException::new);
   }
 
   private CustomQuestion loadWithMatchOrThrow(Long id) {
     return customQuestionRepository.findWithMatchById(id)
-        // TODO 커스텀 예외 처리
-        .orElseThrow(() -> new EntityNotFoundException(QuestionConstants.CUSTOM_QUESTION_NOT_FOUND_MESSAGE));
+        .orElseThrow(CustomQuestionNotFoundException::new);
   }
 }

--- a/back/src/main/java/com/qmate/domain/question/service/QuestionCategoryService.java
+++ b/back/src/main/java/com/qmate/domain/question/service/QuestionCategoryService.java
@@ -19,7 +19,6 @@ public class QuestionCategoryService {
 
   private final QuestionCategoryRepository categoryRepository;
 
-  @Transactional
   public QuestionCategoryResponse createCategory(QuestionCategoryCreateRequest request) {
     if (categoryRepository.existsByName(request.getName())) {
       throw new QuestionCategoryAlreadyExistException();

--- a/back/src/main/java/com/qmate/domain/question/service/QuestionCategoryService.java
+++ b/back/src/main/java/com/qmate/domain/question/service/QuestionCategoryService.java
@@ -1,13 +1,13 @@
 package com.qmate.domain.question.service;
 
-import com.qmate.common.constants.question.QuestionCategoryConstants;
 import com.qmate.domain.question.entity.QuestionCategory;
 import com.qmate.domain.question.mapper.QuestionCategoryMapper;
 import com.qmate.domain.question.model.request.QuestionCategoryCreateRequest;
 import com.qmate.domain.question.model.request.QuestionCategoryUpdateRequest;
 import com.qmate.domain.question.model.response.QuestionCategoryResponse;
 import com.qmate.domain.question.repository.QuestionCategoryRepository;
-import jakarta.persistence.EntityNotFoundException;
+import com.qmate.exception.custom.question.QuestionCategoryAlreadyExistException;
+import com.qmate.exception.custom.question.QuestionCategoryNotFoundException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -22,8 +22,7 @@ public class QuestionCategoryService {
   @Transactional
   public QuestionCategoryResponse createCategory(QuestionCategoryCreateRequest request) {
     if (categoryRepository.existsByName(request.getName())) {
-      // TODO 커스텀 예외로 변경
-      throw new IllegalArgumentException(QuestionCategoryConstants.CATEGORY_ALREADY_EXISTS_MESSAGE);
+      throw new QuestionCategoryAlreadyExistException();
     }
     QuestionCategory category = QuestionCategoryMapper.toEntity(request);
     QuestionCategory saved = categoryRepository.save(category);
@@ -33,14 +32,13 @@ public class QuestionCategoryService {
   @Transactional
   public QuestionCategoryResponse updateCategory(Long id, QuestionCategoryUpdateRequest request) {
     QuestionCategory category = categoryRepository.findById(id)
-        // TODO 커스텀 예외로 변경
-        .orElseThrow(() -> new EntityNotFoundException(QuestionCategoryConstants.CATEGORY_NOT_FOUND_MESSAGE));
-    if (request.getName() != null && !request.getName().equals(category.getName())) {
-      if (categoryRepository.existsByName(request.getName())) {
-        // TODO 커스텀 예외로 변경
-        throw new IllegalArgumentException(QuestionCategoryConstants.CATEGORY_ALREADY_EXISTS_MESSAGE);
-      }
+        .orElseThrow(QuestionCategoryNotFoundException::new);
+    if (request.getName() != null &&
+        !request.getName().equals(category.getName()) &&
+        categoryRepository.existsByName(request.getName())) {
+      throw new QuestionCategoryAlreadyExistException();
     }
+
     QuestionCategoryMapper.updateEntity(category, request);
     return QuestionCategoryMapper.toResponse(category);
   }

--- a/back/src/main/java/com/qmate/domain/question/service/QuestionService.java
+++ b/back/src/main/java/com/qmate/domain/question/service/QuestionService.java
@@ -1,7 +1,5 @@
 package com.qmate.domain.question.service;
 
-import com.qmate.common.constants.question.QuestionCategoryConstants;
-import com.qmate.common.constants.question.QuestionConstants;
 import com.qmate.domain.question.entity.Question;
 import com.qmate.domain.question.entity.QuestionCategory;
 import com.qmate.domain.question.entity.RelationType;
@@ -12,7 +10,8 @@ import com.qmate.domain.question.model.response.QuestionResponse;
 import com.qmate.domain.question.repository.QuestionCategoryRepository;
 import com.qmate.domain.question.repository.QuestionRepository;
 import com.qmate.domain.question.repository.QuestionSpecs;
-import jakarta.persistence.EntityNotFoundException;
+import com.qmate.exception.custom.question.QuestionNotFoundException;
+import com.qmate.exception.custom.question.QuestionCategoryNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -33,7 +32,6 @@ public class QuestionService {
    * @param request 질문 생성 요청
    * @return 생성된 질문 정보
    */
-  @Transactional
   public QuestionResponse createQuestion(QuestionCreateRequest request) {
     // 카테고리 존재 여부 확인
     QuestionCategory category = loadCategoryOrThrow(request.getCategoryId());
@@ -93,15 +91,13 @@ public class QuestionService {
   // 존재하지 않는 질문 조회 시 예외 발생
   private Question loadQuestionOrThrow(Long id) {
     return questionRepository.findById(id)
-        // TODO 커스텀 예외로 변경
-        .orElseThrow(() -> new EntityNotFoundException(QuestionConstants.QUESTION_NOT_FOUND_MESSAGE));
+        .orElseThrow(QuestionNotFoundException::new);
   }
 
   // 존재하지 않는 카테고리 조회 시 예외 발생
   private QuestionCategory loadCategoryOrThrow(Long categoryId) {
     return categoryRepository.findById(categoryId)
-        // TODO 커스텀 예외로 변경
-        .orElseThrow(() -> new EntityNotFoundException(QuestionCategoryConstants.CATEGORY_NOT_FOUND_MESSAGE));
+        .orElseThrow(QuestionCategoryNotFoundException::new);
   }
 
 }

--- a/back/src/main/java/com/qmate/exception/custom/question/CustomQuestionForbiddenException.java
+++ b/back/src/main/java/com/qmate/exception/custom/question/CustomQuestionForbiddenException.java
@@ -1,0 +1,12 @@
+package com.qmate.exception.custom.question;
+
+import com.qmate.exception.BusinessGlobalException;
+import com.qmate.exception.errorcode.CustomQuestionErrorCode;
+
+public class CustomQuestionForbiddenException extends BusinessGlobalException {
+
+  public CustomQuestionForbiddenException() {
+    super(CustomQuestionErrorCode.customQuestionForbidden());
+  }
+
+}

--- a/back/src/main/java/com/qmate/exception/custom/question/CustomQuestionNotFoundException.java
+++ b/back/src/main/java/com/qmate/exception/custom/question/CustomQuestionNotFoundException.java
@@ -1,0 +1,12 @@
+package com.qmate.exception.custom.question;
+
+import com.qmate.exception.BusinessGlobalException;
+import com.qmate.exception.errorcode.CustomQuestionErrorCode;
+
+public class CustomQuestionNotFoundException extends BusinessGlobalException {
+
+  public CustomQuestionNotFoundException() {
+    super(CustomQuestionErrorCode.customQuestionNotFound());
+  }
+
+}

--- a/back/src/main/java/com/qmate/exception/custom/question/QuestionCategoryAlreadyExistException.java
+++ b/back/src/main/java/com/qmate/exception/custom/question/QuestionCategoryAlreadyExistException.java
@@ -1,0 +1,12 @@
+package com.qmate.exception.custom.question;
+
+import com.qmate.exception.BusinessGlobalException;
+import com.qmate.exception.errorcode.QuestionCategoryErrorCode;
+
+public class QuestionCategoryAlreadyExistException extends BusinessGlobalException {
+
+  public QuestionCategoryAlreadyExistException() {
+    super(QuestionCategoryErrorCode.categoryNameAlreadyExists());
+  }
+
+}

--- a/back/src/main/java/com/qmate/exception/custom/question/QuestionCategoryNotFoundException.java
+++ b/back/src/main/java/com/qmate/exception/custom/question/QuestionCategoryNotFoundException.java
@@ -1,0 +1,12 @@
+package com.qmate.exception.custom.question;
+
+import com.qmate.exception.BusinessGlobalException;
+import com.qmate.exception.errorcode.QuestionCategoryErrorCode;
+
+public class QuestionCategoryNotFoundException extends BusinessGlobalException {
+
+  public QuestionCategoryNotFoundException() {
+    super(QuestionCategoryErrorCode.categoryNotFound());
+  }
+
+}

--- a/back/src/main/java/com/qmate/exception/custom/question/QuestionNotFoundException.java
+++ b/back/src/main/java/com/qmate/exception/custom/question/QuestionNotFoundException.java
@@ -1,0 +1,12 @@
+package com.qmate.exception.custom.question;
+
+import com.qmate.exception.BusinessGlobalException;
+import com.qmate.exception.errorcode.QuestionErrorCode;
+
+public class QuestionNotFoundException extends BusinessGlobalException {
+
+  public QuestionNotFoundException() {
+    super(QuestionErrorCode.questionNotFound());
+  }
+
+}

--- a/back/src/main/java/com/qmate/exception/errorcode/CustomQuestionErrorCode.java
+++ b/back/src/main/java/com/qmate/exception/errorcode/CustomQuestionErrorCode.java
@@ -1,0 +1,23 @@
+package com.qmate.exception.errorcode;
+
+import com.qmate.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class CustomQuestionErrorCode extends ErrorCode {
+
+  private static final String CUSTOM_QUESTION_NOT_FOUND_MESSAGE = "해당 커스텀 질문을 찾을 수 없습니다.";
+  private static final String CUSTOM_QUESTION_FORBIDDEN_MESSAGE = "본인이 생성한 질문만 수정/삭제할 수 있습니다.";
+
+  public static ErrorCode customQuestionNotFound() {
+    return new CustomQuestionErrorCode(HttpStatus.NOT_FOUND, "CQ_001", CUSTOM_QUESTION_NOT_FOUND_MESSAGE);
+  }
+
+  public static ErrorCode customQuestionForbidden() {
+    return new CustomQuestionErrorCode(HttpStatus.FORBIDDEN, "CQ_002", CUSTOM_QUESTION_FORBIDDEN_MESSAGE);
+  }
+
+  private CustomQuestionErrorCode(HttpStatus httpStatus, String code, String message) {
+    super(httpStatus, code, message);
+  }
+
+}

--- a/back/src/main/java/com/qmate/exception/errorcode/QuestionCategoryErrorCode.java
+++ b/back/src/main/java/com/qmate/exception/errorcode/QuestionCategoryErrorCode.java
@@ -1,0 +1,23 @@
+package com.qmate.exception.errorcode;
+
+import com.qmate.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class QuestionCategoryErrorCode extends ErrorCode {
+
+  private static final String CATEGORY_NOT_FOUND_MESSAGE = "해당 질문 카테고리를 찾을 수 없습니다.";
+  private static final String CATEGORY_NAME_ALREADY_EXISTS_MESSAGE = "이미 존재하는 카테고리 이름입니다.";
+
+  public static ErrorCode categoryNotFound() {
+    return new QuestionCategoryErrorCode(HttpStatus.NOT_FOUND, "QC_001", CATEGORY_NOT_FOUND_MESSAGE);
+  }
+
+  public static ErrorCode categoryNameAlreadyExists() {
+    return new QuestionCategoryErrorCode(HttpStatus.CONFLICT, "QC_002", CATEGORY_NAME_ALREADY_EXISTS_MESSAGE);
+  }
+
+  private QuestionCategoryErrorCode(HttpStatus httpStatus, String code, String message) {
+    super(httpStatus, code, message);
+  }
+
+}

--- a/back/src/main/java/com/qmate/exception/errorcode/QuestionErrorCode.java
+++ b/back/src/main/java/com/qmate/exception/errorcode/QuestionErrorCode.java
@@ -1,0 +1,17 @@
+package com.qmate.exception.errorcode;
+
+import com.qmate.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class QuestionErrorCode extends ErrorCode {
+
+  private static final String QUESTION_NOT_FOUND_MESSAGE = "해당 질문을 찾을 수 없습니다.";
+
+  public static ErrorCode questionNotFound() {
+    return new QuestionErrorCode(HttpStatus.NOT_FOUND, "Question_001", QUESTION_NOT_FOUND_MESSAGE);
+  }
+
+  private QuestionErrorCode(HttpStatus httpStatus, String code, String message) {
+    super(httpStatus, code, message);
+  }
+}


### PR DESCRIPTION
## 개요
- 세 리소스(question, question-category, custom-question)에 대해 API 문서 보강, Principal 주입 표준화, 커스텀 예외처리를 일괄 적용

## 변경 항목 요약

### question
- NotFound 예외 치환
- 목록/생성/수정 엔드포인트 문서화(응답/에러 응답 명세 포함)

### question-category
- CategoryNotFound/CategoryAlreadyExist 커스텀 예외 적용
- 전체 조회/생성/부분수정 엔드포인트 문서화

### custom-question
- 컨트롤러에 UserPrincipal 주입 및 userId 전파
- 소유자/멤버십 검증 시 Forbidden 예외로 정규화
- 단건/생성/수정/삭제 흐름의 예외 치환
- 엔드포인트 문서화