### PR TITLE
feat: 매치별 커스텀 질문 리스트 API(QueryDSL) 구현 및 테스트 추가

### DIFF
--- a/back/src/main/java/com/qmate/api/question/CustomQuestionController.java
+++ b/back/src/main/java/com/qmate/api/question/CustomQuestionController.java
@@ -1,5 +1,7 @@
 package com.qmate.api.question;
 
+import com.qmate.common.constants.question.CustomQuestionConstants;
+import com.qmate.domain.question.model.request.CustomQuestionStatusFilter;
 import com.qmate.domain.question.model.request.CustomQuestionTextRequest;
 import com.qmate.domain.question.model.response.CustomQuestionResponse;
 import com.qmate.domain.question.service.CustomQuestionService;
@@ -7,6 +9,7 @@ import com.qmate.exception.ErrorResponse;
 import com.qmate.security.UserPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -14,6 +17,11 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -24,6 +32,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -117,5 +126,26 @@ public class CustomQuestionController {
       @PathVariable Long id) {
     Long userId = principal.userId();
     return ResponseEntity.ok(customQuestionService.getOne(userId, id));
+  }
+
+  @GetMapping("/matches/{matchId}/custom-questions")
+  @Operation(
+      summary = "내 커스텀 질문 리스트 조회",
+      description = CustomQuestionConstants.LIST_MD,
+      parameters = {
+          @Parameter(name = "matchId", in = ParameterIn.PATH, description = "매치 id"),
+          @Parameter(name = "status", description = "상태 필터", schema = @Schema(implementation = CustomQuestionStatusFilter.class)),
+          @Parameter(name = "sort", description = CustomQuestionConstants.SORT_DESCRIPTION)
+      }
+  )
+  //@GetMapping("/matches/{matchId}/custom-questions")
+  public Page<CustomQuestionResponse> list(
+      @AuthenticationPrincipal UserPrincipal principal,
+      @PathVariable Long matchId,
+      @RequestParam(required = false) CustomQuestionStatusFilter status,
+      @PageableDefault(page = 0, size = 20, sort = CustomQuestionConstants.SORT_KEY_CREATED_AT, direction = Sort.Direction.DESC)
+      @ParameterObject Pageable pageable
+  ) {
+    return customQuestionService.findPageByOwnerAndStatusFilter(principal.userId(), matchId, status, pageable);
   }
 }

--- a/back/src/main/java/com/qmate/common/constants/question/CustomQuestionConstants.java
+++ b/back/src/main/java/com/qmate/common/constants/question/CustomQuestionConstants.java
@@ -1,0 +1,29 @@
+package com.qmate.common.constants.question;
+
+import com.qmate.common.constants.HttpStatusCode;
+import com.qmate.exception.errorcode.CustomQuestionErrorCode;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CustomQuestionConstants {
+
+  // sort 키
+  // 추가, 제거시 queryImpl의 스위치문 변경 요구 + 아래 api 문서용 설명 변경
+  public static final String SORT_KEY_ID = "id";
+  public static final String SORT_KEY_CREATED_AT = "createdAt";
+  public static final String SORT_KEY_UPDATED_AT = "updatedAt";
+
+  // api 문서 메시지
+  public static final String LIST_MD =
+      "작성자(호출 사용자)의 커스텀 질문을 페이지로 조회합니다.\n\n"
+          + "### 에러 응답\n\n"
+          + "| HTTP | errorCode | message |\n"
+          + "|-----:|-----------|---------|\n"
+          + "| " + HttpStatusCode.BAD_REQUEST + " | " + CustomQuestionErrorCode.CQ_INVALID_SORT_KEY_ERROR_CODE + " | "
+          + CustomQuestionErrorCode.CQ_INVALID_SORT_KEY_MESSAGE + " |\n";
+
+  public static final String SORT_DESCRIPTION = "정렬: `property,(asc|desc)` / 허용 키: `" +
+      SORT_KEY_ID + "`, `" + SORT_KEY_CREATED_AT + "`, `" + SORT_KEY_UPDATED_AT + "`";
+
+}

--- a/back/src/main/java/com/qmate/domain/question/entity/CustomQuestion.java
+++ b/back/src/main/java/com/qmate/domain/question/entity/CustomQuestion.java
@@ -30,9 +30,9 @@ public class CustomQuestion {
   private Match match;
 
   @CreatedBy
-  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(nullable = false)
-  private User createdBy;
+  private Long createdBy;
+
 
   @Column(nullable = false, length = 500)
   private String text;

--- a/back/src/main/java/com/qmate/domain/question/mapper/QuestionMapper.java
+++ b/back/src/main/java/com/qmate/domain/question/mapper/QuestionMapper.java
@@ -85,8 +85,8 @@ public class QuestionMapper {
         match.getId(),
         cq.getText(),
         isEditable,
-        cq.getCreatedAt().format(ISO),
-        cq.getUpdatedAt().format(ISO)
+        cq.getCreatedAt(),
+        cq.getUpdatedAt()
     );
   }
 

