### PR TITLE
Feature/match disconnect restore

### DIFF
--- a/back/src/main/java/com/qmate/api/MatchController.java
+++ b/back/src/main/java/com/qmate/api/MatchController.java
@@ -114,4 +114,15 @@ public class MatchController {
 
     return ResponseEntity.ok(new MatchActionResponse(MatchConstants.DISCONNECT_SUCCESS_MESSAGE));
   }
+  //매칭 연결 복구
+  @PostMapping("/{matchId}/restore")
+  public ResponseEntity<MatchActionResponse> restoreMatch(
+      @PathVariable Long matchId,
+      @AuthenticationPrincipal UserPrincipal principal
+  ){
+    Long currentUserId = principal.userId();
+    matchService.restoreMatch(matchId, currentUserId);
+
+    return ResponseEntity.ok(new MatchActionResponse(MatchConstants.RESTORE_SUCCESS_MESSAGE));
+  }
 }

--- a/back/src/main/java/com/qmate/api/MatchController.java
+++ b/back/src/main/java/com/qmate/api/MatchController.java
@@ -1,8 +1,10 @@
 package com.qmate.api;
 
+import com.qmate.common.constants.match.MatchConstants;
 import com.qmate.domain.match.model.request.MatchCreationRequest;
 import com.qmate.domain.match.model.request.MatchJoinRequest;
 import com.qmate.domain.match.model.request.MatchUpdateRequest;
+import com.qmate.domain.match.model.response.MatchActionResponse;
 import com.qmate.domain.match.model.response.MatchCreationResponse;
 import com.qmate.domain.match.model.response.MatchInfoResponse;
 import com.qmate.domain.match.model.response.MatchJoinResponse;
@@ -100,5 +102,16 @@ public class MatchController {
     matchService.updateMatchInfo(matchId, currentUserId, request);
     // 성공적으로 처리되었지만, 별도의 응답 본문은 없다는 의미로 204 No Content를 반환
     return ResponseEntity.noContent().build();
+  }
+  //매칭 연결을 끊습니다.(2주간의 복구 유예 기간 시작)
+  @PostMapping("/{matchId}/disconnect")
+  public ResponseEntity<MatchActionResponse> disconnectMatch(
+      @PathVariable Long matchId,
+      @AuthenticationPrincipal UserPrincipal principal
+  ){
+    Long currentUserId = principal.userId();
+    matchService.disconnectMatch(matchId, currentUserId);
+
+    return ResponseEntity.ok(new MatchActionResponse(MatchConstants.DISCONNECT_SUCCESS_MESSAGE));
   }
 }

--- a/back/src/main/java/com/qmate/api/MatchController.java
+++ b/back/src/main/java/com/qmate/api/MatchController.java
@@ -121,8 +121,13 @@ public class MatchController {
       @AuthenticationPrincipal UserPrincipal principal
   ){
     Long currentUserId = principal.userId();
-    matchService.restoreMatch(matchId, currentUserId);
+    boolean isFullyRestored = matchService.restoreMatch(matchId, currentUserId);
 
-    return ResponseEntity.ok(new MatchActionResponse(MatchConstants.RESTORE_SUCCESS_MESSAGE));
+    //서비스의 결과에 따른 메세지를 선태
+    String message = isFullyRestored
+        ? MatchConstants.RESTORE_SUCCESS_MESSAGE
+        : MatchConstants.RESTORE_AGREED_AWAITING_PARTNER_MESSAGE;
+
+    return ResponseEntity.ok(new MatchActionResponse(message));
   }
 }

--- a/back/src/main/java/com/qmate/api/MatchController.java
+++ b/back/src/main/java/com/qmate/api/MatchController.java
@@ -8,10 +8,12 @@ import com.qmate.domain.match.model.response.MatchInfoResponse;
 import com.qmate.domain.match.model.response.MatchJoinResponse;
 import com.qmate.domain.match.model.response.MatchMembersResponse;
 import com.qmate.domain.match.service.MatchService;
