### PR TITLE
docs: 공통 에러 규약 상단 안내 및 API별 에러 설명 정리

### DIFF
--- a/back/src/main/java/com/qmate/api/question/CustomQuestionController.java
+++ b/back/src/main/java/com/qmate/api/question/CustomQuestionController.java
@@ -42,15 +42,6 @@ public class CustomQuestionController {
   @Operation(
       summary = "커스텀 질문 생성",
       description = "특정 매치에 대한 커스텀 질문을 생성합니다.",
-      responses = {
-          @ApiResponse(responseCode = "201", description = "생성 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = CustomQuestionResponse.class))),
-          @ApiResponse(responseCode = "400", description = "유효하지 않은 요청 값", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
-          @ApiResponse(responseCode = "404", description = "매치를 찾을 수 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
-      },
-      requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
-          required = true,
-          content = @Content(mediaType = "application/json", schema = @Schema(implementation = CustomQuestionTextRequest.class))
-      ),
       parameters = {
           @Parameter(name = "matchId", description = "커스텀 질문을 추가할 매치 ID", required = true)
       }
@@ -71,16 +62,6 @@ public class CustomQuestionController {
   @Operation(
       summary = "커스텀 질문 수정",
       description = "특정 커스텀 질문을 수정합니다.",
-      responses = {
-          @ApiResponse(responseCode = "200", description = "수정 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = CustomQuestionResponse.class))),
-          @ApiResponse(responseCode = "400", description = "유효하지 않은 요청 값", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
-          @ApiResponse(responseCode = "404", description = "커스텀 질문을 찾을 수 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
-          @ApiResponse(responseCode = "423", description = "수정 불가", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
-      },
-      requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
-          required = true,
-          content = @Content(mediaType = "application/json", schema = @Schema(implementation = CustomQuestionTextRequest.class))
-      ),
       parameters = {
           @Parameter(name = "id", description = "수정할 커스텀 질문 ID", required = true)
       }
@@ -101,11 +82,6 @@ public class CustomQuestionController {
   @Operation(
       summary = "커스텀 질문 삭제",
       description = "특정 커스텀 질문을 삭제합니다.",
-      responses = {
-          @ApiResponse(responseCode = "204", description = "삭제 성공"),
-          @ApiResponse(responseCode = "404", description = "커스텀 질문을 찾을 수 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
-          @ApiResponse(responseCode = "423", description = "삭제 불가", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
-      },
       parameters = {
           @Parameter(name = "id", description = "삭제할 커스텀 질문 ID", required = true)
       }

--- a/back/src/main/java/com/qmate/api/question/QuestionCategoryController.java
+++ b/back/src/main/java/com/qmate/api/question/QuestionCategoryController.java
@@ -1,10 +1,12 @@
 package com.qmate.api.question;
 
+import com.qmate.common.constants.CommonConstants;
+import com.qmate.common.constants.HttpStatusCode;
+import com.qmate.common.constants.question.QuestionCategoryConstants;
 import com.qmate.domain.question.model.request.QuestionCategoryCreateRequest;
 import com.qmate.domain.question.model.request.QuestionCategoryUpdateRequest;
 import com.qmate.domain.question.model.response.QuestionCategoryResponse;
 import com.qmate.domain.question.service.QuestionCategoryService;
-import com.qmate.exception.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -39,15 +41,13 @@ public class QuestionCategoryController {
   @PostMapping
   @Operation(
       summary = "카테고리 생성",
-      description = "새로운 질문 카테고리를 생성합니다.",
+      description = QuestionCategoryConstants.CREATE_MD,
       requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
           required = true,
-          content = @Content(mediaType = "application/json", schema = @Schema(implementation = QuestionCategoryCreateRequest.class))
+          content = @Content(mediaType = CommonConstants.MEDIA_TYPE_JSON, schema = @Schema(implementation = QuestionCategoryCreateRequest.class))
       ),
       responses = {
-          @ApiResponse(responseCode = "201", description = "생성 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = QuestionCategoryResponse.class))),
-          @ApiResponse(responseCode = "400", description = "유효하지 않은 요청 값", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
-          @ApiResponse(responseCode = "409", description = "이미 존재하는 카테고리명", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = HttpStatusCode.CREATED, description = "생성 성공", content = @Content(mediaType = CommonConstants.MEDIA_TYPE_JSON, schema = @Schema(implementation = QuestionCategoryResponse.class))),
       }
   )
   // @PostMapping
@@ -63,16 +63,13 @@ public class QuestionCategoryController {
   @PatchMapping("/{id}")
   @Operation(
       summary = "카테고리 수정",
-      description = "기존 질문 카테고리를 부분 수정합니다.",
+      description = QuestionCategoryConstants.UPDATE_MD,
       requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
           required = true,
-          content = @Content(mediaType = "application/json", schema = @Schema(implementation = QuestionCategoryUpdateRequest.class))
+          content = @Content(mediaType = CommonConstants.MEDIA_TYPE_JSON, schema = @Schema(implementation = QuestionCategoryUpdateRequest.class))
       ),
       responses = {
-          @ApiResponse(responseCode = "200", description = "수정 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = QuestionCategoryResponse.class))),
-          @ApiResponse(responseCode = "400", description = "유효하지 않은 요청 값", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
-          @ApiResponse(responseCode = "404", description = "대상 카테고리 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
-          @ApiResponse(responseCode = "409", description = "이미 존재하는 카테고리명", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = HttpStatusCode.OK, description = "수정 성공", content = @Content(mediaType = CommonConstants.MEDIA_TYPE_JSON, schema = @Schema(implementation = QuestionCategoryResponse.class))),
       }
   )
   // @PatchMapping("/{id}")
@@ -91,7 +88,7 @@ public class QuestionCategoryController {
       summary = "카테고리 전체 조회",
       description = "모든 질문 카테고리를 조회합니다.",
       responses = {
-          @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = QuestionCategoryResponse.class))),
+          @ApiResponse(responseCode = HttpStatusCode.OK, description = "조회 성공", content = @Content(mediaType = CommonConstants.MEDIA_TYPE_JSON, schema = @Schema(implementation = QuestionCategoryResponse.class))),
       }
   )
   //@GetMapping

--- a/back/src/main/java/com/qmate/api/question/QuestionCategoryController.java
+++ b/back/src/main/java/com/qmate/api/question/QuestionCategoryController.java
@@ -1,16 +1,11 @@
 package com.qmate.api.question;
 
-import com.qmate.common.constants.CommonConstants;
-import com.qmate.common.constants.HttpStatusCode;
 import com.qmate.common.constants.question.QuestionCategoryConstants;
 import com.qmate.domain.question.model.request.QuestionCategoryCreateRequest;
 import com.qmate.domain.question.model.request.QuestionCategoryUpdateRequest;
 import com.qmate.domain.question.model.response.QuestionCategoryResponse;
 import com.qmate.domain.question.service.QuestionCategoryService;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -41,14 +36,7 @@ public class QuestionCategoryController {
   @PostMapping
   @Operation(
       summary = "카테고리 생성",
-      description = QuestionCategoryConstants.CREATE_MD,
-      requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
-          required = true,
-          content = @Content(mediaType = CommonConstants.MEDIA_TYPE_JSON, schema = @Schema(implementation = QuestionCategoryCreateRequest.class))
-      ),
-      responses = {
-          @ApiResponse(responseCode = HttpStatusCode.CREATED, description = "생성 성공", content = @Content(mediaType = CommonConstants.MEDIA_TYPE_JSON, schema = @Schema(implementation = QuestionCategoryResponse.class))),
-      }
+      description = QuestionCategoryConstants.CREATE_MD
   )
   // @PostMapping
   public ResponseEntity<QuestionCategoryResponse> createCategory(
@@ -63,14 +51,7 @@ public class QuestionCategoryController {
   @PatchMapping("/{id}")
   @Operation(
       summary = "카테고리 수정",
-      description = QuestionCategoryConstants.UPDATE_MD,
-      requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
-          required = true,
-          content = @Content(mediaType = CommonConstants.MEDIA_TYPE_JSON, schema = @Schema(implementation = QuestionCategoryUpdateRequest.class))
-      ),
-      responses = {
-          @ApiResponse(responseCode = HttpStatusCode.OK, description = "수정 성공", content = @Content(mediaType = CommonConstants.MEDIA_TYPE_JSON, schema = @Schema(implementation = QuestionCategoryResponse.class))),
-      }
+      description = QuestionCategoryConstants.UPDATE_MD
   )
   // @PatchMapping("/{id}")
   public ResponseEntity<QuestionCategoryResponse> updateCategory(
@@ -86,10 +67,7 @@ public class QuestionCategoryController {
   @GetMapping
   @Operation(
       summary = "카테고리 전체 조회",
-      description = "모든 질문 카테고리를 조회합니다.",
-      responses = {
-          @ApiResponse(responseCode = HttpStatusCode.OK, description = "조회 성공", content = @Content(mediaType = CommonConstants.MEDIA_TYPE_JSON, schema = @Schema(implementation = QuestionCategoryResponse.class))),
-      }
+      description = "모든 질문 카테고리를 조회합니다."
   )
   //@GetMapping
   public ResponseEntity<List<QuestionCategoryResponse>> getAllCategories() {

--- a/back/src/main/java/com/qmate/api/question/QuestionController.java
+++ b/back/src/main/java/com/qmate/api/question/QuestionController.java
@@ -1,5 +1,8 @@
 package com.qmate.api.question;
 
+import com.qmate.common.constants.CommonConstants;
+import com.qmate.common.constants.HttpStatusCode;
+import com.qmate.common.constants.question.QuestionConstants;
 import com.qmate.domain.question.entity.RelationType;
 import com.qmate.domain.question.model.request.QuestionCreateRequest;
 import com.qmate.domain.question.model.request.QuestionUpdateRequest;
@@ -48,12 +51,11 @@ public class QuestionController {
       summary = "질문 생성",
       description = "새로운 질문을 생성합니다.",
       responses = {
-          @ApiResponse(responseCode = "201", description = "생성 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = QuestionResponse.class))),
-          @ApiResponse(responseCode = "400", description = "유효하지 않은 요청 값", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = HttpStatusCode.CREATED, description = "생성 성공", content = @Content(mediaType = CommonConstants.MEDIA_TYPE_JSON, schema = @Schema(implementation = QuestionResponse.class))),
       },
       requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
           required = true,
-          content = @Content(mediaType = "application/json", schema = @Schema(implementation = QuestionCreateRequest.class))
+          content = @Content(mediaType = CommonConstants.MEDIA_TYPE_JSON, schema = @Schema(implementation = QuestionCreateRequest.class))
       )
   )
   // @PostMapping
@@ -68,15 +70,13 @@ public class QuestionController {
   @PatchMapping("/{id}")
   @Operation(
       summary = "질문 수정",
-      description = "기존 질문을 부분 수정합니다.",
+      description = QuestionConstants.UPDATE_MD,
       responses = {
-          @ApiResponse(responseCode = "200", description = "수정 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = QuestionResponse.class))),
-          @ApiResponse(responseCode = "400", description = "유효하지 않은 요청 값", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
-          @ApiResponse(responseCode = "404", description = "해당 질문 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = HttpStatusCode.OK, description = "수정 성공", content = @Content(mediaType = CommonConstants.MEDIA_TYPE_JSON, schema = @Schema(implementation = QuestionResponse.class))),
       },
       requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
           required = true,
-          content = @Content(mediaType = "application/json", schema = @Schema(implementation = QuestionUpdateRequest.class))
+          content = @Content(mediaType = CommonConstants.MEDIA_TYPE_JSON, schema = @Schema(implementation = QuestionUpdateRequest.class))
       ),
       parameters = {
           @Parameter(name = "id", description = "수정할 질문 ID", required = true)
@@ -97,8 +97,7 @@ public class QuestionController {
       summary = "질문 전체 조회 (필터링 및 페이징)",
       description = "질문을 필터링 조건에 따라 페이징하여 조회합니다.",
       responses = {
-          @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = QuestionResponse.class))),
-          @ApiResponse(responseCode = "400", description = "유효하지 않은 요청 값", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(mediaType = CommonConstants.MEDIA_TYPE_JSON, schema = @Schema(implementation = QuestionResponse.class))),
       },
       parameters = {
           @Parameter(name = "relationType", description = "질문의 관계 타입", required = false, schema = @Schema(implementation = RelationType.class)),

--- a/back/src/main/java/com/qmate/api/question/QuestionController.java
+++ b/back/src/main/java/com/qmate/api/question/QuestionController.java
@@ -1,19 +1,14 @@
 package com.qmate.api.question;
 
-import com.qmate.common.constants.CommonConstants;
-import com.qmate.common.constants.HttpStatusCode;
 import com.qmate.common.constants.question.QuestionConstants;
 import com.qmate.domain.question.entity.RelationType;
 import com.qmate.domain.question.model.request.QuestionCreateRequest;
 import com.qmate.domain.question.model.request.QuestionUpdateRequest;
 import com.qmate.domain.question.model.response.QuestionResponse;
 import com.qmate.domain.question.service.QuestionService;
-import com.qmate.exception.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -49,14 +44,7 @@ public class QuestionController {
   @PostMapping
   @Operation(
       summary = "질문 생성",
-      description = "새로운 질문을 생성합니다.",
-      responses = {
-          @ApiResponse(responseCode = HttpStatusCode.CREATED, description = "생성 성공", content = @Content(mediaType = CommonConstants.MEDIA_TYPE_JSON, schema = @Schema(implementation = QuestionResponse.class))),
-      },
-      requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
-          required = true,
-          content = @Content(mediaType = CommonConstants.MEDIA_TYPE_JSON, schema = @Schema(implementation = QuestionCreateRequest.class))
-      )
+      description = "새로운 질문을 생성합니다."
   )
   // @PostMapping
   public ResponseEntity<QuestionResponse> createQuestion(
@@ -71,13 +59,6 @@ public class QuestionController {
   @Operation(
       summary = "질문 수정",
       description = QuestionConstants.UPDATE_MD,
-      responses = {
-          @ApiResponse(responseCode = HttpStatusCode.OK, description = "수정 성공", content = @Content(mediaType = CommonConstants.MEDIA_TYPE_JSON, schema = @Schema(implementation = QuestionResponse.class))),
-      },
-      requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
-          required = true,
-          content = @Content(mediaType = CommonConstants.MEDIA_TYPE_JSON, schema = @Schema(implementation = QuestionUpdateRequest.class))
-      ),
       parameters = {
           @Parameter(name = "id", description = "수정할 질문 ID", required = true)
       }
@@ -96,9 +77,6 @@ public class QuestionController {
   @Operation(
       summary = "질문 전체 조회 (필터링 및 페이징)",
       description = "질문을 필터링 조건에 따라 페이징하여 조회합니다.",
-      responses = {
-          @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(mediaType = CommonConstants.MEDIA_TYPE_JSON, schema = @Schema(implementation = QuestionResponse.class))),
-      },
       parameters = {
           @Parameter(name = "relationType", description = "질문의 관계 타입", required = false, schema = @Schema(implementation = RelationType.class)),
           @Parameter(name = "categoryId", description = "질문의 카테고리 ID", required = false),

--- a/back/src/main/java/com/qmate/common/constants/CommonConstants.java
+++ b/back/src/main/java/com/qmate/common/constants/CommonConstants.java
@@ -1,0 +1,10 @@
+package com.qmate.common.constants;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CommonConstants {
+
+  public static final String MEDIA_TYPE_JSON = "application/json";
+}

--- a/back/src/main/java/com/qmate/common/constants/HttpStatusCode.java
+++ b/back/src/main/java/com/qmate/common/constants/HttpStatusCode.java
@@ -1,0 +1,29 @@
+package com.qmate.common.constants;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class HttpStatusCode {
+
+  // 2xx Success
+  public static final String OK = "200";
+  public static final String CREATED = "201";
+  public static final String NO_CONTENT = "204";
+
+  // 4xx Client Error
+  public static final String BAD_REQUEST = "400";
+  public static final String UNAUTHORIZED = "401";
+  public static final String FORBIDDEN = "403";
+  public static final String NOT_FOUND = "404";
+  public static final String CONFLICT = "409";
+  public static final String GONE = "410";
+  public static final String PRECONDITION_FAILED = "412";
+  public static final String URI_TOO_LONG = "414";               // aka REQUEST_URI_TOO_LONG
+  public static final String LOCKED = "423";                     // WebDAV (RFC 4918)
+  public static final String TOO_MANY_REQUESTS = "429";          // RFC 6585
+
+  // 5xx Server Error
+  public static final String INTERNAL_SERVER_ERROR = "500";
+
+}

--- a/back/src/main/java/com/qmate/common/constants/question/QuestionCategoryConstants.java
+++ b/back/src/main/java/com/qmate/common/constants/question/QuestionCategoryConstants.java
@@ -1,5 +1,7 @@
 package com.qmate.common.constants.question;
 
+import com.qmate.common.constants.HttpStatusCode;
+import com.qmate.exception.errorcode.QuestionCategoryErrorCode;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -15,7 +17,24 @@ public class QuestionCategoryConstants {
   public static final String NAME_SIZE_MESSAGE = "카테고리명은 최대 " + MAX_NAME_LENGTH + "자까지 입력할 수 있습니다.";
   public static final String RELATION_TYPE_NOT_BLANK_MESSAGE = "대상 관계는 필수입니다.";
 
-  // 예외 메시지
-  public static final String CATEGORY_NOT_FOUND_MESSAGE = "카테고리를 찾을 수 없습니다.";
-  public static final String CATEGORY_ALREADY_EXISTS_MESSAGE = "이미 존재하는 카테고리명입니다.";
+  // api 문서 메시지
+  public static final String CREATE_MD =
+      "새로운 질문 카테고리를 생성합니다.\n\n"
+          + "### 에러 응답\n\n"
+          + "| HTTP | errorCode | message |\n"
+          + "|-----:|-----------|---------|\n"
+          + "| " + HttpStatusCode.CONFLICT + " | " + QuestionCategoryErrorCode.QC_NAME_ALREADY_EXISTS_ERROR_CODE + " | "
+          + QuestionCategoryErrorCode.QC_NAME_ALREADY_EXISTS_MESSAGE + " |\n";
+
+  public static final String UPDATE_MD =
+      "기존 질문 카테고리를 부분 수정합니다.\n\n"
+      + "### 에러 응답\n\n"
+      + "| HTTP | errorCode | message |\n"
+      + "|-----:|-----|---------|\n"
+      + "|" + HttpStatusCode.NOT_FOUND + " | " + QuestionCategoryErrorCode.QC_NOT_FOUND_ERROR_CODE + " | "
+      + QuestionCategoryErrorCode.QC_NOT_FOUND_MESSAGE
+      + "|\n"
+      + "| " + HttpStatusCode.CONFLICT + " | " + QuestionCategoryErrorCode.QC_NAME_ALREADY_EXISTS_ERROR_CODE + " | "
+      + QuestionCategoryErrorCode.QC_NAME_ALREADY_EXISTS_MESSAGE
+      + "|\n";
 }

--- a/back/src/main/java/com/qmate/common/constants/question/QuestionConstants.java
+++ b/back/src/main/java/com/qmate/common/constants/question/QuestionConstants.java
@@ -1,5 +1,7 @@
 package com.qmate.common.constants.question;
 
+import com.qmate.common.constants.HttpStatusCode;
+import com.qmate.exception.errorcode.QuestionErrorCode;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -15,11 +17,12 @@ public class QuestionConstants {
   public static final String TEXT_NOT_BLANK_MESSAGE = "질문 내용은 필수입니다.";
   public static final String TEXT_SIZE_MESSAGE = "질문은 최대 " + MAX_TEXT_LENGTH + "자까지 입력할 수 있습니다.";
 
-  // 예외 메시지
-  public static final String QUESTION_NOT_FOUND_MESSAGE = "질문을 찾을 수 없습니다.";
-  // 커스텀 질문 관련
-  public static final String CUSTOM_QUESTION_NOT_FOUND_MESSAGE = "커스텀 질문을 찾을 수 없습니다.";
-  public static final String CUSTOM_QUESTION_FORBIDDEN_MESSAGE = "본인이 생성한 질문만 수정/삭제할 수 있습니다.";
-  public static final String CUSTOM_QUESTION_NOT_EDITABLE_MESSAGE = "해당 질문은 수정할 수 없습니다.";
-  public static final String CUSTOM_QUESTION_NOT_DELETABLE_MESSAGE = "해당 질문은 삭제할 수 없습니다.";
+  // api 문서 메시지
+  public static final String UPDATE_MD =
+      "기존 질문을 부분 수정합니다.\n\n"
+          + "### 에러 응답\n\n"
+          + "| HTTP | errorCode | message |\n"
+          + "|-----:|-----|---------|\n"
+          + "| " + HttpStatusCode.NOT_FOUND + " | " + QuestionErrorCode.QUESTION_NOT_FOUND_ERROR_CODE + " | "
+          + QuestionErrorCode.QUESTION_NOT_FOUND_MESSAGE + " |\n";
 }

--- a/back/src/main/java/com/qmate/config/OpenApiConfig.java
+++ b/back/src/main/java/com/qmate/config/OpenApiConfig.java
@@ -5,7 +5,6 @@ import static com.qmate.config.OpenApiConfig.COMMON_ERRORS_MD;
 import com.qmate.exception.CommonErrorCode;
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
-import org.springframework.http.HttpStatus;
 
 @OpenAPIDefinition(
     info = @Info(
@@ -16,7 +15,8 @@ import org.springframework.http.HttpStatus;
 public class OpenApiConfig {
 
   public static final String COMMON_ERRORS_MD =
-      "## 공통 오류 규약\n"
+      "API 문서 https://qmate.notion.site/API-26cc12a8ec408024a84de4639eaf3eed\n\n"
+          + "## 공통 오류 규약\n"
           + "### 오류 바디: ErrorResponse\n"
           + "```\n"
           + "{\n"

--- a/back/src/main/java/com/qmate/config/OpenApiConfig.java
+++ b/back/src/main/java/com/qmate/config/OpenApiConfig.java
@@ -1,0 +1,44 @@
+package com.qmate.config;
+
+import static com.qmate.config.OpenApiConfig.COMMON_ERRORS_MD;
+
+import com.qmate.exception.CommonErrorCode;
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import org.springframework.http.HttpStatus;
+
+@OpenAPIDefinition(
+    info = @Info(
+        title = "Q-Mate API",
+        description = COMMON_ERRORS_MD
+    )
+)
+public class OpenApiConfig {
+
+  public static final String COMMON_ERRORS_MD =
+      "## 공통 오류 규약\n"
+          + "### 오류 바디: ErrorResponse\n"
+          + "```\n"
+          + "{\n"
+          + "  \"errorCode\": \"string\",\n"
+          + "  \"message\": \"string\",\n"
+          + "  \"errors\": [\n"
+          + "    {\n"
+          + "      \"field\": \"string\",\n"
+          + "      \"defaultMessage\": \"string\"\n"
+          + "    }\n"
+          + "  ]\n"
+          + "}\n"
+          + "```\n"
+          + "### 공통 에러 응답\n"
+          + "| HTTP | errorCode | message |\n"
+          + "|-----:|-----|---------|\n"
+          + "|" + 400 + "|" + CommonErrorCode.INVALID_INPUT_ERROR_CODE + "|" + CommonErrorCode.INVALID_INPUT_MESSAGE
+          + "|\n"
+          + "|" + 401 + "|" + CommonErrorCode.UNAUTHORIZED_ERROR_CODE + "|" + CommonErrorCode.UNAUTHORIZED_MESSAGE
+          + "|\n"
+          + "|" + 403 + "|" + CommonErrorCode.FORBIDDEN_ERROR_CODE + "|" + CommonErrorCode.FORBIDDEN_MESSAGE
+          + "|\n"
+          + "|" + 500 + "|" + CommonErrorCode.INTERNAL_SERVER_ERROR_CODE + "|" + CommonErrorCode.INTERNAL_SERVER_ERROR_MESSAGE
+          + "|\n";
+}

--- a/back/src/main/java/com/qmate/domain/question/service/QuestionCategoryService.java
+++ b/back/src/main/java/com/qmate/domain/question/service/QuestionCategoryService.java
@@ -19,6 +19,12 @@ public class QuestionCategoryService {
 
   private final QuestionCategoryRepository categoryRepository;
 
+  /**
+   * 카테고리 생성
+   *
+   * @param request 카테고리 생성 요청
+   * @return 생성된 카테고리 정보
+   */
   public QuestionCategoryResponse createCategory(QuestionCategoryCreateRequest request) {
     if (categoryRepository.existsByName(request.getName())) {
       throw new QuestionCategoryAlreadyExistException();
@@ -28,6 +34,13 @@ public class QuestionCategoryService {
     return QuestionCategoryMapper.toResponse(saved);
   }
 
+  /**
+   * 카테고리 수정
+   *
+   * @param id  수정할 카테고리 ID
+   * @param request 카테고리 수정 요청
+   * @return 수정된 카테고리 정보
+   */
   @Transactional
   public QuestionCategoryResponse updateCategory(Long id, QuestionCategoryUpdateRequest request) {
     QuestionCategory category = categoryRepository.findById(id)
@@ -42,6 +55,11 @@ public class QuestionCategoryService {
     return QuestionCategoryMapper.toResponse(category);
   }
 
+  /**
+   * 모든 카테고리 조회
+   *
+   * @return 카테고리 목록
+   */
   @Transactional(readOnly = true)
   public List<QuestionCategoryResponse> getAllCategories() {
     return categoryRepository.findAll().stream()

--- a/back/src/main/java/com/qmate/exception/CommonErrorCode.java
+++ b/back/src/main/java/com/qmate/exception/CommonErrorCode.java
@@ -9,26 +9,32 @@ import org.springframework.http.HttpStatus;
 public class CommonErrorCode extends ErrorCode {
 
   // 메시지 상수
-  private static final String INVALID_INPUT_MESSAGE = "잘못된 입력 값입니다.";
-  private static final String UNAUTHORIZED_MESSAGE = "인증에 실패했습니다.";
-  private static final String FORBIDDEN_MESSAGE = "접근 권한이 없습니다.";
-  private static final String INTERNAL_SERVER_ERROR_MESSAGE = "서버 내부 오류가 발생했습니다.";
+  public static final String INVALID_INPUT_MESSAGE = "잘못된 입력 값입니다.";
+  public static final String UNAUTHORIZED_MESSAGE = "인증에 실패했습니다.";
+  public static final String FORBIDDEN_MESSAGE = "접근 권한이 없습니다.";
+  public static final String INTERNAL_SERVER_ERROR_MESSAGE = "서버 내부 오류가 발생했습니다.";
+
+  // 에러 코드
+  public static final String INVALID_INPUT_ERROR_CODE = "COMMON_001";
+  public static final String UNAUTHORIZED_ERROR_CODE = "COMMON_002";
+  public static final String FORBIDDEN_ERROR_CODE = "COMMON_003";
+  public static final String INTERNAL_SERVER_ERROR_CODE = "COMMON_004";
 
   // 에러 코드 객체 반환 메서드
   public static ErrorCode invalidInput() {
-    return new CommonErrorCode(HttpStatus.BAD_REQUEST, "COMMON_001", INVALID_INPUT_MESSAGE);
+    return new CommonErrorCode(HttpStatus.BAD_REQUEST, INVALID_INPUT_ERROR_CODE, INVALID_INPUT_MESSAGE);
   }
 
   public static ErrorCode unauthorized() {
-    return new CommonErrorCode(HttpStatus.UNAUTHORIZED, "COMMON_002", UNAUTHORIZED_MESSAGE);
+    return new CommonErrorCode(HttpStatus.UNAUTHORIZED, UNAUTHORIZED_ERROR_CODE, UNAUTHORIZED_MESSAGE);
   }
 
   public static ErrorCode forbidden() {
-    return new CommonErrorCode(HttpStatus.FORBIDDEN, "COMMON_003", FORBIDDEN_MESSAGE);
+    return new CommonErrorCode(HttpStatus.FORBIDDEN, FORBIDDEN_ERROR_CODE, FORBIDDEN_MESSAGE);
   }
 
   public static ErrorCode internalServerError() {
-    return new CommonErrorCode(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_004",
+    return new CommonErrorCode(HttpStatus.INTERNAL_SERVER_ERROR, INTERNAL_SERVER_ERROR_CODE,
         INTERNAL_SERVER_ERROR_MESSAGE);
   }
 

--- a/back/src/main/java/com/qmate/exception/errorcode/CustomQuestionErrorCode.java
+++ b/back/src/main/java/com/qmate/exception/errorcode/CustomQuestionErrorCode.java
@@ -5,15 +5,20 @@ import org.springframework.http.HttpStatus;
 
 public class CustomQuestionErrorCode extends ErrorCode {
 
-  private static final String CUSTOM_QUESTION_NOT_FOUND_MESSAGE = "해당 커스텀 질문을 찾을 수 없습니다.";
-  private static final String CUSTOM_QUESTION_FORBIDDEN_MESSAGE = "본인이 생성한 질문만 수정/삭제할 수 있습니다.";
+  // message
+  public static final String CUSTOM_QUESTION_NOT_FOUND_MESSAGE = "해당 커스텀 질문을 찾을 수 없습니다.";
+  public static final String CUSTOM_QUESTION_FORBIDDEN_MESSAGE = "본인이 생성한 질문만 수정/삭제할 수 있습니다.";
+
+  // error code
+  public static final String CQ_NOT_FOUND_ERROR_CODE = "CQ_001";
+  public static final String CQ_FORBIDDEN_ERROR_CODE = "CQ_002";
 
   public static ErrorCode customQuestionNotFound() {
-    return new CustomQuestionErrorCode(HttpStatus.NOT_FOUND, "CQ_001", CUSTOM_QUESTION_NOT_FOUND_MESSAGE);
+    return new CustomQuestionErrorCode(HttpStatus.NOT_FOUND, CQ_NOT_FOUND_ERROR_CODE, CUSTOM_QUESTION_NOT_FOUND_MESSAGE);
   }
 
   public static ErrorCode customQuestionForbidden() {
-    return new CustomQuestionErrorCode(HttpStatus.FORBIDDEN, "CQ_002", CUSTOM_QUESTION_FORBIDDEN_MESSAGE);
+    return new CustomQuestionErrorCode(HttpStatus.FORBIDDEN, CQ_FORBIDDEN_ERROR_CODE, CUSTOM_QUESTION_FORBIDDEN_MESSAGE);
   }
 
   private CustomQuestionErrorCode(HttpStatus httpStatus, String code, String message) {

--- a/back/src/main/java/com/qmate/exception/errorcode/QuestionCategoryErrorCode.java
+++ b/back/src/main/java/com/qmate/exception/errorcode/QuestionCategoryErrorCode.java
@@ -5,15 +5,20 @@ import org.springframework.http.HttpStatus;
 
 public class QuestionCategoryErrorCode extends ErrorCode {
 
-  private static final String CATEGORY_NOT_FOUND_MESSAGE = "해당 질문 카테고리를 찾을 수 없습니다.";
-  private static final String CATEGORY_NAME_ALREADY_EXISTS_MESSAGE = "이미 존재하는 카테고리 이름입니다.";
+  // message
+  public static final String QC_NOT_FOUND_MESSAGE = "해당 질문 카테고리를 찾을 수 없습니다.";
+  public static final String QC_NAME_ALREADY_EXISTS_MESSAGE = "이미 존재하는 카테고리 이름입니다.";
+
+  // error code
+  public static final String QC_NOT_FOUND_ERROR_CODE = "QC_001";
+  public static final String QC_NAME_ALREADY_EXISTS_ERROR_CODE = "QC_002";
 
   public static ErrorCode categoryNotFound() {
-    return new QuestionCategoryErrorCode(HttpStatus.NOT_FOUND, "QC_001", CATEGORY_NOT_FOUND_MESSAGE);
+    return new QuestionCategoryErrorCode(HttpStatus.NOT_FOUND, QC_NOT_FOUND_ERROR_CODE, QC_NOT_FOUND_MESSAGE);
   }
 
   public static ErrorCode categoryNameAlreadyExists() {
-    return new QuestionCategoryErrorCode(HttpStatus.CONFLICT, "QC_002", CATEGORY_NAME_ALREADY_EXISTS_MESSAGE);
+    return new QuestionCategoryErrorCode(HttpStatus.CONFLICT, QC_NAME_ALREADY_EXISTS_ERROR_CODE, QC_NAME_ALREADY_EXISTS_MESSAGE);
   }
 
   private QuestionCategoryErrorCode(HttpStatus httpStatus, String code, String message) {

--- a/back/src/main/java/com/qmate/exception/errorcode/QuestionErrorCode.java
+++ b/back/src/main/java/com/qmate/exception/errorcode/QuestionErrorCode.java
@@ -5,12 +5,15 @@ import org.springframework.http.HttpStatus;
 
 public class QuestionErrorCode extends ErrorCode {
 
+  // message
   public static final String QUESTION_NOT_FOUND_MESSAGE = "해당 질문을 찾을 수 없습니다.";
-  // 해당 질문에 이미 평가를 남겼습니다.
   public static final String DUPLICATE_QUESTION_RATING_MESSAGE = "해당 질문에 이미 평가를 남겼습니다.";
 
+  // error code
+  public static final String QUESTION_NOT_FOUND_ERROR_CODE = "QUESTION_001";
+
   public static ErrorCode questionNotFound() {
-    return new QuestionErrorCode(HttpStatus.NOT_FOUND, "Q_001", QUESTION_NOT_FOUND_MESSAGE);
+    return new QuestionErrorCode(HttpStatus.NOT_FOUND, QUESTION_NOT_FOUND_ERROR_CODE, QUESTION_NOT_FOUND_MESSAGE);
   }
   public static ErrorCode duplicateQuestionRating() {
     return new QuestionErrorCode(HttpStatus.CONFLICT, "Q_002", DUPLICATE_QUESTION_RATING_MESSAGE);


### PR DESCRIPTION
## 개요
- Swagger(UI) 상단에 **공통 에러 규약**을 추가하고, `Question`/`QuestionCategory` 각 API의 **발생 가능한 예외**를 설명 섹션에 통합했습니다.
- 각 Operation의 `@ApiResponses`에서는 **성공 응답만 남기고**, 에러 응답은 상단/섹션 설명으로 일원화했습니다.
- `CommonErrorCode`의 상수들을 **public 상수**로 변경하여 문서 작성 시 **직접 참조** 가능하도록 했습니다.

## 스크린샷
<details>
  <summary><b>상단 설명부 (공통 에러 규약)</b></summary>

  <!-- 상단 설명부 이미지 -->
  <img src="https://github.com/user-attachments/assets/00a53ccd-83dd-4429-8458-d171810e55ea" alt="Swagger 상단 공통 에러 규약" width="980">
</details>

<details>
  <summary><b>API별 설명 섹션 예시 (Question / QuestionCategory)</b></summary>

  <!-- 각 API의 설명 섹션 예시 이미지 -->
  <img src="https://github.com/user-attachments/assets/9535549c-b03f-4307-b3a4-05a725dc84d3" alt="QuestionCategory API 설명부 예시" width="980">
</details>

## 변경 사항

- OpenAPI
  - 상단 `Info.description`에 **공통 오류 바디/코드 표** 추가
  - `Question`, `QuestionCategory` 태그/엔드포인트 설명에 **예외 목록 표** 추가 (HTTP, errorCode, message)
  - 각 Operation의 `@ApiResponses`에서 **에러 응답 제거 → 성공 응답만 유지**
- 코드
  - `CommonErrorCode` 내부 상수 접근 제어자 **private → public**(컴파일 타임 상수로 문서에서 참조)
  - 문서 상수(`HttpStatusCode`, 공통 MD 문자열) 정리 및 재사용화