--- a/back/src/main/java/com/qmate/domain/question/model/request/CustomQuestionStatusFilter.java
+++ b/back/src/main/java/com/qmate/domain/question/model/request/CustomQuestionStatusFilter.java
@@ -1,0 +1,7 @@
+package com.qmate.domain.question.model.request;
+
+public enum CustomQuestionStatusFilter {
+  EDITABLE,
+  PENDING,
+  COMPLETED
+}

--- a/back/src/main/java/com/qmate/domain/question/model/response/CustomQuestionResponse.java
+++ b/back/src/main/java/com/qmate/domain/question/model/response/CustomQuestionResponse.java
@@ -2,6 +2,7 @@ package com.qmate.domain.question.model.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.qmate.domain.match.RelationType;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -23,6 +24,6 @@ public class CustomQuestionResponse {
   @JsonProperty("isEditable") // api 명세 맞춤
   private boolean editable;
 
-  private String createdAt;
-  private String updatedAt;
+  private LocalDateTime createdAt;
+  private LocalDateTime updatedAt;
 }

--- a/back/src/main/java/com/qmate/domain/question/repository/CustomQuestionQueryRepository.java
+++ b/back/src/main/java/com/qmate/domain/question/repository/CustomQuestionQueryRepository.java
@@ -1,0 +1,11 @@
+package com.qmate.domain.question.repository;
+
+import com.qmate.domain.question.model.request.CustomQuestionStatusFilter;
+import com.qmate.domain.question.model.response.CustomQuestionResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface CustomQuestionQueryRepository {
+
+  Page<CustomQuestionResponse> findPageByOwnerAndStatusFilter(Long userId, Long matchId, CustomQuestionStatusFilter status, Pageable pageable);
+}

--- a/back/src/main/java/com/qmate/domain/question/repository/CustomQuestionQueryRepositoryImpl.java
+++ b/back/src/main/java/com/qmate/domain/question/repository/CustomQuestionQueryRepositoryImpl.java
@@ -1,0 +1,135 @@
+package com.qmate.domain.question.repository;
+
+import static com.qmate.domain.match.QMatch.match;
+import static com.qmate.domain.question.entity.QCustomQuestion.customQuestion;
+import static com.qmate.domain.questioninstance.entity.QQuestionInstance.questionInstance;
+
+import com.qmate.common.constants.question.CustomQuestionConstants;
+import com.qmate.domain.question.entity.CustomQuestion;
+import com.qmate.domain.question.model.request.CustomQuestionStatusFilter;
+import com.qmate.domain.question.model.response.CustomQuestionResponse;
+import com.qmate.domain.question.model.response.SourceType;
+import com.qmate.domain.questioninstance.entity.QuestionInstanceStatus;
+import com.qmate.exception.custom.question.CustomQuestionInvalidSortKeyException;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class CustomQuestionQueryRepositoryImpl implements CustomQuestionQueryRepository {
+
+  private final JPAQueryFactory query;
+
+  @Override
+  public Page<CustomQuestionResponse> findPageByOwnerAndStatusFilter(Long userId, Long matchId, CustomQuestionStatusFilter status,
+      Pageable pageable) {
+    BooleanBuilder where = new BooleanBuilder()
+        .and(customQuestion.createdBy.eq(userId)); // 작성자=나
+
+    if (matchId != null) {
+      where.and(customQuestion.match.id.eq(matchId));
+    }
+
+    // status 필터
+    if (status != null) {
+      switch (status) {
+        case EDITABLE -> where.and(
+            JPAExpressions.selectOne()
+                .from(questionInstance)
+                .where(questionInstance.customQuestion.eq(customQuestion))
+                .notExists()
+        );
+        case PENDING -> where.and(
+            JPAExpressions.selectOne()
+                .from(questionInstance)
+                .where(
+                    questionInstance.customQuestion.eq(customQuestion)
+                        .and(questionInstance.status.eq(QuestionInstanceStatus.PENDING))
+                ).exists()
+        );
+        case COMPLETED -> where.and(
+            JPAExpressions.selectOne()
+                .from(questionInstance)
+                .where(
+                    questionInstance.customQuestion.eq(customQuestion)
+                        .and(questionInstance.status.eq(QuestionInstanceStatus.COMPLETED))
+                ).exists()
+        );
+      }
+    }
+
+    // editable 계산식
+    BooleanExpression editableExpr = JPAExpressions.selectOne()
+        .from(questionInstance)
+        .where(questionInstance.customQuestion.eq(customQuestion))
+        .notExists();
+
+    // 정렬 변환 (Pageable 반영; 화이트리스트 적용)
+    OrderSpecifier<?>[] orderSpecifiers = toOrderSpecifiers(pageable.getSort());
+    if (orderSpecifiers.length == 0) {
+      orderSpecifiers = new OrderSpecifier<?>[]{customQuestion.createdAt.desc()};
+    }
+
+    // 데이터 조회: DTO로 바로 프로젝션 (생성자 파라미터 순서 주의)
+    List<CustomQuestionResponse> content = query
+        .select(Projections.constructor(
+            CustomQuestionResponse.class,
+            customQuestion.id,                         // customQuestionId
+            Expressions.constant(SourceType.CUSTOM),   // ← 상수 주입
+            match.relationType,                        // relationType
+            match.id,                                  // matchId
+            customQuestion.text,                       // text
+            editableExpr,                              // isEditable
+            customQuestion.createdAt,                  // createdAt (LocalDateTime)
+            customQuestion.updatedAt                   // updatedAt (LocalDateTime)
+        ))
+        .from(customQuestion)
+        .join(customQuestion.match, match)
+        .where(where)
+        .orderBy(orderSpecifiers)
+        .offset(pageable.getOffset())
+        .limit(pageable.getPageSize())
+        .fetch();
+
+    Long total = query
+        .select(customQuestion.count())
+        .from(customQuestion)
+        .where(where)
+        .fetchOne();
+
+    return new PageImpl<>(content, pageable, total == null ? 0L : total);
+  }
+
+  private OrderSpecifier<?>[] toOrderSpecifiers(Sort sort) {
+    PathBuilder<?> cq = new PathBuilder<>(CustomQuestion.class, "customQuestion");
+
+    return sort.stream()
+        .map(o -> {
+          Order dir = o.isAscending() ? Order.ASC : Order.DESC;
+          return switch (o.getProperty()) {
+            case CustomQuestionConstants.SORT_KEY_ID -> new OrderSpecifier<>(dir, cq.getNumber(CustomQuestionConstants.SORT_KEY_ID, Long.class));
+            case CustomQuestionConstants.SORT_KEY_CREATED_AT ->
+                new OrderSpecifier<>(dir, cq.get(CustomQuestionConstants.SORT_KEY_CREATED_AT, LocalDateTime.class));
+            case CustomQuestionConstants.SORT_KEY_UPDATED_AT ->
+                new OrderSpecifier<>(dir, cq.get(CustomQuestionConstants.SORT_KEY_UPDATED_AT, LocalDateTime.class));
+            default -> throw new CustomQuestionInvalidSortKeyException();
+          };
+        })
+        .toArray(OrderSpecifier[]::new);
+  }
+}