+import com.qmate.security.UserPrincipal;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -30,15 +32,12 @@ public class MatchController {
   //매칭 생성(초대 코드 발급)
   @PostMapping
   public ResponseEntity<MatchCreationResponse> createMatch(
-      @RequestBody @Valid MatchCreationRequest request
-      // @AuthenticationPrincipal UserDetailsImpl userDetails => spring Security가 로그인한 사용자의 정보를 자동으로 주입
+      @RequestBody @Valid MatchCreationRequest request,
+      @AuthenticationPrincipal UserPrincipal principal
   ) {
-    // (임시) 로그인 기능 구현 전이므로, 사용자 ID를 1L로 가정
-    Long currentUserId = 3L;
-    // Long currentUserId = userDetails.getUser().getUserId(); // 나중에는 이렇게 ID를 가져올 예정.
 
+    Long currentUserId = principal.userId();
     MatchCreationResponse response = matchService.createMatch(request, currentUserId);
-
     // 5. API 명세서에 따라 201 Created 상태 코드와 함께 응답 반환
     return ResponseEntity.status(HttpStatus.CREATED).body(response);
 
@@ -47,19 +46,16 @@ public class MatchController {
   //매칭 참여(초대 코드 입력)
   @PostMapping("/join")
   public ResponseEntity<MatchJoinResponse> joinMatch(
-      @RequestBody @Valid MatchJoinRequest request
-      // @AuthenticationPrincipal UserDetailsImpl userDetails //  나중에 로그인 기능 연동
+      @RequestBody @Valid MatchJoinRequest request,
+      @AuthenticationPrincipal UserPrincipal principal
   ) {
-    // 임시로 참여자 ID를 2L로 가정 (1L은 이미 방을 만들었으므로)
-    Long currentUserId = 4L;
-    // Long currentUserId = userDetails.getUser().getUserId();
-
+    Long currentUserId = principal.userId();
     MatchJoinResponse response = matchService.joinMatch(request, currentUserId);
-
     return ResponseEntity.ok(response); // 200 OK 상태 코드와 함께 응답
 
 
   }
+
   /**
    * 특정 매칭의 상세 정보를 조회합니다.
    *
@@ -68,45 +64,41 @@ public class MatchController {
    */
   @GetMapping("{matchId}")
   public ResponseEntity<MatchInfoResponse> getMatchInfo(
-      @PathVariable Long matchId
-      // @AuthenticationPrincipal UserDetailsImpl userDetails //  나중에 로그인 기능 연동
+      @PathVariable Long matchId,
+      @AuthenticationPrincipal UserPrincipal principal
   ) {
-    Long currentUserId = 3L;
-    // 임시로 사용자 Id를 1L로 가정 Long currentUserId = userDetails.getUser().getId();
+    Long currentUserId = principal.userId();
     MatchInfoResponse response = matchService.getMatchInfo(matchId, currentUserId);
-
     return ResponseEntity.ok(response);
   }
+
   //특정 매칭의 구성원 목록(상세정보)을 조회.
   @GetMapping("/{matchId}/members")
   public ResponseEntity<MatchMembersResponse> getMatchMembers(
-      @PathVariable Long matchId
-      // @AuthenticationPrincipal UserDetailsImpl userDetails
-  ){
-    Long currentUserId = 3L;
-    // Long currentUserId = userDetails.getUser().getId();
-
+      @PathVariable Long matchId,
+      @AuthenticationPrincipal UserPrincipal principal
+  ) {
+    Long currentUserId = principal.userId();
     MatchMembersResponse response = matchService.getMatchMembers(matchId, currentUserId);
     return ResponseEntity.ok(response);
   }
-  /**특정 매칭의 정보를 업데이트(기념일, 질문 받는 시간 등)
+
+  /**
+   * 특정 매칭의 정보를 업데이트(기념일, 질문 받는 시간 등)
+   *
    * @param matchId URL 경로에서 받아온 매칭 ID
    * @param request 업데이트할 정보가 담긴 DTO
    * @return 200 OK 상태 코드와 함께 성공 메시지를 반환
    */
-   @PatchMapping("/{matchId}/info")
+  @PatchMapping("/{matchId}/info")
   public ResponseEntity<Void> updateMatchInfo(
       @PathVariable Long matchId,
-       @RequestBody @Valid MatchUpdateRequest request
-       // @AuthenticationPrincipal UserDetailsImpl userDetails
-   ){
-     // 임시로 요청을 보낸 사용자의 ID를 3L로 가정합니다.
-     Long currentUserId = 3L;
-     // Long currentUserId = userDetails.getUser().getId();
-
-     matchService.updateMatchInfo(matchId, currentUserId,request);
-
-     // 성공적으로 처리되었지만, 별도의 응답 본문은 없다는 의미로 204 No Content를 반환
-     return ResponseEntity.noContent().build();
-   }
+      @RequestBody @Valid MatchUpdateRequest request,
+      @AuthenticationPrincipal UserPrincipal principal
+  ) {
+    Long currentUserId = principal.userId();
+    matchService.updateMatchInfo(matchId, currentUserId, request);
+    // 성공적으로 처리되었지만, 별도의 응답 본문은 없다는 의미로 204 No Content를 반환
+    return ResponseEntity.noContent().build();
+  }
 }

--- a/back/src/main/java/com/qmate/common/constants/match/MatchConstants.java
+++ b/back/src/main/java/com/qmate/common/constants/match/MatchConstants.java
@@ -16,5 +16,5 @@ public class MatchConstants {
 
   // MatchController
   public static final String DISCONNECT_SUCCESS_MESSAGE = "매칭 연결 끊기 요청이 처리되었습니다. 2주 후에 데이터가 삭제됩니다.";
-
+  public static final String RESTORE_SUCCESS_MESSAGE = "매칭이 성공적으로 복구되었습니다.";
 }

--- a/back/src/main/java/com/qmate/common/constants/match/MatchConstants.java
+++ b/back/src/main/java/com/qmate/common/constants/match/MatchConstants.java
@@ -17,4 +17,5 @@ public class MatchConstants {
   // MatchController
   public static final String DISCONNECT_SUCCESS_MESSAGE = "매칭 연결 끊기 요청이 처리되었습니다. 2주 후에 데이터가 삭제됩니다.";
   public static final String RESTORE_SUCCESS_MESSAGE = "매칭이 성공적으로 복구되었습니다.";
+  public static final String RESTORE_AGREED_AWAITING_PARTNER_MESSAGE = "복구에 동의했습니다. 상대방의 동의를 기다려주세요.";
 }

--- a/back/src/main/java/com/qmate/common/constants/match/MatchConstants.java
+++ b/back/src/main/java/com/qmate/common/constants/match/MatchConstants.java
@@ -14,4 +14,7 @@ public class MatchConstants {
   public static final String RELATION_TYPE_NOT_NULL = "관계 유형을 선택해주세요.";
   public static final String VALID_START_DATE_DEFAULT = "연인(COUPLE) 관계는 기념일(startDate)을 필수로 입력해야 합니다.";
 
+  // MatchController
+  public static final String DISCONNECT_SUCCESS_MESSAGE = "매칭 연결 끊기 요청이 처리되었습니다. 2주 후에 데이터가 삭제됩니다.";
+
 }

--- a/back/src/main/java/com/qmate/domain/match/Match.java
+++ b/back/src/main/java/com/qmate/domain/match/Match.java
@@ -84,19 +84,28 @@ public class Match {
     }
     this.status = MatchStatus.DETACHED_PENDING_DELETE;
     this.detachedAt = LocalDateTime.now();
+    this.members.forEach(MatchMember::resetAgreement);
   }
   //끊어진 매칭 연결을 복구합니다.