--- a/back/src/main/java/com/qmate/domain/question/repository/CustomQuestionRepository.java
+++ b/back/src/main/java/com/qmate/domain/question/repository/CustomQuestionRepository.java
@@ -5,7 +5,7 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CustomQuestionRepository extends JpaRepository<CustomQuestion, Long> {
+public interface CustomQuestionRepository extends JpaRepository<CustomQuestion, Long>, CustomQuestionQueryRepository {
 
   @EntityGraph(attributePaths = "match")
   Optional<CustomQuestion> findWithMatchById(Long id);

--- a/back/src/main/java/com/qmate/domain/question/service/CustomQuestionService.java
+++ b/back/src/main/java/com/qmate/domain/question/service/CustomQuestionService.java
@@ -56,7 +56,7 @@ public class CustomQuestionService {
     CustomQuestion entity = loadWithMatchOrThrow(id);
 
     // 본인 질문인지 확인
-    if (!Objects.equals(entity.getCreatedBy().getId(), userId)) {
+    if (!Objects.equals(entity.getCreatedBy(), userId)) {
       throw new CustomQuestionForbiddenException();
     }
 
@@ -78,7 +78,7 @@ public class CustomQuestionService {
   public void delete(Long userId, Long id) {
     CustomQuestion entity = loadOrThrow(id);
     // 본인 질문인지 확인
-    if (!Objects.equals(entity.getCreatedBy().getId(), userId)) {
+    if (!Objects.equals(entity.getCreatedBy(), userId)) {
       throw new CustomQuestionForbiddenException();
     }
     // TODO 삭제 가능한 상태인지 확인 : QuestionInstance 존재 여부로 판단
@@ -94,7 +94,7 @@ public class CustomQuestionService {
   public CustomQuestionResponse getOne(Long userId, Long id) {
     CustomQuestion entity = loadWithMatchOrThrow(id);
     // 본인 질문인지 확인
-    if (!Objects.equals(entity.getCreatedBy().getId(), userId)) {
+    if (!Objects.equals(entity.getCreatedBy(), userId)) {
       throw new CustomQuestionForbiddenException();
     }
     boolean editable = true; // TODO QuestionInstance 존재 여부로 판단

--- a/back/src/main/java/com/qmate/domain/question/service/CustomQuestionService.java
+++ b/back/src/main/java/com/qmate/domain/question/service/CustomQuestionService.java
@@ -3,6 +3,7 @@ package com.qmate.domain.question.service;
 import com.qmate.domain.match.Match;
 import com.qmate.domain.question.entity.CustomQuestion;
 import com.qmate.domain.question.mapper.QuestionMapper;
+import com.qmate.domain.question.model.request.CustomQuestionStatusFilter;
 import com.qmate.domain.question.model.request.CustomQuestionTextRequest;
 import com.qmate.domain.question.model.response.CustomQuestionResponse;
 import com.qmate.domain.question.repository.CustomQuestionRepository;
@@ -10,6 +11,8 @@ import com.qmate.exception.custom.question.CustomQuestionForbiddenException;
 import com.qmate.exception.custom.question.CustomQuestionNotFoundException;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -99,6 +102,11 @@ public class CustomQuestionService {
     }
     boolean editable = true; // TODO QuestionInstance 존재 여부로 판단
     return QuestionMapper.toResponse(entity, editable, entity.getMatch());
+  }
+
+  public Page<CustomQuestionResponse> findPageByOwnerAndStatusFilter(Long ownerUserId, Long matchId, CustomQuestionStatusFilter status,
+      Pageable pageable) {
+    return customQuestionRepository.findPageByOwnerAndStatusFilter(ownerUserId, matchId, status, pageable);
   }
 
   private Match loadMatchOrThrow(Long matchId) {

--- a/back/src/main/java/com/qmate/exception/GlobalExceptionHandler.java
+++ b/back/src/main/java/com/qmate/exception/GlobalExceptionHandler.java
@@ -1,7 +1,9 @@
 package com.qmate.exception;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -10,6 +12,7 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 @Slf4j
 @RestControllerAdvice
@@ -48,6 +51,38 @@ public class GlobalExceptionHandler {
 
     );
 
+  }
+
+  // 컨트롤러에서 타입 미스매치 예외를 처리하는 핸들러
+  @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+  public ResponseEntity<ErrorResponse> handleTypeMismatch(MethodArgumentTypeMismatchException ex) {
+    log.warn("파라미터 타입 불일치: {}", ex.getMessage());
+
+    ErrorCode errorCode = CommonErrorCode.invalidInput();
+    String field = ex.getName();
+    Object rejected = ex.getValue();
+    String detailMsg = "잘못된 파라미터 값입니다.";
+
+    // Enum인 경우 허용 가능한 값 힌트 제공
+    Class<?> required = ex.getRequiredType();
+    if (required != null && required.isEnum()) {
+      String allowed = Arrays.stream(required.getEnumConstants())
+          .map(Object::toString)
+          .collect(Collectors.joining(", "));
+      detailMsg = "허용 가능한 값: " + allowed;
+    }
+
+    List<ErrorResponse.FieldErrorDetail> errors = List.of(
+        new ErrorResponse.FieldErrorDetail(
+            field,
+            String.format("입력값 '%s'은(는) 유효하지 않습니다. %s", rejected, detailMsg)
+        )
+    );
+
+    return new ResponseEntity<>(
+        new ErrorResponse(errorCode.getCode(), errorCode.getMessage(), errors),
+        errorCode.getHttpStatus()
+    );
   }
 
   //인증 실패 예외를 처리하는 핸들러(401)

--- a/back/src/main/java/com/qmate/exception/custom/question/CustomQuestionInvalidSortKeyException.java
+++ b/back/src/main/java/com/qmate/exception/custom/question/CustomQuestionInvalidSortKeyException.java
@@ -1,0 +1,11 @@
+package com.qmate.exception.custom.question;
+
+import com.qmate.exception.BusinessGlobalException;
+import com.qmate.exception.errorcode.CustomQuestionErrorCode;
+
+public class CustomQuestionInvalidSortKeyException extends BusinessGlobalException {
+
+  public CustomQuestionInvalidSortKeyException() {
+    super(CustomQuestionErrorCode.customQuestionInvalidSortKey());
+  }
+}

--- a/back/src/main/java/com/qmate/exception/errorcode/CustomQuestionErrorCode.java
+++ b/back/src/main/java/com/qmate/exception/errorcode/CustomQuestionErrorCode.java
@@ -8,10 +8,12 @@ public class CustomQuestionErrorCode extends ErrorCode {
   // message
   public static final String CUSTOM_QUESTION_NOT_FOUND_MESSAGE = "해당 커스텀 질문을 찾을 수 없습니다.";
   public static final String CUSTOM_QUESTION_FORBIDDEN_MESSAGE = "본인이 생성한 질문만 수정/삭제할 수 있습니다.";
+  public static final String CQ_INVALID_SORT_KEY_MESSAGE = "허용되지 않은 정렬 키 입니다.";
 
   // error code
   public static final String CQ_NOT_FOUND_ERROR_CODE = "CQ_001";
   public static final String CQ_FORBIDDEN_ERROR_CODE = "CQ_002";
+  public static final String CQ_INVALID_SORT_KEY_ERROR_CODE = "CQ_003";
 
   public static ErrorCode customQuestionNotFound() {
     return new CustomQuestionErrorCode(HttpStatus.NOT_FOUND, CQ_NOT_FOUND_ERROR_CODE, CUSTOM_QUESTION_NOT_FOUND_MESSAGE);
@@ -19,6 +21,10 @@ public class CustomQuestionErrorCode extends ErrorCode {
 
   public static ErrorCode customQuestionForbidden() {
     return new CustomQuestionErrorCode(HttpStatus.FORBIDDEN, CQ_FORBIDDEN_ERROR_CODE, CUSTOM_QUESTION_FORBIDDEN_MESSAGE);
+  }
+
+  public static ErrorCode customQuestionInvalidSortKey() {
+    return new CustomQuestionErrorCode(HttpStatus.BAD_REQUEST, CQ_INVALID_SORT_KEY_ERROR_CODE, CQ_INVALID_SORT_KEY_MESSAGE);
   }
 
   private CustomQuestionErrorCode(HttpStatus httpStatus, String code, String message) {

--- a/back/src/test/java/com/qmate/api/question/CustomQuestionControllerTest.java
+++ b/back/src/test/java/com/qmate/api/question/CustomQuestionControllerTest.java
@@ -1,0 +1,160 @@
+package com.qmate.api.question;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.qmate.AuthTestUtils;
+import com.qmate.SecuritySliceTestConfig;
+import com.qmate.domain.match.RelationType;
+import com.qmate.domain.question.model.request.CustomQuestionStatusFilter;
+import com.qmate.domain.question.model.response.CustomQuestionResponse;
+import com.qmate.domain.question.model.response.SourceType;
+import com.qmate.domain.question.service.CustomQuestionService;
+import com.qmate.exception.custom.question.CustomQuestionInvalidSortKeyException;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = CustomQuestionController.class)
+@AutoConfigureMockMvc
+@Import(SecuritySliceTestConfig.class)
+class CustomQuestionControllerTest {
+
+  @Autowired
+  MockMvc mvc;
+
+  @MockitoBean
+  CustomQuestionService customQuestionService;
+
+  private CustomQuestionResponse dto(long id, long matchId, boolean editable, LocalDateTime cAt, LocalDateTime uAt) {
+    return new CustomQuestionResponse(
+        id,
+        SourceType.CUSTOM,
+        RelationType.COUPLE, // 아무 관계타입이나 고정
+        matchId,
+        "질문-" + id,
+        editable,
+        cAt,
+        uAt
+    );
+  }
+
+  @Nested
+  @DisplayName("성공")
+  class Success {
+
+    @Test
+    @DisplayName("기본 파라미터로 목록 조회 200")
+    void list_ok_defaultParams() throws Exception {
+      // given
+      long userId = 1L;
+      long matchId = 10L;
+      var cAt = LocalDateTime.parse("2025-09-11T12:00:00");
+      var uAt = LocalDateTime.parse("2025-09-11T12:34:56");
+
+      Page<CustomQuestionResponse> page = new PageImpl<>(
+          List.of(dto(101, matchId, true, cAt, uAt), dto(102, matchId, false, cAt, uAt)),
+          PageRequest.of(0, 20, Sort.by(Sort.Order.desc("createdAt"))),
+          2
+      );
+
+      given(customQuestionService.findPageByOwnerAndStatusFilter(eq(userId), eq(matchId), isNull(), any(Pageable.class)))
+          .willReturn(page);
+
+      // when & then
+      mvc.perform(get("/api/matches/{matchId}/custom-questions", matchId)
+              .with(AuthTestUtils.userPrincipal(userId))
+              .accept(MediaType.APPLICATION_JSON))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.content", hasSize(2)))
+          .andExpect(jsonPath("$.content[0].customQuestionId").value(101))
+          .andExpect(jsonPath("$.content[0].sourceType").value("CUSTOM"))
+          .andExpect(jsonPath("$.content[0].relationType").value("COUPLE"))
+          .andExpect(jsonPath("$.content[0].matchId").value((int) matchId))
+          .andExpect(jsonPath("$.content[0].text").value("질문-101"))
+          .andExpect(jsonPath("$.content[0].isEditable").value(true))
+          .andExpect(jsonPath("$.content[0].createdAt").value("2025-09-11T12:00:00"))
+          .andExpect(jsonPath("$.content[0].updatedAt").value("2025-09-11T12:34:56"))
+          .andExpect(jsonPath("$.totalElements").value(2));
+
+      then(customQuestionService).should()
+          .findPageByOwnerAndStatusFilter(eq(userId), eq(matchId), isNull(), any(Pageable.class));
+    }
+
+    @Test
+    @DisplayName("status/정렬 파라미터 포함 목록 조회 200")
+    void list_ok_withStatusAndSort() throws Exception {
+      long userId = 1L;
+      long matchId = 10L;
+      Page<CustomQuestionResponse> empty = Page.empty();
+
+      given(customQuestionService.findPageByOwnerAndStatusFilter(eq(userId), eq(matchId),
+          eq(CustomQuestionStatusFilter.COMPLETED), any(Pageable.class)))
+          .willReturn(empty);
+
+      mvc.perform(get("/api/matches/{matchId}/custom-questions", matchId)
+              .with(AuthTestUtils.userPrincipal(userId))
+              .param("status", "COMPLETED")
+              .param("sort", "createdAt,desc")
+              .param("sort", "updatedAt,asc")
+              .param("page", "0")
+              .param("size", "20")
+              .accept(MediaType.APPLICATION_JSON))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.content", hasSize(0)));
+
+      then(customQuestionService).should()
+          .findPageByOwnerAndStatusFilter(eq(userId), eq(matchId),
+              eq(CustomQuestionStatusFilter.COMPLETED), any(Pageable.class));
+    }
+  }
+
+  @Nested
+  @DisplayName("실패")
+  class Failure {
+
+    @Test
+    @DisplayName("status 소문자 등 enum 바인딩 실패 → 400")
+    void list_invalidStatus_badRequest() throws Exception {
+      mvc.perform(get("/api/matches/{matchId}/custom-questions", 10L)
+              .with(AuthTestUtils.userPrincipal(1L))
+              .param("status", "editable")) // 소문자 → 매핑 실패
+          .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("지원하지 않는 정렬 키 → 400")
+    void list_invalidSortKey_badRequest() throws Exception {
+      long userId = 1L;
+      long matchId = 10L;
+
+      given(customQuestionService.findPageByOwnerAndStatusFilter(eq(userId), eq(matchId),
+          isNull(), any(Pageable.class)))
+          .willThrow(new CustomQuestionInvalidSortKeyException());
+
+      mvc.perform(get("/api/matches/{matchId}/custom-questions", matchId)
+              .with(AuthTestUtils.userPrincipal(userId))
+              .param("sort", "unknown,asc")
+              .accept(MediaType.APPLICATION_JSON))
+          .andExpect(status().isBadRequest());
+    }
+  }
+}

--- a/back/src/test/java/com/qmate/domain/question/repository/CustomQuestionQueryRepositoryImplTest.java
+++ b/back/src/test/java/com/qmate/domain/question/repository/CustomQuestionQueryRepositoryImplTest.java
@@ -1,0 +1,145 @@
+package com.qmate.domain.question.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.qmate.config.JpaConfig;
+import com.qmate.domain.match.Match;
+import com.qmate.domain.match.RelationType;
+import com.qmate.domain.question.entity.CustomQuestion;
+import com.qmate.domain.question.model.request.CustomQuestionStatusFilter;
+import com.qmate.domain.question.model.response.CustomQuestionResponse;
+import com.qmate.domain.questioninstance.entity.QuestionInstance;
+import com.qmate.domain.questioninstance.entity.QuestionInstanceStatus;
+import com.qmate.exception.custom.question.CustomQuestionInvalidSortKeyException;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@DataJpaTest
+@Import(JpaConfig.class)
+@Tag("local")
+class CustomQuestionQueryRepositoryImplTest {
+
+  static final Long USER_ID = 100L;
+
+  @Autowired
+  EntityManager em;
+  @Autowired
+  CustomQuestionRepository repo;
+
+  @TestConfiguration
+  static class QuerydslTestConfig {
+
+    @Bean
+    JPAQueryFactory jpaQueryFactory(EntityManager em) {
+      return new JPAQueryFactory(em);
+    }
+  }
+
+  private Match persistMatch(RelationType type) {
+    Match m = Match.builder()
+        .relationType(type)
+        .build();
+    em.persist(m);
+    return m;
+  }
+
+  private CustomQuestion persistCQ(Match m, String text, Long createdBy) {
+    CustomQuestion cq = CustomQuestion.builder()
+        .match(m)
+        .text(text)
+        .createdBy(createdBy)
+        .build();
+    em.persist(cq);
+    return cq;
+  }
+
+  private QuestionInstance persistQI(CustomQuestion cq, QuestionInstanceStatus st) {
+    QuestionInstance qi = QuestionInstance.builder()
+        .customQuestion(cq)
+        .match(cq.getMatch())
+        .status(st)
+        .deliveredAt(LocalDateTime.now())
+        .build();
+    em.persist(qi);
+    return qi;
+  }
+
+  @Test
+  @DisplayName("EDITABLE: 해당 CQ에 매칭된 QI가 없으면 조회")
+  void editable_only() {
+    var m = persistMatch(RelationType.FRIEND);
+    var cq1 = persistCQ(m, "no qi", USER_ID);   // EDITABLE
+    var cq2 = persistCQ(m, "has qi", USER_ID);  // not editable
+    persistQI(cq2, QuestionInstanceStatus.PENDING);
+
+    Page<CustomQuestionResponse> page = repo.findPageByOwnerAndStatusFilter(
+        USER_ID, m.getId(), CustomQuestionStatusFilter.EDITABLE,
+        PageRequest.of(0, 20, Sort.by(Sort.Order.desc("createdAt"))));
+
+    assertThat(page.getContent()).extracting(CustomQuestionResponse::getCustomQuestionId)
+        .contains(cq1.getId()).doesNotContain(cq2.getId());
+    assertThat(page.getContent()).allMatch(CustomQuestionResponse::isEditable);
+  }
+
+  @Test
+  @DisplayName("PENDING / COMPLETED 상태 필터링")
+  void pending_completed() {
+    var m = persistMatch(RelationType.COUPLE);
+    var cqP = persistCQ(m, "pending", USER_ID);
+    var cqC = persistCQ(m, "completed", USER_ID);
+    persistQI(cqP, QuestionInstanceStatus.PENDING);
+    persistQI(cqC, QuestionInstanceStatus.COMPLETED);
+
+    Page<CustomQuestionResponse> p1 = repo.findPageByOwnerAndStatusFilter(
+        USER_ID, m.getId(), CustomQuestionStatusFilter.PENDING, PageRequest.of(0, 10));
+    Page<CustomQuestionResponse> p2 = repo.findPageByOwnerAndStatusFilter(
+        USER_ID, m.getId(), CustomQuestionStatusFilter.COMPLETED, PageRequest.of(0, 10));
+
+    assertThat(p1.getContent()).extracting(CustomQuestionResponse::getCustomQuestionId).containsExactly(cqP.getId());
+    assertThat(p2.getContent()).extracting(CustomQuestionResponse::getCustomQuestionId).containsExactly(cqC.getId());
+  }
+
+  @Test
+  @DisplayName("작성자(userId) 및 matchId 범위 이외 데이터는 제외")
+  void owner_and_match_scope() {
+    var m1 = persistMatch(RelationType.FRIEND);
+    var m2 = persistMatch(RelationType.COUPLE);
+    var cq1 = persistCQ(m1, "mine in m1", USER_ID);
+    var cq2 = persistCQ(m1, "others in m1", 999L);
+    var cq3 = persistCQ(m2, "mine in m2", USER_ID);
+
+    Page<CustomQuestionResponse> page = repo.findPageByOwnerAndStatusFilter(
+        USER_ID, m1.getId(), null, PageRequest.of(0, 20));
+
+    assertThat(page.getContent()).extracting(CustomQuestionResponse::getCustomQuestionId)
+        .contains(cq1.getId())
+        .doesNotContain(cq2.getId(), cq3.getId());
+  }
+
+  @Test
+  @DisplayName("정렬 키가 잘못되면 커스텀 예외 발생")
+  void invalid_sort_key() {
+    var m = persistMatch(RelationType.FRIEND);
+    persistCQ(m, "x", USER_ID);
+
+    assertThatThrownBy(() ->
+        repo.findPageByOwnerAndStatusFilter(USER_ID, m.getId(), null,
+            PageRequest.of(0, 10, Sort.by(Sort.Order.desc("unknown")))))
+        .isInstanceOf(CustomQuestionInvalidSortKeyException.class);
+  }
+}

--- a/back/src/test/java/com/qmate/domain/question/service/CustomQuestionServiceTest.java
+++ b/back/src/test/java/com/qmate/domain/question/service/CustomQuestionServiceTest.java
@@ -1,0 +1,124 @@
+package com.qmate.domain.question.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.*;
+
+import com.qmate.domain.question.model.request.CustomQuestionStatusFilter;
+import com.qmate.domain.question.model.response.CustomQuestionResponse;
+import com.qmate.domain.question.model.response.SourceType;
+import com.qmate.domain.question.repository.CustomQuestionRepository;
+import com.qmate.exception.custom.question.CustomQuestionInvalidSortKeyException;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+@ExtendWith(MockitoExtension.class)
+class CustomQuestionServiceTest {
+
+  @Mock
+  CustomQuestionRepository repository;
+
+  @InjectMocks
+  CustomQuestionService service;
+
+  private CustomQuestionResponse sampleDto(Long cqId, Long matchId, boolean editable) {
+    return new CustomQuestionResponse(
+        cqId,
+        SourceType.CUSTOM,
+        /* relationType */ null,
+        matchId,
+        "text-" + cqId,
+        editable,
+        LocalDateTime.now().minusDays(1),
+        LocalDateTime.now()
+    );
+  }
+
+  @Test
+  @DisplayName("정상 인자 조회시 레포 결과를 그대로 반환")
+  void list_pass_through() {
+    // given
+    Long userId = 10L, matchId = 20L;
+    var pageable = PageRequest.of(0, 20);
+    Page<CustomQuestionResponse> stub =
+        new PageImpl<>(List.of(sampleDto(1L, matchId, true)), pageable, 1);
+
+    given(repository.findPageByOwnerAndStatusFilter(userId, matchId, CustomQuestionStatusFilter.EDITABLE, pageable))
+        .willReturn(stub);
+
+    // when
+    Page<CustomQuestionResponse> result =
+        service.findPageByOwnerAndStatusFilter(userId, matchId, CustomQuestionStatusFilter.EDITABLE, pageable);
+
+    // then
+    assertThat(result.getTotalElements()).isEqualTo(1);
+    assertThat(result.getContent().getFirst().isEditable()).isTrue();
+
+    // and: 레포 호출 인자 검증
+    then(repository).should(times(1))
+        .findPageByOwnerAndStatusFilter(userId, matchId, CustomQuestionStatusFilter.EDITABLE, pageable);
+    then(repository).shouldHaveNoMoreInteractions();
+  }
+
+  @Test
+  @DisplayName("status=null 조회시 레포에 null 그대로 전달되고 모든 상태 결과를 받는다")
+  void list_with_null_status() {
+    // given
+    Long userId = 11L, matchId = 22L;
+    var pageable = PageRequest.of(1, 10);
+
+    var dto1 = new CustomQuestionResponse(1L, SourceType.CUSTOM, null, matchId, "q1", true,
+        LocalDateTime.now().minusDays(1), LocalDateTime.now());
+    var dto2 = new CustomQuestionResponse(2L, SourceType.CUSTOM, null, matchId, "q2", false,
+        LocalDateTime.now().minusDays(2), LocalDateTime.now());
+
+    Page<CustomQuestionResponse> stub =
+        new PageImpl<>(List.of(dto1, dto2), pageable, 2L);
+
+    given(repository.findPageByOwnerAndStatusFilter(userId, matchId, null, pageable))
+        .willReturn(stub);
+
+    // when
+    Page<CustomQuestionResponse> result =
+        service.findPageByOwnerAndStatusFilter(userId, matchId, null, pageable);
+
+    // then
+    assertThat(result.getNumberOfElements()).isEqualTo(2L);
+    assertThat(result.getContent())
+        .extracting(CustomQuestionResponse::getCustomQuestionId)
+        .containsExactly(1L, 2L);
+
+    // and: 레포에 status=null로 전달되었는지 캡처로 확인
+    ArgumentCaptor<CustomQuestionStatusFilter> statusCap = ArgumentCaptor.forClass(CustomQuestionStatusFilter.class);
+    then(repository).should().findPageByOwnerAndStatusFilter(eq(userId), eq(matchId), statusCap.capture(), eq(pageable));
+    assertThat(statusCap.getValue()).isNull();
+  }
+
+  @Test
+  @DisplayName("레포가 잘못된 정렬키 예외를 던지면 예외를 그대로 전파한다")
+  void list_propagates_invalid_sort_exception() {
+    // given
+    Long userId = 33L, matchId = 44L;
+    var pageable = PageRequest.of(0, 10);
+
+    given(repository.findPageByOwnerAndStatusFilter(userId, matchId, null, pageable))
+        .willThrow(new CustomQuestionInvalidSortKeyException());
+
+    // when / then
+    assertThatThrownBy(() ->
+        service.findPageByOwnerAndStatusFilter(userId, matchId, null, pageable))
+        .isInstanceOf(CustomQuestionInvalidSortKeyException.class);
+
+    then(repository).should().findPageByOwnerAndStatusFilter(userId, matchId, null, pageable);
+  }
+}


### PR DESCRIPTION
## 개요
매치 스코프에서 커스텀 질문을 페이지로 조회하는 API를 추가했습니다.  
상태 필터(EDITABLE/PENDING/COMPLETED), 정렬 키 화이트리스트, `editable` 계산(존재 여부 기반)을 지원합니다.

## 주요 변경
- **엔드포인트**: `GET api/matches/{matchId}/custom-questions`
  - **파라미터**: `status`(선택), `page`, `size`, `sort`
  - **정렬 허용 키**: `id`, `createdAt`, `updatedAt`
- **Repository (QueryDSL)**:
  - `exists / not exists` 서브쿼리로 상태 필터링
  - DTO 프로젝션: `relationType`, `matchId`, `editable`(QI 미존재 여부) 포함
  - Pageable 정렬 키를 화이트리스트 기반 `OrderSpecifier`로 변환
- **Service**: 패스스루 메서드 (`findPageByOwnerAndStatusFilter`)
- **예외**:
  - 미지원 정렬 키 → `CustomQuestionInvalidSortKeyException` → 400
- **테스트**:
  - **Repository**: 상태 필터/작성자·매치 스코프/정렬 키 예외
  - **Service (BDD Mockito)**: status=null 패스스루·예외 전파
  - **Controller (MockMvc + SecuritySlice)**: 정상/enum 바인딩 실패(400)/정렬 키 예외(400)

## 동작 확인
- Swagger에 상수 기반 설명(`CustomQuestionConstants`) 반영
- 기본 정렬: `createdAt,desc`