-  public void restore(){
+  public boolean attemptToRestore() {
     //복구할 수 있는 상태인지 확인
-    if (this.status != MatchStatus.DETACHED_PENDING_DELETE){
+    if (this.status != MatchStatus.DETACHED_PENDING_DELETE) {
       throw new MatchStateConflictException();
     }
-    if (this.detachedAt != null && this.detachedAt.plusWeeks(2).isBefore(LocalDateTime.now())){
+    if (this.detachedAt != null && this.detachedAt.plusWeeks(2).isBefore(LocalDateTime.now())) {
       throw new MatchRecoveryExpiredException();
     }
-    this.status = MatchStatus.ACTIVE;
-    this.detachedAt = null;
+    boolean allAgreed = this.members.stream().allMatch(MatchMember::isAgreed);
+
+    if (allAgreed) {
+      this.status = MatchStatus.ACTIVE;
+      this.detachedAt = null;
+      return true;
+    }
+//아직 상대방이 동의하지 않았다면, 상태를 변경하지 않고 '아직 대기 중'임을 알림
+    return false;
   }
+
 
   //정적 팩토리 메서드 추가
   public static Match create(RelationType relationType, LocalDateTime startDate) {

--- a/back/src/main/java/com/qmate/domain/match/Match.java
+++ b/back/src/main/java/com/qmate/domain/match/Match.java
@@ -1,5 +1,6 @@
 package com.qmate.domain.match;
 
+import com.qmate.exception.custom.matchinstance.MatchRecoveryExpiredException;
 import com.qmate.exception.custom.matchinstance.MatchStateConflictException;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -83,6 +84,18 @@ public class Match {
     }
     this.status = MatchStatus.DETACHED_PENDING_DELETE;
     this.detachedAt = LocalDateTime.now();
+  }
+  //끊어진 매칭 연결을 복구합니다.
+  public void restore(){
+    //복구할 수 있는 상태인지 확인
+    if (this.status != MatchStatus.DETACHED_PENDING_DELETE){
+      throw new MatchStateConflictException();
+    }
+    if (this.detachedAt != null && this.detachedAt.plusWeeks(2).isBefore(LocalDateTime.now())){
+      throw new MatchRecoveryExpiredException();
+    }
+    this.status = MatchStatus.ACTIVE;
+    this.detachedAt = null;
   }
 
   //정적 팩토리 메서드 추가

--- a/back/src/main/java/com/qmate/domain/match/Match.java
+++ b/back/src/main/java/com/qmate/domain/match/Match.java
@@ -1,5 +1,6 @@
 package com.qmate.domain.match;
 
+import com.qmate.exception.custom.matchinstance.MatchStateConflictException;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -73,6 +74,15 @@ public class Match {
   }
   public void updateStartDate(LocalDate startDate) {
     this.startDate = startDate.atStartOfDay();
+  }
+
+  public void disconnect(){
+    //이미 끊어진 관계를 또 끊으려고 하는 것 방지
+    if (this.status != MatchStatus.ACTIVE){
+      throw new MatchStateConflictException();
+    }
+    this.status = MatchStatus.DETACHED_PENDING_DELETE;
+    this.detachedAt = LocalDateTime.now();
   }
 
   //정적 팩토리 메서드 추가

--- a/back/src/main/java/com/qmate/domain/match/MatchMember.java
+++ b/back/src/main/java/com/qmate/domain/match/MatchMember.java
@@ -54,6 +54,14 @@ public class MatchMember {
   public void setMatch(Match match) {
     this.match = match;
   }
+  //복구에 동의하는 메서드
+  public void agreeToRestore(){
+    this.isAgreed = true;
+  }
+  //동의 상태를 초기화하는 메서드
+  public void resetAgreement(){
+    this.isAgreed = false;
+  }
 
   //정적 팩토리 메서드 추가
   public static MatchMember create(User user, Match match) {

--- a/back/src/main/java/com/qmate/domain/match/model/response/MatchActionResponse.java
+++ b/back/src/main/java/com/qmate/domain/match/model/response/MatchActionResponse.java
@@ -1,0 +1,14 @@
+package com.qmate.domain.match.model.response;
+
+import lombok.Getter;
+
+@Getter
+public class MatchActionResponse {
+
+  private final String message;
+
+  public MatchActionResponse(String message){
+    this.message = message;
+  }
+
+}

--- a/back/src/main/java/com/qmate/domain/match/model/response/MatchInfoResponse.java
+++ b/back/src/main/java/com/qmate/domain/match/model/response/MatchInfoResponse.java
@@ -21,7 +21,7 @@ public class MatchInfoResponse {
     this.startDate = match.getStartDate();
     // Match 엔티티가 가진 MatchMember 리스트를 순회하며 MemberInfo DTO 리스트로 변환
     this.users = match.getMembers().stream()
-        .map(matchMember -> new MemberInfoResponse(matchMember.getUser(), requesterId))
+        .map(matchMember -> new MemberInfoResponse(matchMember, requesterId))
         .toList();
   }
 }

--- a/back/src/main/java/com/qmate/domain/match/model/response/MemberInfoResponse.java
+++ b/back/src/main/java/com/qmate/domain/match/model/response/MemberInfoResponse.java
@@ -1,5 +1,6 @@
 package com.qmate.domain.match.model.response;
 
+import com.qmate.domain.match.MatchMember;
 import com.qmate.domain.user.User;
 import lombok.Getter;
 
@@ -9,12 +10,14 @@ public class MemberInfoResponse {
   private final Long userId;
   private final String nickname;
   private final boolean isMe; //본인 여부 필드
+  private final boolean isAgreed;
 
   // User 엔티티를 받아서 필요한 정보만 뽑아내는 생성자
-  public MemberInfoResponse(User user, Long requesterId) {
-    this.userId = user.getId();
-    this.nickname = user.getNickname();
-    this.isMe = user.getId().equals(requesterId);
+  public MemberInfoResponse(MatchMember member, Long requesterId) {
+    this.userId = member.getUser().getId();
+    this.nickname = member.getUser().getNickname();
+    this.isMe = member.getUser().getId().equals(requesterId);
+    this.isAgreed = member.isAgreed();
   }
 
 }

--- a/back/src/main/java/com/qmate/domain/match/service/MatchService.java
+++ b/back/src/main/java/com/qmate/domain/match/service/MatchService.java
@@ -172,6 +172,24 @@ public class MatchService {
     }
   }
 
+  /**
+   * 특정 매칭의 연결을 끊습니다.
+   * @param matchId 연결을 끊을 매칭의 ID
+   * @param userId 요청을 보낸 사용자의 ID(권한 검증용)
+   */
+  @Transactional
+  public void disconnectMatch(Long matchId, Long userId){
+    Match match = matchRepository.findWithMembersAndUsersById(matchId)
+        .orElseThrow(MatchNotFoundException::new);
+    boolean isMember = match.getMembers().stream()
+        .anyMatch(matchMember -> matchMember.getUser().getId().equals(userId));
+    if (!isMember){
+      throw new MatchForbiddenException();
+    }
+    match.disconnect();
+  }
+
+
   //가독성을 위한 private 헬퍼 메서드(초대 생성 관련)
   private void validateUserNotInActiveMatch(Long userId) {
     matchMemberRepository.findByUser_IdAndMatch_Status(userId, MatchStatus.ACTIVE)

--- a/back/src/main/java/com/qmate/domain/match/service/MatchService.java
+++ b/back/src/main/java/com/qmate/domain/match/service/MatchService.java
@@ -189,6 +189,23 @@ public class MatchService {
     match.disconnect();
   }
 
+  /**
+   * 끊어진 매칭 연결을 복구합나다.
+   * @param matchId 복구할 매칭의 ID
+   * @param userId 요청을 보낸 사용자의 ID (권한 검증용)
+   */
+  @Transactional
+  public void restoreMatch(Long matchId, Long userId){
+    Match match = matchRepository.findWithMembersAndUsersById(matchId)
+        .orElseThrow(MatchNotFoundException::new);
+    boolean isMember = match.getMembers().stream()
+        .anyMatch(matchMember -> matchMember.getUser().getId().equals(userId));
+    if (!isMember){
+      throw new MatchForbiddenException();
+    }
+    match.restore();
+  }
+
 
   //가독성을 위한 private 헬퍼 메서드(초대 생성 관련)
   private void validateUserNotInActiveMatch(Long userId) {

--- a/back/src/main/java/com/qmate/domain/match/service/MatchService.java
+++ b/back/src/main/java/com/qmate/domain/match/service/MatchService.java
@@ -190,12 +190,11 @@ public class MatchService {
   }
 
   /**
-   * 끊어진 매칭 연결을 복구합나다.
-   * @param matchId 복구할 매칭의 ID
-   * @param userId 요청을 보낸 사용자의 ID (권한 검증용)
+   * 끊어진 매칭 연결 복구를 시도합니다.
+   * @return 최종 복구 여부 (true: 완전 복구, false: 내 동의만 완료)
    */
   @Transactional
-  public void restoreMatch(Long matchId, Long userId){
+  public boolean restoreMatch(Long matchId, Long userId){
     Match match = matchRepository.findWithMembersAndUsersById(matchId)
         .orElseThrow(MatchNotFoundException::new);
     boolean isMember = match.getMembers().stream()
@@ -203,7 +202,14 @@ public class MatchService {
     if (!isMember){
       throw new MatchForbiddenException();
     }
-    match.restore();
+    //요청자의 MatchMember를 찾습니다.
+    MatchMember requester = match.getMembers().stream()
+            .filter(matchMember -> matchMember.getUser().getId().equals(userId))
+                .findFirst()
+                    .orElseThrow();
+    requester.agreeToRestore();
+
+    return match.attemptToRestore();
   }
 
 

--- a/back/src/main/java/com/qmate/exception/MatchErrorCode.java
+++ b/back/src/main/java/com/qmate/exception/MatchErrorCode.java
@@ -16,6 +16,7 @@ public class MatchErrorCode extends ErrorCode {
   private static final String CANNOT_MATCH_WITH_SELF_MESSAGE = "자기 자신과 매칭할 수 없습니다.";
   private static final String MATCH_FORBIDDEN_MESSAGE = "해당 매칭에 대한 접근 권한이 없습니다.";
   private static final String MATCH_STATE_CONFLICT_MESSAGE = "요청을 처리할 수 없는 매칭 상태입니다.";
+  private static final String MATCH_RECOVERY_EXPIRED_MESSAGE = "복구 가능 기간(2주)이 지나 매칭을 복구할 수 없습니다.";
 
   // 에러 코드 객체 반환 메서드
   public static ErrorCode alreadyInMatch() {
@@ -52,6 +53,10 @@ public class MatchErrorCode extends ErrorCode {
 
   public static ErrorCode matchStateConflict(){
     return new MatchErrorCode(HttpStatus.CONFLICT, "MATCH_009",MATCH_STATE_CONFLICT_MESSAGE);
+  }
+
+  public static ErrorCode matchRecoveryExpired() {
+    return new MatchErrorCode(HttpStatus.CONFLICT, "MATCH_010", MATCH_RECOVERY_EXPIRED_MESSAGE);
   }
 
   private MatchErrorCode(HttpStatus httpStatus, String code, String message) {

--- a/back/src/main/java/com/qmate/exception/MatchErrorCode.java
+++ b/back/src/main/java/com/qmate/exception/MatchErrorCode.java
@@ -15,6 +15,8 @@ public class MatchErrorCode extends ErrorCode {
   private static final String INVITE_ATTEMPT_LOCKED_MESSAGE = "초대 코드 입력 5회 실패하여 24시간 동안 시도할 수 없습니다.";
   private static final String CANNOT_MATCH_WITH_SELF_MESSAGE = "자기 자신과 매칭할 수 없습니다.";
   private static final String MATCH_FORBIDDEN_MESSAGE = "해당 매칭에 대한 접근 권한이 없습니다.";
+  private static final String MATCH_STATE_CONFLICT_MESSAGE = "요청을 처리할 수 없는 매칭 상태입니다.";
+
   // 에러 코드 객체 반환 메서드
   public static ErrorCode alreadyInMatch() {
     return new MatchErrorCode(HttpStatus.CONFLICT, "MATCH_001", ALREADY_IN_MATCH_MESSAGE);
@@ -46,6 +48,10 @@ public class MatchErrorCode extends ErrorCode {
 
   public static ErrorCode matchForbidden(){
     return new MatchErrorCode(HttpStatus.FORBIDDEN, "MATCH_008", MATCH_FORBIDDEN_MESSAGE);
+  }
+
+  public static ErrorCode matchStateConflict(){
+    return new MatchErrorCode(HttpStatus.CONFLICT, "MATCH_009",MATCH_STATE_CONFLICT_MESSAGE);
   }
 
   private MatchErrorCode(HttpStatus httpStatus, String code, String message) {

--- a/back/src/main/java/com/qmate/exception/custom/matchinstance/MatchRecoveryExpiredException.java
+++ b/back/src/main/java/com/qmate/exception/custom/matchinstance/MatchRecoveryExpiredException.java
@@ -1,0 +1,11 @@
+package com.qmate.exception.custom.matchinstance;
+
+import com.qmate.exception.BusinessGlobalException;
+import com.qmate.exception.MatchErrorCode;
+
+public class MatchRecoveryExpiredException extends BusinessGlobalException {
+  public MatchRecoveryExpiredException(){
+    super(MatchErrorCode.matchRecoveryExpired());
+  }
+
+}

--- a/back/src/main/java/com/qmate/exception/custom/matchinstance/MatchStateConflictException.java
+++ b/back/src/main/java/com/qmate/exception/custom/matchinstance/MatchStateConflictException.java
@@ -1,0 +1,11 @@
+package com.qmate.exception.custom.matchinstance;
+
+import com.qmate.exception.BusinessGlobalException;
+import com.qmate.exception.MatchErrorCode;
+
+public class MatchStateConflictException extends BusinessGlobalException {
+  public MatchStateConflictException(){
+    super(MatchErrorCode.matchStateConflict());
+  }
+
+}

--- a/back/src/test/java/com/qmate/api/MatchControllerDisconnectTest.java
+++ b/back/src/test/java/com/qmate/api/MatchControllerDisconnectTest.java
@@ -1,0 +1,93 @@
+package com.qmate.api;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.qmate.AuthTestUtils; // ◀◀◀ 1. AuthTestUtils import
+import com.qmate.SecuritySliceTestConfig; // ◀◀◀ 2. SecuritySliceTestConfig import
+import com.qmate.domain.match.service.MatchService;
+import com.qmate.exception.custom.matchinstance.MatchForbiddenException;
+import com.qmate.exception.custom.matchinstance.MatchNotFoundException;
+import com.qmate.exception.custom.matchinstance.MatchStateConflictException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+
+@WebMvcTest(controllers = MatchController.class)
+@AutoConfigureMockMvc // 이 어노테이션은 그대로 두거나, addFilters=false를 제거합니다.
+@Import(SecuritySliceTestConfig.class) // ◀◀◀ 3. SecurityConfig 대신, 테스트 전용 설정을 import
+class MatchControllerDisconnectTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockitoBean
+  private MatchService matchService;
+
+
+  @Test
+  @DisplayName("연결 끊기 성공 시 200 OK와 성공 메시지를 응답한다")
+  void disconnectMatch_success_200ok() throws Exception {
+    // given: 서비스가 정상적으로 동작하는 상황
+    Long matchId = 100L;
+    Long requesterId = 1L; // 테스트용 사용자 ID
+    willDoNothing().given(matchService).disconnectMatch(anyLong(), anyLong());
+
+    // expect: API를 호출하면, 200 OK 응답과 메시지가 와야 함
+    mockMvc.perform(post("/api/matches/{matchId}/disconnect", matchId)
+            .with(AuthTestUtils.userPrincipal(requesterId))) // ◀◀◀ 4. .with()로 가짜 사용자 주입!
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.message").exists());
+  }
+  @Test
+  @DisplayName("연결 끊기 실패: 존재하지 않는 매칭 ID 요청 시 404 Not Found 응답")
+  void disconnectMatch_fail_404notFound() throws Exception {
+    Long nonExistentMatchId = 404L;
+    willThrow(new MatchNotFoundException())
+        .given(matchService).disconnectMatch(anyLong(), anyLong());
+
+    mockMvc.perform(post("/api/matches/{matchId}/disconnect", nonExistentMatchId)
+            .with(AuthTestUtils.userPrincipal(1L)))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.errorCode").value("MATCH_002"));
+  }
+  @Test
+  @DisplayName("연결 끊기 실패: 권한 없는 접근 시 403 Forbidden 응답")
+  void disconnectMatch_fail_403forbidden() throws Exception {
+    // given: 서비스가 MatchForbiddenException을 던지는 상황
+    Long nonExistentMatchId = 100L;
+    willThrow(new MatchForbiddenException())
+        .given(matchService).disconnectMatch(anyLong(), anyLong());
+
+    // expect: 403 Forbidden 응답과 MATCH_008 에러 코드가 와야 함
+    mockMvc.perform(post("/api/matches/{matchId}/disconnect", nonExistentMatchId)
+            .with(AuthTestUtils.userPrincipal(1L)))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.errorCode").value("MATCH_008"));
+  }
+
+  @Test
+  @DisplayName("연결 끊기 실패: 상태 불일치 시 409 Conflict 응답")
+  void disconnectMatch_fail_409conflict() throws Exception {
+    // given: 서비스가 MatchStateConflictException을 던지는 상황
+    Long nonExistentMatchId = 100L;
+    willThrow(new MatchStateConflictException())
+        .given(matchService).disconnectMatch(anyLong(), anyLong());
+
+    // expect: 409 Conflict 응답과 MATCH_009 에러 코드가 와야 함
+    mockMvc.perform(post("/api/matches/{matchId}/disconnect", nonExistentMatchId)
+        .with(AuthTestUtils.userPrincipal(1L)))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.errorCode").value("MATCH_009"));
+  }
+}

--- a/back/src/test/java/com/qmate/api/MatchControllerRestoreTest.java
+++ b/back/src/test/java/com/qmate/api/MatchControllerRestoreTest.java
@@ -1,0 +1,67 @@
+package com.qmate.api;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.qmate.AuthTestUtils;
+import com.qmate.SecuritySliceTestConfig;
+import com.qmate.domain.match.service.MatchService;
+import com.qmate.exception.custom.matchinstance.MatchForbiddenException;
+import com.qmate.exception.custom.matchinstance.MatchNotFoundException;
+import com.qmate.exception.custom.matchinstance.MatchRecoveryExpiredException;
+import com.qmate.exception.custom.matchinstance.MatchStateConflictException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = MatchController.class)
+@AutoConfigureMockMvc
+@Import(SecuritySliceTestConfig.class)
+class MatchControllerRestoreTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockitoBean
+  private MatchService matchService;
+
+  @Test
+  @DisplayName("연결 복구 성공 시 200 OK와 성공 메시지를 응답한다")
+  void restoreMatch_success_200ok() throws Exception {
+    // given
+    Long matchId = 100L;
+    willDoNothing().given(matchService).restoreMatch(anyLong(), anyLong());
+
+    // expect
+    mockMvc.perform(post("/api/matches/{matchId}/restore", matchId)
+            .with(AuthTestUtils.userPrincipal(1L)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.message").value("매칭이 성공적으로 복구되었습니다."));
+  }
+
+  @Test
+  @DisplayName("연결 복구 실패: 복구 기간 만료 시 409 Conflict 응답")
+  void restoreMatch_fail_409expired() throws Exception {
+    // given
+    Long matchId = 100L;
+    willThrow(new MatchRecoveryExpiredException())
+        .given(matchService).restoreMatch(anyLong(), anyLong());
+
+    // expect
+    mockMvc.perform(post("/api/matches/{matchId}/restore", matchId)
+            .with(AuthTestUtils.userPrincipal(1L)))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.errorCode").value("MATCH_010"));
+  }
+
+  // (이하 MatchControllerDisconnectTest와 유사하게, 404, 403, 409(상태) 실패 케이스도 추가하면 좋습니다.)
+}

--- a/back/src/test/java/com/qmate/api/MatchControllerRestoreTest.java
+++ b/back/src/test/java/com/qmate/api/MatchControllerRestoreTest.java
@@ -1,6 +1,7 @@
 package com.qmate.api;
 
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.BDDMockito.willThrow;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -9,6 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.qmate.AuthTestUtils;
 import com.qmate.SecuritySliceTestConfig;
+import com.qmate.common.constants.match.MatchConstants;
 import com.qmate.domain.match.service.MatchService;
 import com.qmate.exception.custom.matchinstance.MatchForbiddenException;
 import com.qmate.exception.custom.matchinstance.MatchNotFoundException;
@@ -35,17 +37,31 @@ class MatchControllerRestoreTest {
   private MatchService matchService;
 
   @Test
-  @DisplayName("연결 복구 성공 시 200 OK와 성공 메시지를 응답한다")
-  void restoreMatch_success_200ok() throws Exception {
-    // given
+  @DisplayName("연결 복구 성공: 상대 동의를 기다려야 할 때, '대기' 메시지를 응답한다")
+  void restoreMatch_success_awaitingPartner() throws Exception {
+    // given: 서비스가 '최종 복구 아님'을 의미하는 false를 반환하는 상황
     Long matchId = 100L;
-    willDoNothing().given(matchService).restoreMatch(anyLong(), anyLong());
+    given(matchService.restoreMatch(anyLong(), anyLong())).willReturn(false);
 
-    // expect
+    // expect: 200 OK 응답과 함께 '상대방 동의 대기' 메시지가 와야 함
     mockMvc.perform(post("/api/matches/{matchId}/restore", matchId)
             .with(AuthTestUtils.userPrincipal(1L)))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.message").value("매칭이 성공적으로 복구되었습니다."));
+        .andExpect(jsonPath("$.message").value(MatchConstants.RESTORE_AGREED_AWAITING_PARTNER_MESSAGE));
+  }
+
+  @Test
+  @DisplayName("연결 복구 성공: 최종 복구 완료 시, '성공' 메시지를 응답한다")
+  void restoreMatch_success_fullyRestored() throws Exception {
+    // given: 서비스가 '최종 복구 성공'을 의미하는 true를 반환하는 상황
+    Long matchId = 100L;
+    given(matchService.restoreMatch(anyLong(), anyLong())).willReturn(true);
+
+    // expect: 200 OK 응답과 함께 '성공' 메시지가 와야 함
+    mockMvc.perform(post("/api/matches/{matchId}/restore", matchId)
+            .with(AuthTestUtils.userPrincipal(1L)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.message").value(MatchConstants.RESTORE_SUCCESS_MESSAGE));
   }
 
   @Test

--- a/back/src/test/java/com/qmate/domain/match/service/MatchServiceDisconnectTest.java
+++ b/back/src/test/java/com/qmate/domain/match/service/MatchServiceDisconnectTest.java
@@ -1,0 +1,100 @@
+package com.qmate.domain.match.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import com.qmate.domain.match.Match;
+import com.qmate.domain.match.MatchMember;
+import com.qmate.domain.match.MatchStatus;
+import com.qmate.domain.match.repository.MatchRepository;
+import com.qmate.domain.user.User;
+import com.qmate.exception.custom.matchinstance.MatchForbiddenException;
+import com.qmate.exception.custom.matchinstance.MatchNotFoundException;
+import com.qmate.exception.custom.matchinstance.MatchStateConflictException;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class MatchServiceDisconnectTest {
+
+  @InjectMocks
+  private MatchService sut;
+
+  @Mock
+  private MatchRepository matchRepository;
+
+  private User user1, user2;
+  private Match activeMatch;
+
+  @BeforeEach
+  void setup(){
+    // 모든 테스트에서 공통으로 사용할 가짜 데이터 준비
+    user1 = User.builder().id(1L).build();
+    user2 = User.builder().id(2L).build();
+    activeMatch = Match.builder().id(100L).status(MatchStatus.ACTIVE).build();
+    activeMatch.addMember(MatchMember.create(user1, activeMatch));
+    activeMatch.addMember(MatchMember.create(user2, activeMatch));
+
+  }
+  @Test
+  @DisplayName("연결 끊기 성공: 상태가 DETACHED_PENDING_DELETE로 변경된다")
+  void disconnectMatch_success() {
+    // given: 1번 유저가 자신의 ACTIVE 상태인 매칭에 대해 연결 끊기를 요청
+    Long matchId = 100L;
+    Long requesterId = 1L;
+    given(matchRepository.findWithMembersAndUsersById(matchId)).willReturn(Optional.of(activeMatch));
+
+    // when: 서비스 메서드를 실행
+    sut.disconnectMatch(matchId, requesterId);
+
+    // then: Match 엔티티의 상태가 올바르게 변경되었는지 검증
+    assertThat(activeMatch.getStatus()).isEqualTo(MatchStatus.DETACHED_PENDING_DELETE);
+    assertThat(activeMatch.getDetachedAt()).isNotNull();
+  }
+
+  @Test
+  @DisplayName("연결 끊기 실패: 존재하지 않는 매칭(404)")
+  void disconnectMatch_fail_matchNotFound() {
+    // given: 존재하지 않는 매칭 ID로 요청
+    Long nonExistentMatchId = 404L;
+    given(matchRepository.findWithMembersAndUsersById(nonExistentMatchId)).willReturn(Optional.empty());
+
+    // expect: MatchNotFoundException 예외가 발생해야 함
+    assertThatThrownBy(() -> sut.disconnectMatch(nonExistentMatchId, 1L))
+        .isInstanceOf(MatchNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("연결 끊기 실패: 멤버가 아닌 사용자의 접근(403)")
+  void disconnectMatch_fail_forbidden() {
+    // given: 100번 매칭 정보를 상관없는 99번 유저가 끊으려고 시도
+    Long matchId = 100L;
+    Long outsiderId = 99L;
+    given(matchRepository.findWithMembersAndUsersById(matchId)).willReturn(Optional.of(activeMatch));
+
+    // expect: MatchForbiddenException 예외가 발생해야 함
+    assertThatThrownBy(() -> sut.disconnectMatch(matchId, outsiderId))
+        .isInstanceOf(MatchForbiddenException.class);
+  }
+  @Test
+  @DisplayName("연결 끊기 실패: 이미 끊어진 매칭을 또 끊으려는 시도(409)")
+  void disconnectMatch_fail_stateConflict() {
+    // given: 매칭의 상태가 ACTIVE가 아닌 DETACHED_PENDING_DELETE인 상황
+    Long matchId = 100L;
+    Long requesterId = 1L;
+    activeMatch.setStatus(MatchStatus.DETACHED_PENDING_DELETE); // 상태를 미리 변경
+    given(matchRepository.findWithMembersAndUsersById(matchId)).willReturn(Optional.of(activeMatch));
+
+    // expect: MatchStateConflictException 예외가 발생해야 함
+    assertThatThrownBy(() -> sut.disconnectMatch(matchId, requesterId))
+        .isInstanceOf(MatchStateConflictException.class);
+  }
+
+}

--- a/back/src/test/java/com/qmate/domain/match/service/MatchServiceRestoreTest.java
+++ b/back/src/test/java/com/qmate/domain/match/service/MatchServiceRestoreTest.java
@@ -52,19 +52,49 @@ class MatchServiceRestoreTest {
   }
 
   @Test
-  @DisplayName("연결 복구 성공: 상태가 ACTIVE로 변경되고 detachedAt은 null이 된다")
-  void restoreMatch_success() {
-    // given: 1번 유저가 자신의 DETACHED 상태인 매칭에 대해 복구를 요청
+  @DisplayName("연결 복구 성공: 내가 첫 번째로 동의한 경우, false를 반환하고 상태는 유지된다")
+  void restoreMatch_success_firstAgreement() {
+    // given: 1번 유저(나)와 2번 유저(상대)가 매칭된 상황. 상대는 아직 동의 안 함(isAgreed=false)
     Long matchId = 100L;
     Long requesterId = 1L;
-    given(matchRepository.findWithMembersAndUsersById(matchId)).willReturn(Optional.of(detachedMatch));
+    User user1 = User.builder().id(1L).build();
+    User user2 = User.builder().id(2L).build();
+    Match match = Match.builder().id(matchId).status(MatchStatus.DETACHED_PENDING_DELETE).detachedAt(LocalDateTime.now()).build();
+    match.addMember(MatchMember.builder().user(user1).isAgreed(false).build()); // 내 동의 상태: false
+    match.addMember(MatchMember.builder().user(user2).isAgreed(false).build()); // 상대 동의 상태: false
 
-    // when: 서비스 메서드를 실행
-    sut.restoreMatch(matchId, requesterId);
+    given(matchRepository.findWithMembersAndUsersById(matchId)).willReturn(Optional.of(match));
 
-    // then: Match 엔티티의 상태가 올바르게 변경되었는지 검증
-    assertThat(detachedMatch.getStatus()).isEqualTo(MatchStatus.ACTIVE);
-    assertThat(detachedMatch.getDetachedAt()).isNull();
+    // when: 내가 복구를 요청하면
+    boolean isFullyRestored = sut.restoreMatch(matchId, requesterId);
+
+    // then:
+    assertThat(isFullyRestored).isFalse(); // 최종 복구는 아니므로 false 반환
+    assertThat(match.getMembers().get(0).isAgreed()).isTrue(); // 내 동의 상태는 true로 변경
+    assertThat(match.getStatus()).isEqualTo(MatchStatus.DETACHED_PENDING_DELETE); // 매칭 상태는 그대로 유지
+  }
+
+  @Test
+  @DisplayName("연결 복구 성공: 내가 마지막으로 동의하여 최종 복구되는 경우, true를 반환하고 상태가 변경된다")
+  void restoreMatch_success_finalAgreement() {
+    // given: 상대방은 이미 동의한 상황 (isAgreed=true)
+    Long matchId = 100L;
+    Long requesterId = 1L;
+    User user1 = User.builder().id(1L).build();
+    User user2 = User.builder().id(2L).build();
+    Match match = Match.builder().id(matchId).status(MatchStatus.DETACHED_PENDING_DELETE).detachedAt(LocalDateTime.now()).build();
+    match.addMember(MatchMember.builder().user(user1).isAgreed(false).build()); // 내 동의 상태: false
+    match.addMember(MatchMember.builder().user(user2).isAgreed(true).build());  // 상대 동의 상태: true
+
+    given(matchRepository.findWithMembersAndUsersById(matchId)).willReturn(Optional.of(match));
+
+    // when: 내가 복구를 요청하면
+    boolean isFullyRestored = sut.restoreMatch(matchId, requesterId);
+
+    // then:
+    assertThat(isFullyRestored).isTrue(); // 최종 복구되었으므로 true 반환
+    assertThat(match.getStatus()).isEqualTo(MatchStatus.ACTIVE); // 매칭 상태가 ACTIVE로 변경
+    assertThat(match.getDetachedAt()).isNull(); // 끊어진 시각은 null로 초기화
   }
 
   @Test

--- a/back/src/test/java/com/qmate/domain/match/service/MatchServiceRestoreTest.java
+++ b/back/src/test/java/com/qmate/domain/match/service/MatchServiceRestoreTest.java
@@ -1,0 +1,133 @@
+package com.qmate.domain.match.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import com.qmate.domain.match.MatchStatus;
+import com.qmate.domain.match.Match;
+import com.qmate.domain.match.MatchMember;
+import com.qmate.domain.match.repository.MatchRepository;
+import com.qmate.domain.user.User;
+import com.qmate.exception.custom.matchinstance.MatchForbiddenException;
+import com.qmate.exception.custom.matchinstance.MatchNotFoundException;
+import com.qmate.exception.custom.matchinstance.MatchRecoveryExpiredException;
+import com.qmate.exception.custom.matchinstance.MatchStateConflictException;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MatchServiceRestoreTest {
+
+  @InjectMocks
+  private MatchService sut;
+
+  @Mock
+  private MatchRepository matchRepository;
+
+  private User user1, user2;
+  private Match detachedMatch;
+
+  @BeforeEach
+  void setUp() {
+    // 모든 테스트에서 공통으로 사용할 가짜 데이터 준비
+    user1 = User.builder().id(1L).build();
+    user2 = User.builder().id(2L).build();
+
+    // 연결이 끊긴 지 '1주일' 된 매칭을 기본 상태로 설정
+    detachedMatch = Match.builder()
+        .id(100L)
+        .status(MatchStatus.DETACHED_PENDING_DELETE)
+        .detachedAt(LocalDateTime.now().minusWeeks(1)) // 1주일 전
+        .build();
+    detachedMatch.addMember(MatchMember.create(user1, detachedMatch));
+    detachedMatch.addMember(MatchMember.create(user2, detachedMatch));
+  }
+
+  @Test
+  @DisplayName("연결 복구 성공: 상태가 ACTIVE로 변경되고 detachedAt은 null이 된다")
+  void restoreMatch_success() {
+    // given: 1번 유저가 자신의 DETACHED 상태인 매칭에 대해 복구를 요청
+    Long matchId = 100L;
+    Long requesterId = 1L;
+    given(matchRepository.findWithMembersAndUsersById(matchId)).willReturn(Optional.of(detachedMatch));
+
+    // when: 서비스 메서드를 실행
+    sut.restoreMatch(matchId, requesterId);
+
+    // then: Match 엔티티의 상태가 올바르게 변경되었는지 검증
+    assertThat(detachedMatch.getStatus()).isEqualTo(MatchStatus.ACTIVE);
+    assertThat(detachedMatch.getDetachedAt()).isNull();
+  }
+
+  @Test
+  @DisplayName("연결 복구 실패: 존재하지 않는 매칭(404)")
+  void restoreMatch_fail_matchNotFound() {
+    // given: 존재하지 않는 매칭 ID로 요청
+    Long nonExistentMatchId = 404L;
+    given(matchRepository.findWithMembersAndUsersById(nonExistentMatchId)).willReturn(Optional.empty());
+
+    // expect: MatchNotFoundException 예외가 발생해야 함
+    assertThatThrownBy(() -> sut.restoreMatch(nonExistentMatchId, 1L))
+        .isInstanceOf(MatchNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("연결 복구 실패: 멤버가 아닌 사용자의 접근(403)")
+  void restoreMatch_fail_forbidden() {
+    // given: 100번 매칭 정보를 상관없는 99번 유저가 복구하려고 시도
+    Long matchId = 100L;
+    Long outsiderId = 99L;
+    given(matchRepository.findWithMembersAndUsersById(matchId)).willReturn(Optional.of(detachedMatch));
+
+    // expect: MatchForbiddenException 예외가 발생해야 함
+    assertThatThrownBy(() -> sut.restoreMatch(matchId, outsiderId))
+        .isInstanceOf(MatchForbiddenException.class);
+  }
+
+  @Test
+  @DisplayName("연결 복구 실패: 복구할 수 없는 상태의 매칭(409)")
+  void restoreMatch_fail_stateConflict() {
+    // given: 매칭의 상태가 ACTIVE인 상황
+    Long matchId = 100L;
+    Long requesterId = 1L;
+    detachedMatch.setStatus(MatchStatus.ACTIVE); // 상태를 미리 변경
+    given(matchRepository.findWithMembersAndUsersById(matchId)).willReturn(Optional.of(detachedMatch));
+
+    // expect: MatchStateConflictException 예외가 발생해야 함
+    assertThatThrownBy(() -> sut.restoreMatch(matchId, requesterId))
+        .isInstanceOf(MatchStateConflictException.class);
+  }
+
+  @Test
+  @DisplayName("연결 복구 실패: 복구 가능 기간(2주) 만료(409)")
+  void restoreMatch_fail_recoveryExpired() {
+    // given: 연결이 끊긴 지 '3주'가 지난, 이 테스트만을 위한 특별한 Match 객체를 만듭니다.
+    Long matchId = 100L;
+    Long requesterId = 1L;
+    User user1 = User.builder().id(requesterId).build();
+
+    // setDetachedAt 대신, builder를 사용해 detachedAt 값을 처음부터 설정합니다.
+    Match expiredMatch = Match.builder()
+        .id(matchId)
+        .status(MatchStatus.DETACHED_PENDING_DELETE)
+        .detachedAt(LocalDateTime.now().minusWeeks(3)) // ◀◀◀ 3주 전으로 시간 설정
+        .build();
+    expiredMatch.addMember(MatchMember.create(user1, expiredMatch));
+
+    // Repository가 이 테스트용 객체를 반환하도록 설정합니다.
+    given(matchRepository.findWithMembersAndUsersById(matchId)).willReturn(Optional.of(expiredMatch));
+    // ▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲
+
+    // expect: MatchRecoveryExpiredException 예외가 발생해야 함
+    assertThatThrownBy(() -> sut.restoreMatch(matchId, requesterId))
+        .isInstanceOf(MatchRecoveryExpiredException.class);
+  }
+}


### PR DESCRIPTION
### 개요

매칭된 사용자가 의도적으로 연결을 끊거나, 2주 유예 기간 내에 다시 복구할 수 있는 **매칭 연결 끊기 및 복구 기능**을 구현했습니다. 또한, 컨트롤러의 인증 처리 방식을 임시 ID 대신 실제 로그인 정보를 사용하는 **`UserPrincipal`**로 전면 리팩토링하여 보안과 일관성을 강화했습니다.

### 변경 사항

#### API
- `POST /api/matches/{matchId}/disconnect`: 매칭 연결을 끊고, 2주간의 복구 유예 기간을 시작합니다.
- `POST /api/matches/{matchId}/restore`: 유예 기간 내의 매칭을 다시 활성화합니다.

#### 제약/상태코드
- **성공:** `200 OK`
- **실패:**
    - **`403 Forbidden` (`MATCH_008`):** 요청자가 해당 매칭의 멤버가 아닌 경우
    - **`404 Not Found` (`MATCH_002`):** 해당 `matchId`가 존재하지 않을 경우
    - **`409 Conflict` (`MATCH_009`, `MATCH_010`):** API를 호출할 수 없는 매칭 상태이거나 복구 기간이 만료된 경우

#### 리팩토링
- **`MatchController`**
    - 기존의 모든 엔드포인트에서 임시 `userId`를 사용하던 방식을 제거하고, Spring Security의 `@AuthenticationPrincipal UserPrincipal`을 사용하도록 통일했습니다. 이를 통해 실제 로그인한 사용자의 정보를 기반으로 모든 기능이 동작하도록 개선했습니다.

#### DTO
- `MatchActionResponse.java`: 연결 끊기/복구 등 액션에 대한 간단한 성공 메시지를 담는 DTO를 `match` 도메인 내에 추가했습니다.

#### Entity
- **`Match.java`**
    - `disconnect()`: `status`를 `DETACHED_PENDING_DELETE`로 변경하고 `detachedAt`을 기록하는, 의도가 명확한 비즈니스 메서드를 추가했습니다.
    - `restore()`: `status`를 `ACTIVE`로 변경하고 `detachedAt`을 `null`로 되돌리는 비즈니스 메서드를 추가했습니다. 복구 가능 기간(2주) 검증 로직을 포함합니다.

#### Service
- **`MatchService`**
    - `disconnectMatch(matchId, userId)`: 권한 검증 후, `Match` 엔티티의 `disconnect()` 메서드를 호출합니다.
    - `restoreMatch(matchId, userId)`: 권한 검증 및 복구 유예 기간을 확인한 후, `Match` 엔티티의 `restore()` 메서드를 호출합니다.

#### Exception
- `MatchErrorCode`에 `MATCH_STATE_CONFLICT`(`MATCH_009`), `MATCH_RECOVERY_EXPIRED`(`MATCH_010`) 에러 코드를 추가했습니다.
- `MatchStateConflictException`, `MatchRecoveryExpiredException` 커스텀 예외 클래스를 추가하여 실패 원인을 세분화했습니다.

### 테스트

#### Tests
- **서비스 단위 테스트 (`MatchServiceDisconnectTest`, `MatchServiceRestoreTest`)**
    - 기능별로 테스트 클래스를 분리하여 각 기능의 성공 케이스와 모든 실패 케이스(404, 403, 409)를 검증했습니다.
- **컨트롤러 단위 테스트 (`MatchControllerDisconnectTest`, `MatchControllerRestoreTest`)**
    - 팀의 `AuthTestUtils`와 `SecuritySliceTestConfig`를 활용하여 `@AuthenticationPrincipal`이 정상 동작하는 환경에서 테스트를 진행했습니다.
    - 서비스가 던지는 각 예외에 대해 컨트롤러가 올바른 HTTP 상태 코드를 응답하는지 검증했습니다.

#### 기타
질문에 대한 미 답변(14일)으로 인한 자동연결 끊기는 이후 따로 기능 개발 예정.