### PR TITLE
Feature/apply meeting feedback

### DIFF
--- a/back/src/main/java/com/qmate/api/InviteController.java
+++ b/back/src/main/java/com/qmate/api/InviteController.java
@@ -3,6 +3,8 @@ package com.qmate.api;
 import com.qmate.domain.match.model.request.InviteCodeValidationRequest;
 import com.qmate.domain.match.model.response.InviteCodeValidationResponse;
 import com.qmate.domain.match.service.MatchService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -14,11 +16,16 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/invites")
 @RequiredArgsConstructor
+@Tag(name = "InviteCodeValidation", description = "초대코드 유효성 검증")
 public class InviteController {
 
   private final MatchService matchService;
 
   @PostMapping("/validate")
+  @Operation(
+      summary = "초대코드 유효성 검증",
+      description = "발급받은 초대코드의 유효한지 및 파트너 닉네임 리턴"
+  )
   public ResponseEntity<InviteCodeValidationResponse> validateInviteCode(
       @RequestBody @Valid InviteCodeValidationRequest request
   ){

--- a/back/src/main/java/com/qmate/api/InviteController.java
+++ b/back/src/main/java/com/qmate/api/InviteController.java
@@ -1,0 +1,29 @@
+package com.qmate.api;
+
+import com.qmate.domain.match.model.request.InviteCodeValidationRequest;
+import com.qmate.domain.match.model.response.InviteCodeValidationResponse;
+import com.qmate.domain.match.service.MatchService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/invites")
+@RequiredArgsConstructor
+public class InviteController {
+
+  private final MatchService matchService;
+
+  @PostMapping("/validate")
+  public ResponseEntity<InviteCodeValidationResponse> validateInviteCode(
+      @RequestBody @Valid InviteCodeValidationRequest request
+  ){
+    InviteCodeValidationResponse response = matchService.validateInviteCode(request.getInviteCode());
+    return ResponseEntity.ok(response);
+  }
+
+}

--- a/back/src/main/java/com/qmate/api/MatchController.java
+++ b/back/src/main/java/com/qmate/api/MatchController.java
@@ -12,6 +12,8 @@ import com.qmate.domain.match.model.response.MatchJoinResponse;
 import com.qmate.domain.match.model.response.MatchMembersResponse;
 import com.qmate.domain.match.service.MatchService;
 import com.qmate.security.UserPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -29,6 +31,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/matches")
 @RequiredArgsConstructor
+@Tag(name = "Match", description = "매칭 관련 API")
 public class MatchController {
 
   private final MatchService matchService;
@@ -36,6 +39,10 @@ public class MatchController {
   //매칭 생성(초대 코드 발급)
   @ResponseStatus(HttpStatus.CREATED)
   @PostMapping
+  @Operation(
+      summary = "매칭 초대코드 발급",
+      description = "로그인한 매칭 요청자가 초대코드 발급합니다."
+  )
   public ResponseEntity<MatchCreationResponse> createMatch(
       @RequestBody @Valid MatchCreationRequest request,
       @AuthenticationPrincipal UserPrincipal principal
@@ -50,6 +57,10 @@ public class MatchController {
 
   //매칭 참여(초대 코드 입력)
   @PostMapping("/join")
+  @Operation(
+      summary = "매칭 참여 초대코드 입력",
+      description = "로그인한 초대코드 전달받은 자가 초대코드 입력합니다. "
+  )
   public ResponseEntity<MatchJoinResponse> joinMatch(
       @RequestBody @Valid MatchJoinRequest request,
       @AuthenticationPrincipal UserPrincipal principal
@@ -68,6 +79,10 @@ public class MatchController {
    * @return 200 OK 상태 코드와 함께 매칭 정보 DTO를 반환
    */
   @GetMapping("{matchId}")
+  @Operation(
+      summary = "매칭 정보 조회",
+      description = "특정 매칭의 상세 정보(관계 유형, 구성원, 시작일 등)를 조회합니다."
+  )
   public ResponseEntity<MatchInfoResponse> getMatchInfo(
       @PathVariable Long matchId,
       @AuthenticationPrincipal UserPrincipal principal
@@ -79,6 +94,10 @@ public class MatchController {
 
   //특정 매칭의 구성원 목록(상세정보)을 조회.
   @GetMapping("/{matchId}/members")
+  @Operation(
+      summary = "특정 매칭의 구성원 목록 조회",
+      description = "매칭 구성원 목록을 조회하는 API. 두 사람의 닉네임, 생일, 요청자 본인 유무, 복구동의 유무 등 멤버 정보를 불러올 때 사용합니다."
+  )
   public ResponseEntity<MatchMembersResponse> getMatchMembers(
       @PathVariable Long matchId,
       @AuthenticationPrincipal UserPrincipal principal
@@ -96,6 +115,10 @@ public class MatchController {
    * @return 200 OK 상태 코드와 함께 성공 메시지를 반환
    */
   @PatchMapping("/{matchId}/info")
+  @Operation(
+      summary = "특정 매칭의 정보를 업데이트 합니다.",
+      description = "특정 매칭 정보를 업데이트하는 API. 매칭이 성립된 후, 질문 받는 시간 등 설정을 변경할 때 사용합니다. "
+  )
   public ResponseEntity<Void> updateMatchInfo(
       @PathVariable Long matchId,
       @RequestBody @Valid MatchUpdateRequest request,
@@ -108,6 +131,10 @@ public class MatchController {
   }
   //매칭 연결을 끊습니다.(2주간의 복구 유예 기간 시작)
   @PostMapping("/{matchId}/disconnect")
+  @Operation(
+      summary = "매칭 연결을 끊습니다.",
+      description = "매칭을 종료하는 API. 사용자가 의도적으로 연결을 끊을 때 사용하며, 즉시 데이터가 삭제되는 것이 아니라 유예기간이 시작됩니다."
+  )
   public ResponseEntity<MatchActionResponse> disconnectMatch(
       @PathVariable Long matchId,
       @AuthenticationPrincipal UserPrincipal principal
@@ -119,6 +146,10 @@ public class MatchController {
   }
   //매칭 연결 복구
   @PostMapping("/{matchId}/restore")
+  @Operation(
+      summary = "매칭 연결 복구",
+      description = "2주 유예 기간 내에 매칭을 복구합니다."
+  )
   public ResponseEntity<MatchActionResponse> restoreMatch(
       @PathVariable Long matchId,
       @AuthenticationPrincipal UserPrincipal principal
@@ -135,6 +166,10 @@ public class MatchController {
   }
   //현재 로그인한 사용자의 초대 코드 입력 잠금 상태를 조회
   @GetMapping("/lock-status")
+  @Operation(
+      summary = "잠금 상태 조회",
+      description = "초대코드 입력 횟수 초과시 조회 잠금 상태 조회"
+  )
   public ResponseEntity<LockStatusResponse> getLockStatus(
       @AuthenticationPrincipal UserPrincipal principal
   ){

--- a/back/src/main/java/com/qmate/api/MatchController.java
+++ b/back/src/main/java/com/qmate/api/MatchController.java
@@ -4,6 +4,7 @@ import com.qmate.common.constants.match.MatchConstants;
 import com.qmate.domain.match.model.request.MatchCreationRequest;
 import com.qmate.domain.match.model.request.MatchJoinRequest;
 import com.qmate.domain.match.model.request.MatchUpdateRequest;
+import com.qmate.domain.match.model.response.LockStatusResponse;
 import com.qmate.domain.match.model.response.MatchActionResponse;
 import com.qmate.domain.match.model.response.MatchCreationResponse;
 import com.qmate.domain.match.model.response.MatchInfoResponse;
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -32,6 +34,7 @@ public class MatchController {
   private final MatchService matchService;
 
   //매칭 생성(초대 코드 발급)
+  @ResponseStatus(HttpStatus.CREATED)
   @PostMapping
   public ResponseEntity<MatchCreationResponse> createMatch(
       @RequestBody @Valid MatchCreationRequest request,
@@ -129,5 +132,13 @@ public class MatchController {
         : MatchConstants.RESTORE_AGREED_AWAITING_PARTNER_MESSAGE;
 
     return ResponseEntity.ok(new MatchActionResponse(message));
+  }
+  //현재 로그인한 사용자의 초대 코드 입력 잠금 상태를 조회
+  @GetMapping("/lock-status")
+  public ResponseEntity<LockStatusResponse> getLockStatus(
+      @AuthenticationPrincipal UserPrincipal principal
+  ){
+    LockStatusResponse response = matchService.getLockStatus(principal.userId());
+    return ResponseEntity.ok(response);
   }
 }

--- a/back/src/main/java/com/qmate/common/redis/RedisHelper.java
+++ b/back/src/main/java/com/qmate/common/redis/RedisHelper.java
@@ -80,4 +80,15 @@ public class RedisHelper {
     redisTemplate.opsForValue().set(lockKey, "locked", Duration.ofHours(24));
     redisTemplate.delete(countKey);//24시간 락 이후 카운트는 삭제
   }
+  /**
+   * 사용자의 잠금 상태에 대한 남은 유효시간을 초(second) 단위로 반환합니다.
+   * @param userId 조회할 사용자 ID
+   * @return 남은 시간 (초). 키가 없으면 Optional.empty() 반환
+   */
+  public Optional<Long> getLockTimeRemaining(Long userId) {
+    String key = RedisKeyConstants.LOCK_PREFIX + userId;
+    // redisTemplate.getExpire()는 키의 남은 TTL을 초 단위로 반환합니다.
+    // 키가 없거나 TTL이 설정되지 않은 경우 null을 반환할 수 있습니다.
+    return Optional.ofNullable(redisTemplate.getExpire(key));
+  }
 }

--- a/back/src/main/java/com/qmate/domain/auth/model/response/LockStatusResponse.java
+++ b/back/src/main/java/com/qmate/domain/auth/model/response/LockStatusResponse.java
@@ -1,0 +1,16 @@
+package com.qmate.domain.auth.model.response;
+
+import lombok.Getter;
+
+@Getter
+public class LockStatusResponse {
+
+  private final boolean isLocked;
+  private final Long remainingSeconds;// 남은 잠금 시간(초 단위)
+
+  public LockStatusResponse(boolean isLocked, Long remainingSeconds) {
+    this.isLocked = isLocked;
+    this.remainingSeconds = remainingSeconds;
+  }
+
+}

--- a/back/src/main/java/com/qmate/domain/match/Match.java
+++ b/back/src/main/java/com/qmate/domain/match/Match.java
@@ -77,6 +77,10 @@ public class Match {
   public void setStatus(MatchStatus status) {
     this.status = status;
   }
+  public void setMatchSetting(MatchSetting matchSetting){
+    this.matchSetting = matchSetting;
+  }
+
   public void updateStartDate(LocalDate startDate) {
     this.startDate = startDate.atStartOfDay();
   }

--- a/back/src/main/java/com/qmate/domain/match/Match.java
+++ b/back/src/main/java/com/qmate/domain/match/Match.java
@@ -11,6 +11,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -63,6 +64,9 @@ public class Match {
   @OneToMany(mappedBy = "match", cascade = CascadeType.ALL, orphanRemoval = true)
   @Builder.Default
   private List<MatchMember> members = new ArrayList<>();
+
+  @OneToOne(mappedBy = "match", cascade = CascadeType.ALL, orphanRemoval = true)
+  private MatchSetting matchSetting;
 
   //연관관계 평의 메서드
   public void addMember(MatchMember member) {

--- a/back/src/main/java/com/qmate/domain/match/model/request/InviteCodeValidationRequest.java
+++ b/back/src/main/java/com/qmate/domain/match/model/request/InviteCodeValidationRequest.java
@@ -1,0 +1,17 @@
+package com.qmate.domain.match.model.request;
+
+import com.qmate.common.constants.match.MatchConstants;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class InviteCodeValidationRequest {
+
+  @NotBlank(message = MatchConstants.INVITE_CODE_NOT_BLANK)
+  @Size(min = 6, max = 6, message = MatchConstants.INVITE_CODE_SIZE)
+  private String inviteCode;
+
+}

--- a/back/src/main/java/com/qmate/domain/match/model/response/InviteCodeValidationResponse.java
+++ b/back/src/main/java/com/qmate/domain/match/model/response/InviteCodeValidationResponse.java
@@ -1,0 +1,16 @@
+package com.qmate.domain.match.model.response;
+
+import lombok.Getter;
+
+@Getter
+public class InviteCodeValidationResponse {
+
+  private final boolean isValid;
+  private final String partnerNickname;
+
+  public InviteCodeValidationResponse(boolean isValid, String partnerNickname){
+    this.isValid = isValid;
+    this.partnerNickname = partnerNickname;
+  }
+
+}

--- a/back/src/main/java/com/qmate/domain/match/model/response/LockStatusResponse.java
+++ b/back/src/main/java/com/qmate/domain/match/model/response/LockStatusResponse.java
@@ -1,4 +1,4 @@
-package com.qmate.domain.auth.model.response;
+package com.qmate.domain.match.model.response;
 
 import lombok.Getter;
 

--- a/back/src/main/java/com/qmate/domain/match/model/response/LockStatusResponse.java
+++ b/back/src/main/java/com/qmate/domain/match/model/response/LockStatusResponse.java
@@ -6,7 +6,8 @@ import lombok.Getter;
 public class LockStatusResponse {
 
   private final boolean isLocked;
-  private final Long remainingSeconds;// 남은 잠금 시간(초 단위)
+  private final Long remainingSeconds;
+  // 남은 잠금 시간(초 단위) front에서 핸들링해서 사용가능 하게끔 Long타입 반환.
 
   public LockStatusResponse(boolean isLocked, Long remainingSeconds) {
     this.isLocked = isLocked;

--- a/back/src/main/java/com/qmate/domain/match/model/response/MatchInfoResponse.java
+++ b/back/src/main/java/com/qmate/domain/match/model/response/MatchInfoResponse.java
@@ -14,8 +14,9 @@ public class MatchInfoResponse {
   private final Long matchId;
   private final RelationType relationType;
   private final LocalDateTime startDate;
-  private final List<MemberInfoResponse> users;
   private final int dailyQuestionHour;
+  private final List<MemberInfoResponse> users;
+
 
   // Match 엔티티를 통째로 받아서 이 DTO를 완성하는 생성자
   public MatchInfoResponse(Match match, Long requesterId) {

--- a/back/src/main/java/com/qmate/domain/match/model/response/MatchInfoResponse.java
+++ b/back/src/main/java/com/qmate/domain/match/model/response/MatchInfoResponse.java
@@ -1,9 +1,11 @@
 package com.qmate.domain.match.model.response;
 
 import com.qmate.domain.match.Match;
+import com.qmate.domain.match.MatchSetting;
 import com.qmate.domain.match.RelationType;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import lombok.Getter;
 
 @Getter
@@ -13,12 +15,18 @@ public class MatchInfoResponse {
   private final RelationType relationType;
   private final LocalDateTime startDate;
   private final List<MemberInfoResponse> users;
+  private final int dailyQuestionHour;
 
   // Match 엔티티를 통째로 받아서 이 DTO를 완성하는 생성자
   public MatchInfoResponse(Match match, Long requesterId) {
     this.matchId = match.getId();
     this.relationType = match.getRelationType();
     this.startDate = match.getStartDate();
+    // MatchSetting이 존재하면 그 값을, 없으면(null) 기본값 12를 사용합니다.
+    this.dailyQuestionHour = Optional.ofNullable(match.getMatchSetting())
+        .map(MatchSetting::getDailyQuestionHour)
+        .orElse(12);
+
     // Match 엔티티가 가진 MatchMember 리스트를 순회하며 MemberInfo DTO 리스트로 변환
     this.users = match.getMembers().stream()
         .map(matchMember -> new MemberInfoResponse(matchMember, requesterId))

--- a/back/src/main/java/com/qmate/domain/match/model/response/MatchInfoResponse.java
+++ b/back/src/main/java/com/qmate/domain/match/model/response/MatchInfoResponse.java
@@ -2,6 +2,7 @@ package com.qmate.domain.match.model.response;
 
 import com.qmate.domain.match.Match;
 import com.qmate.domain.match.MatchSetting;
+import com.qmate.domain.match.MatchStatus;
 import com.qmate.domain.match.RelationType;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -15,6 +16,7 @@ public class MatchInfoResponse {
   private final RelationType relationType;
   private final LocalDateTime startDate;
   private final int dailyQuestionHour;
+  private final MatchStatus status;
   private final List<MemberInfoResponse> users;
 
 
@@ -27,6 +29,7 @@ public class MatchInfoResponse {
     this.dailyQuestionHour = Optional.ofNullable(match.getMatchSetting())
         .map(MatchSetting::getDailyQuestionHour)
         .orElse(12);
+    this.status = match.getStatus();
 
     // Match 엔티티가 가진 MatchMember 리스트를 순회하며 MemberInfo DTO 리스트로 변환
     this.users = match.getMembers().stream()

--- a/back/src/main/java/com/qmate/domain/match/service/MatchService.java
+++ b/back/src/main/java/com/qmate/domain/match/service/MatchService.java
@@ -9,6 +9,7 @@ import com.qmate.domain.match.RelationType;
 import com.qmate.domain.match.model.request.MatchCreationRequest;
 import com.qmate.domain.match.model.request.MatchJoinRequest;
 import com.qmate.domain.match.model.request.MatchUpdateRequest;
+import com.qmate.domain.match.model.response.InviteCodeValidationResponse;
 import com.qmate.domain.match.model.response.MatchCreationResponse;
 import com.qmate.domain.match.model.response.MatchInfoResponse;
 import com.qmate.domain.match.model.response.MatchJoinResponse;
@@ -18,6 +19,8 @@ import com.qmate.domain.match.repository.MatchRepository;
 import com.qmate.domain.match.repository.MatchSettingRepository;
 import com.qmate.domain.user.User;
 import com.qmate.domain.user.UserRepository;
+import com.qmate.exception.BusinessGlobalException;
+import com.qmate.exception.CommonErrorCode;
 import com.qmate.exception.custom.matchinstance.AlreadyInMatchException;
 import com.qmate.exception.custom.matchinstance.InvalidStartDateForCoupleException;
 import com.qmate.exception.custom.matchinstance.InviteAttemptLockedException;
@@ -220,6 +223,22 @@ public class MatchService {
     }
 
     return isFullyRestored;
+  }
+
+  //초대 코드의 유효성 검증하고, 코드를 생성한 파트너의 닉네임을 반환합니다.
+  @Transactional(readOnly = true)
+  public InviteCodeValidationResponse validateInviteCode(String inviteCode){
+    Long matchId = redisHelper.getMatchIdByInviteCode(inviteCode)
+        .orElseThrow(InviteCodeExpiredException::new);//코드가 없거나 만료됨
+
+    Match match = matchRepository.findWithMembersAndUsersById(matchId)
+        .orElseThrow(MatchNotFoundException::new);
+    if (match.getMembers().isEmpty()){
+      throw new BusinessGlobalException(CommonErrorCode.internalServerError());
+      //500번 처리 이유: 사용자가 무언가를 잘못했다(4xx)"가 아닌, 우리가 코드를 잘못 짜서 시스템이 고장 났다(500)"는 것을 의미
+    }
+    String partnerNickname = match.getMembers().get(0).getUser().getNickname();
+    return new InviteCodeValidationResponse(true, partnerNickname);
   }
 
 

--- a/back/src/main/java/com/qmate/domain/match/service/MatchService.java
+++ b/back/src/main/java/com/qmate/domain/match/service/MatchService.java
@@ -190,6 +190,7 @@ public class MatchService {
     if (!isMember){
       throw new MatchForbiddenException();
     }
+    match.getMembers().forEach(matchMember -> matchMember.getUser().leaveMatch());
     match.disconnect();
   }
 
@@ -213,7 +214,12 @@ public class MatchService {
                     .orElseThrow();
     requester.agreeToRestore();
 
-    return match.attemptToRestore();
+    boolean isFullyRestored = match.attemptToRestore();
+    if (isFullyRestored){
+      match.getMembers().forEach(matchMember -> matchMember.getUser().joinMatch(match));
+    }
+
+    return isFullyRestored;
   }
 
 

--- a/back/src/main/java/com/qmate/domain/match/service/MatchService.java
+++ b/back/src/main/java/com/qmate/domain/match/service/MatchService.java
@@ -95,13 +95,17 @@ public class MatchService {
       matchMemberRepository.save(joinerMember);
       match.setStatus(MatchStatus.ACTIVE);
 
-      MatchMember partner = findPartner(matchId, joinerId);
+      MatchMember partnerMember = findPartner(matchId, joinerId);
+      User partner = partnerMember.getUser();
+
+      joiner.joinMatch(match);
+      partner.joinMatch(match);
       redisHelper.deleteInviteCode(inviteCode);
 
       return MatchJoinResponse.builder()
           .matchId(matchId)
           .message("매칭에 성공적으로 참여했습니다.")
-          .partnerNickname(partner.getUser().getNickname())
+          .partnerNickname(partner.getNickname())
           .build();
     } catch (InviteCodeExpiredException e) {
       //초대 코드가 틀렸을 때 실행되는 실패 로직

--- a/back/src/main/java/com/qmate/domain/match/service/MatchService.java
+++ b/back/src/main/java/com/qmate/domain/match/service/MatchService.java
@@ -10,6 +10,7 @@ import com.qmate.domain.match.model.request.MatchCreationRequest;
 import com.qmate.domain.match.model.request.MatchJoinRequest;
 import com.qmate.domain.match.model.request.MatchUpdateRequest;
 import com.qmate.domain.match.model.response.InviteCodeValidationResponse;
+import com.qmate.domain.match.model.response.LockStatusResponse;
 import com.qmate.domain.match.model.response.MatchCreationResponse;
 import com.qmate.domain.match.model.response.MatchInfoResponse;
 import com.qmate.domain.match.model.response.MatchJoinResponse;
@@ -239,6 +240,14 @@ public class MatchService {
     }
     String partnerNickname = match.getMembers().get(0).getUser().getNickname();
     return new InviteCodeValidationResponse(true, partnerNickname);
+  }
+
+  //사용자의 초대 코드 입력 잠금 상태와 남은 시간을 조회합니다.
+  public LockStatusResponse getLockStatus(Long userId){
+    // RedisHelper를 통해 사용자의 잠금 남은 시간을 가져옴.
+    return redisHelper.getLockTimeRemaining(userId)
+        .map(remainingSeconds -> new LockStatusResponse(true, remainingSeconds)) // 잠겨있다면 (시간이 남아있다면)
+        .orElse(new LockStatusResponse(false, 0L)); // 잠겨있지 않다면
   }
 
 

--- a/back/src/main/java/com/qmate/domain/match/service/MatchService.java
+++ b/back/src/main/java/com/qmate/domain/match/service/MatchService.java
@@ -62,6 +62,8 @@ public class MatchService {
     LocalDateTime startDateTime = parseStartDate(request.getRelationType(), request.getStartDate());
     Match newMatch = Match.create(request.getRelationType(), startDateTime);
     MatchMember inviterMember = MatchMember.create(inviter, newMatch);
+    MatchSetting newMatchSetting = new MatchSetting(newMatch);
+    newMatch.setMatchSetting(newMatchSetting);
 
     matchRepository.save(newMatch);
     matchMemberRepository.save(inviterMember);

--- a/back/src/main/java/com/qmate/domain/user/User.java
+++ b/back/src/main/java/com/qmate/domain/user/User.java
@@ -1,5 +1,6 @@
 package com.qmate.domain.user;
 
+import com.qmate.domain.match.Match;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -69,5 +70,13 @@ public class User {
 
   public enum Role {
     USER, ADMIN
+  }
+  //특정 매칭에 참여할 때 currentMatchId를 업데이트.
+  public void joinMatch(Match match){
+    this.currentMatchId = match.getId();
+  }
+  //매칭에서 연결이 끊어지거나 탈퇴할 때 currentMatchId를 null로 초기화 합니다.
+  public void leaveMatch(){
+    this.currentMatchId = null;
   }
 }

--- a/back/src/test/java/com/qmate/api/InviteControllerValidateTest.java
+++ b/back/src/test/java/com/qmate/api/InviteControllerValidateTest.java
@@ -1,0 +1,85 @@
+package com.qmate.api;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.qmate.AuthTestUtils;
+import com.qmate.SecuritySliceTestConfig;
+import com.qmate.domain.match.model.request.InviteCodeValidationRequest;
+import com.qmate.domain.match.model.response.InviteCodeValidationResponse;
+import com.qmate.domain.match.service.MatchService;
+import com.qmate.exception.custom.matchinstance.InviteCodeExpiredException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = InviteController.class)
+@AutoConfigureMockMvc
+@Import(SecuritySliceTestConfig.class)
+class InviteControllerValidateTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @MockitoBean
+  private MatchService matchService;
+
+  @Test
+  @DisplayName("초대 코드 유효성 검증 성공 시 200 OK와 결과를 응답한다")
+  void validateInviteCode_success_200ok() throws Exception {
+    // given
+    var request = new InviteCodeValidationRequest();
+    request.setInviteCode("123456");
+    var fakeResponse = new InviteCodeValidationResponse(true, "파트너닉네임");
+
+    given(matchService.validateInviteCode(any(String.class))).willReturn(fakeResponse);
+
+    // expect
+    // ▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼ 이 부분의 괄호 위치가 수정되었습니다 ▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼
+    mockMvc.perform(post("/api/invites/validate")
+            .with(AuthTestUtils.userPrincipal(1L))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)) // ◀◀◀ 요청 만들기가 여기서 끝나고
+        ) // ◀◀◀ perform()의 닫는 괄호가 여기에 위치해야 합니다.
+        .andExpect(status().isOk()) // ◀◀◀ 그 다음에 응답을 검증합니다.
+        .andExpect(jsonPath("$.valid").value(true))
+        .andExpect(jsonPath("$.partnerNickname").value("파트너닉네임"));
+    // ▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲
+  }
+
+  @Test
+  @DisplayName("초대 코드 유효성 검증 실패: 코드가 유효하지 않을 시 400 Bad Request 응답")
+  void validateInviteCode_fail_400badRequest() throws Exception {
+    // given
+    var request = new InviteCodeValidationRequest();
+    request.setInviteCode("000000");
+
+    willThrow(new InviteCodeExpiredException())
+        .given(matchService).validateInviteCode(any(String.class));
+
+    // expect
+    // ▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼ 이 부분의 괄호 위치가 수정되었습니다 ▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼
+    mockMvc.perform(post("/api/invites/validate")
+            .with(AuthTestUtils.userPrincipal(1L))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request))
+        )
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.errorCode").value("MATCH_004"));
+    // ▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲
+  }
+}

--- a/back/src/test/java/com/qmate/api/MatchControllerInvitedCodeLockUserTest.java
+++ b/back/src/test/java/com/qmate/api/MatchControllerInvitedCodeLockUserTest.java
@@ -1,0 +1,64 @@
+package com.qmate.api;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.qmate.AuthTestUtils;
+import com.qmate.SecuritySliceTestConfig;
+import com.qmate.domain.match.model.response.LockStatusResponse;
+import com.qmate.domain.match.service.MatchService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = MatchController.class)
+@AutoConfigureMockMvc
+@Import(SecuritySliceTestConfig.class)
+public class MatchControllerInvitedCodeLockUserTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockitoBean
+  private MatchService matchService;
+
+  @Test
+  @DisplayName("잠금 상태 조회 성공: 잠겨있을 때 true와 남은 시간을 응답한다")
+  void getLockStatus_success_whenLocked() throws Exception {
+    // given: 서비스가 '잠겨있음' DTO를 반환하는 상황
+    Long requesterId = 1L;
+    var fakeResponse = new LockStatusResponse(true, 3600L);
+    given(matchService.getLockStatus(anyLong())).willReturn(fakeResponse);
+
+    // expect: API를 호출하면, 200 OK 응답과 DTO 내용이 정확히 와야 함
+    mockMvc.perform(get("/api/matches/lock-status")
+            .with(AuthTestUtils.userPrincipal(requesterId)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.locked").value(true))
+        .andExpect(jsonPath("$.remainingSeconds").value(3600L));
+  }
+
+  @Test
+  @DisplayName("잠금 상태 조회 성공: 잠겨있지 않을 때 false와 0을 응답한다")
+  void getLockStatus_success_whenNotLocked() throws Exception {
+    // given: 서비스가 '잠겨있지 않음' DTO를 반환하는 상황
+    Long requesterId = 2L;
+    var fakeResponse = new LockStatusResponse(false, 0L);
+    given(matchService.getLockStatus(anyLong())).willReturn(fakeResponse);
+
+    // expect
+    mockMvc.perform(get("/api/matches/lock-status")
+            .with(AuthTestUtils.userPrincipal(requesterId)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.locked").value(false))
+        .andExpect(jsonPath("$.remainingSeconds").value(0L));
+  }
+}

--- a/back/src/test/java/com/qmate/api/MatchControllerTest.java
+++ b/back/src/test/java/com/qmate/api/MatchControllerTest.java
@@ -1,7 +1,7 @@
 package com.qmate.api;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.BDDMockito.willThrow;
@@ -12,15 +12,17 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.qmate.AuthTestUtils;
+import com.qmate.SecuritySliceTestConfig;
+import com.qmate.domain.match.Match;
 import com.qmate.domain.match.RelationType;
 import com.qmate.domain.match.model.request.MatchJoinRequest;
 import com.qmate.domain.match.model.request.MatchUpdateRequest;
 import com.qmate.domain.match.model.response.MatchInfoResponse;
-import com.qmate.domain.match.Match;
 import com.qmate.domain.match.model.response.MatchMembersResponse;
 import com.qmate.domain.match.service.MatchService;
-
-import com.qmate.exception.custom.matchinstance.InviteAttemptLockedException;
+import com.qmate.exception.BusinessGlobalException;
+import com.qmate.exception.MatchErrorCode;
 import com.qmate.exception.custom.matchinstance.MatchForbiddenException;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -29,51 +31,53 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(controllers = MatchController.class)
-@AutoConfigureMockMvc(addFilters = false) // SecurityConfig를 테스트에 포함
+@AutoConfigureMockMvc
+@Import(SecuritySliceTestConfig.class)
 class MatchControllerTest {
 
   @Autowired
-  private MockMvc mockMvc; // API 요청을 보낼 가짜 웹 브라우저
+  private MockMvc mockMvc;
 
   @Autowired
-  private ObjectMapper objectMapper; // Java 객체를 JSON으로 변환
+  private ObjectMapper objectMapper;
 
-  @MockitoBean // 가짜 MatchService를 Spring에 등록
+  @MockitoBean
   private MatchService matchService;
-
 
   @Test
   @DisplayName("매칭 정보 업데이트 성공 시 204 No content 응답")
-  void updateMatchInfo_success_204noContent() throws Exception{
+  void updateMatchInfo_success_204noContent() throws Exception {
     Long matchId = 3L;
+    Long requesterId = 1L;
     var request = new MatchUpdateRequest();
     request.setDailyQuestionHour(20);
 
-    // matchService.updateMatchInfo가 호출되어도 아무 일도 일어나지 않도록 설정 (void 메서드이므로)
-    willDoNothing().given(matchService).updateMatchInfo(anyLong(), anyLong(), any(MatchUpdateRequest.class));
+    willDoNothing().given(matchService)
+        .updateMatchInfo(matchId, requesterId, request);
 
-    // expect: API를 호출하면, 204 No Content 응답이 와야 함
-    mockMvc.perform(patch("/api/matches/{matchId}/info", matchId) // PATCH 요청
+    mockMvc.perform(patch("/api/matches/{matchId}/info", matchId)
+            .with(AuthTestUtils.userPrincipal(requesterId))
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(request)))
-        .andExpect(status().isNoContent()); // 1. HTTP 상태 코드가 204 No Content인지 검증
-
+        .andExpect(status().isNoContent());
   }
+
   @Test
   @DisplayName("매칭 정보 업데이트 실패: 유효성 검증 실패 시 400 Bad Request 응답")
   void updateMatchInfo_fail_400badRequest() throws Exception {
-    // given: @Max(23) 유효성 검증을 위반하는 요청
     Long matchId = 3L;
+    Long requesterId = 1L;
     var badRequest = new MatchUpdateRequest();
-    badRequest.setDailyQuestionHour(25); // 23을 초과하는 값
+    badRequest.setDailyQuestionHour(25);
 
-    // expect: API를 호출하면, 400 Bad Request 응답이 와야 함
     mockMvc.perform(patch("/api/matches/{matchId}/info", matchId)
+            .with(AuthTestUtils.userPrincipal(requesterId))
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(badRequest)))
         .andExpect(status().isBadRequest());
@@ -82,15 +86,14 @@ class MatchControllerTest {
   @Test
   @DisplayName("매칭 멤버 상세 조회 실패: 권한 없는 접근 시 403 Forbidden 응답")
   void getMatchMembers_fail_403forbidden() throws Exception {
-    // given: 서비스가 MatchForbiddenException을 던지는 상황을 가정
     Long matchId = 4L;
+    Long requesterId = 2L;
 
-    // "만약 matchService의 getMatchMembers가 어떤 ID로든 호출되면, 이 예외를 던져라"
     willThrow(new MatchForbiddenException())
-        .given(matchService).getMatchMembers(anyLong(), anyLong());
+        .given(matchService).getMatchMembers(matchId, requesterId);
 
-    // expect: API를 호출하면, 403 Forbidden 응답과 MATCH_008 에러 코드가 와야 함
-    mockMvc.perform(get("/api/matches/{matchId}/members", matchId))
+    mockMvc.perform(get("/api/matches/{matchId}/members", matchId)
+            .with(AuthTestUtils.userPrincipal(requesterId)))
         .andExpect(status().isForbidden())
         .andExpect(jsonPath("$.errorCode").value("MATCH_008"));
   }
@@ -98,20 +101,18 @@ class MatchControllerTest {
   @Test
   @DisplayName("매칭 멤버 상세 조회 성공 시 200 OK와 DTO를 응답한다")
   void getMatchMembers_success_200ok() throws Exception {
-    // given: 서비스가 정상적으로 MatchMembersResponse DTO를 반환하는 상황
     Long matchId = 1L;
     Long requesterId = 1L;
 
-    // 서비스가 반환할 가짜 응답 DTO를 미리 만들어둠
     var fakeResponse = new MatchMembersResponse(
         Match.builder().id(matchId).members(List.of()).build(),
         requesterId
     );
 
-    given(matchService.getMatchMembers(anyLong(), anyLong())).willReturn(fakeResponse);
+    given(matchService.getMatchMembers(matchId, requesterId)).willReturn(fakeResponse);
 
-    // expect: API를 호출하면, 200 OK 응답과 DTO 내용이 정확히 와야 함
-    mockMvc.perform(get("/api/matches/{matchId}/members", matchId)) // GET 요청
+    mockMvc.perform(get("/api/matches/{matchId}/members", matchId)
+            .with(AuthTestUtils.userPrincipal(requesterId)))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.matchId").value(matchId));
   }
@@ -119,63 +120,63 @@ class MatchControllerTest {
   @Test
   @DisplayName("매칭 정보 조회 성공 시 200 OK와 DTO를 응답한다")
   void getMatchInfo_success_200ok() throws Exception {
-    // given: 서비스가 정상적으로 MatchInfoResponse DTO를 반환하는 상황
     Long matchId = 1L;
     Long requesterId = 3L;
 
-    // 서비스가 반환할 가짜 응답 DTO를 미리 만들어둠
     var fakeResponse = new MatchInfoResponse(
         Match.builder()
             .id(matchId)
             .relationType(RelationType.COUPLE)
             .startDate(LocalDateTime.now())
-            .members(List.of()) // 테스트에서는 멤버 리스트가 비어있어도 괜찮습니다.
+            .members(List.of())
             .build(),
         requesterId
     );
 
-    // matchService.getMatchInfo가 어떤 ID로든 호출되면, 위에서 만든 가짜 응답을 반환하도록 설정
-    given(matchService.getMatchInfo(anyLong(), anyLong())).willReturn(fakeResponse);
+    given(matchService.getMatchInfo(matchId, requesterId)).willReturn(fakeResponse);
 
-    // expect: API를 호출하면, 200 OK 응답과 DTO 내용이 정확히 와야 함
-    mockMvc.perform(get("/api/matches/{matchId}", matchId)) // GET 요청
-        .andExpect(status().isOk()) // 1. HTTP 상태 코드가 200 OK인지 검증
-        .andExpect(jsonPath("$.matchId").value(matchId)) // 2. 응답 JSON의 필드 검증
+    mockMvc.perform(get("/api/matches/{matchId}", matchId)
+            .with(AuthTestUtils.userPrincipal(requesterId)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.matchId").value(matchId))
         .andExpect(jsonPath("$.relationType").value("COUPLE"));
   }
 
   @Test
   @DisplayName("매칭 정보 조회 실패: 권한 없는 접근 시 403 Forbidden 응답")
   void getMatchInfo_fail_403forbidden() throws Exception {
-    // given: 서비스가 MatchForbiddenException을 던지는 상황
     Long matchId = 2L;
+    Long requesterId = 5L;
 
-    // "만약 matchService의 getMatchInfo가 어떤 ID로든 호출되면, 이 예외를 던져라"
     willThrow(new MatchForbiddenException())
-        .given(matchService).getMatchInfo(anyLong(), anyLong());
+        .given(matchService).getMatchInfo(matchId, requesterId);
 
-    // expect: API를 호출하면, 403 Forbidden 응답과 MATCH_008 에러 코드가 와야 함
-    mockMvc.perform(get("/api/matches/{matchId}", matchId))
-        .andExpect(status().isForbidden()) // 1. HTTP 상태 코드가 403 Forbidden인지 검증
-        .andExpect(jsonPath("$.errorCode").value("MATCH_008")); // 2. 응답 JSON의 에러 코드 검증
+    mockMvc.perform(get("/api/matches/{matchId}", matchId)
+            .with(AuthTestUtils.userPrincipal(requesterId)))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.errorCode").value("MATCH_008"));
   }
 
   @Test
   @DisplayName("매칭 참여 실패: 5회 시도 잠금 시 403 Forbidden 응답")
   void joinMatch_fail_whenLocked() throws Exception {
-    // given: matchService가 InviteAttemptLockedException을 던지도록 설정
+    Long requesterId = 7L;
     var request = new MatchJoinRequest();
     request.setInviteCode("000000");
 
-    willThrow(new InviteAttemptLockedException())
-        .given(matchService).joinMatch(any(MatchJoinRequest.class), anyLong());
+    // InviteAttemptLockedException이 BusinessGlobalException을 상속하고,
+    // MatchErrorCode.inviteAttemptLocked()를 넘겨줘야 함
+    willThrow(new BusinessGlobalException(MatchErrorCode.inviteAttemptLocked()))
+        .given(matchService).joinMatch(any(MatchJoinRequest.class), eq(requesterId));
 
-    // expect: API를 호출하면, 403 Forbidden 응답과 MATCH_007 에러 코드가 와야 함
     mockMvc.perform(post("/api/matches/join")
+            .with(AuthTestUtils.userPrincipal(requesterId))
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(request)))
-        .andExpect(status().isForbidden())
-        .andExpect(jsonPath("$.errorCode").value("MATCH_007"));
+        .andExpect(status().isForbidden())              // 403
+        .andExpect(jsonPath("$.errorCode").value(
+            "MATCH_007")) // JSON 응답 필드명이 $.errorCode가 아니라 $.code일 가능성 있음
+        .andExpect(jsonPath("$.message").value("초대 코드 입력 5회 실패하여 24시간 동안 시도할 수 없습니다."));
   }
-}
 
+}

--- a/back/src/test/java/com/qmate/domain/match/service/MatchServiceCurrentMatchIdTest.java
+++ b/back/src/test/java/com/qmate/domain/match/service/MatchServiceCurrentMatchIdTest.java
@@ -1,0 +1,102 @@
+package com.qmate.domain.match.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import com.qmate.domain.match.MatchStatus;
+import com.qmate.domain.match.Match;
+import com.qmate.domain.match.MatchMember;
+import com.qmate.domain.match.model.request.MatchJoinRequest;
+import com.qmate.domain.match.repository.MatchMemberRepository;
+import com.qmate.domain.match.repository.MatchRepository;
+import com.qmate.domain.user.User;
+import com.qmate.domain.user.UserRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import com.qmate.common.redis.RedisHelper;
+
+
+@ExtendWith(MockitoExtension.class)
+class MatchServiceCurrentMatchIdTest {
+
+  @InjectMocks
+  private MatchService sut;
+
+  @Mock
+  private MatchRepository matchRepository;
+  @Mock
+  private MatchMemberRepository matchMemberRepository;
+  @Mock
+  private UserRepository userRepository;
+  @Mock
+  private RedisHelper redisHelper;
+
+  @Test
+  @DisplayName("매칭 참여 성공: 두 멤버의 current_match_id가 업데이트된다")
+  void joinMatch_success_updatesCurrentMatchId() {
+    // given: 3번 유저(초대자)와 4번 유저(참여자)가 5번 매칭에 참여하는 상황
+    Long matchId = 5L;
+    Long inviterId = 3L;
+    Long joinerId = 4L;
+
+    User inviter = User.builder().id(inviterId).build();
+    User joiner = User.builder().id(joinerId).build();
+    Match match = Match.builder().id(matchId).build();
+
+    MatchMember inviterMember = MatchMember.create(inviter, match);
+    match.addMember(inviterMember);
+
+    var request = new MatchJoinRequest();
+    request.setInviteCode("123456");
+
+    // Repository들의 행동을 정의(stubbing)합니다.
+    given(userRepository.findById(joinerId)).willReturn(Optional.of(joiner));
+    given(redisHelper.getMatchIdByInviteCode("123456")).willReturn(Optional.of(matchId));
+    given(matchRepository.findById(matchId)).willReturn(Optional.of(match));
+
+    // ▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼ 이 부분이 핵심 수정사항입니다 ▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼
+    // "matchMemberRepository에게 findAllBy...를 요청하면, '초대자'가 담긴 리스트를 돌려줘" 라는 대본
+    given(matchMemberRepository.findAllByMatch_Id(matchId)).willReturn(List.of(inviterMember));
+    // ▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲
+
+    // when: 4번 유저가 매칭에 참여하면
+    sut.joinMatch(request, joinerId);
+
+    // then: 두 유저의 currentMatchId가 매칭 ID로 설정되었는지 검증
+    assertThat(joiner.getCurrentMatchId()).isEqualTo(matchId);
+    assertThat(inviter.getCurrentMatchId()).isEqualTo(matchId);
+  }
+
+  @Test
+  @DisplayName("연결 끊기 성공: 두 멤버의 current_match_id가 null로 초기화된다")
+  void disconnectMatch_success_clearsCurrentMatchId() {
+    // given: 5번 매칭에 3번, 4번 유저가 속해있는 상황
+    Long matchId = 5L;
+    Long requesterId = 3L;
+
+    User user3 = User.builder().id(3L).build();
+    User user4 = User.builder().id(4L).build();
+    Match match = Match.builder().id(matchId).status(MatchStatus.ACTIVE).build();
+    match.addMember(MatchMember.create(user3, match));
+    match.addMember(MatchMember.create(user4, match));
+
+    // 연결 끊기 전에는 current_match_id가 설정되어 있다고 가정
+    user3.joinMatch(match);
+    user4.joinMatch(match);
+
+    given(matchRepository.findWithMembersAndUsersById(matchId)).willReturn(Optional.of(match));
+
+    // when: 3번 유저가 연결 끊기를 요청하면
+    sut.disconnectMatch(matchId, requesterId);
+
+    // then: 두 유저의 currentMatchId가 null로 변경되었는지 검증
+    assertThat(user3.getCurrentMatchId()).isNull();
+    assertThat(user4.getCurrentMatchId()).isNull();
+  }
+}

--- a/back/src/test/java/com/qmate/domain/match/service/MatchServiceInvitedCodeLockUserTest.java
+++ b/back/src/test/java/com/qmate/domain/match/service/MatchServiceInvitedCodeLockUserTest.java
@@ -1,0 +1,55 @@
+package com.qmate.domain.match.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import com.qmate.common.redis.RedisHelper;
+import com.qmate.domain.match.model.response.LockStatusResponse;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class MatchServiceInvitedCodeLockUserTest {
+
+  @InjectMocks
+  private MatchService sut;
+
+  @Mock
+  private RedisHelper redisHelper;
+
+  @Test
+  @DisplayName("잠금 상태 조회: 사용자가 잠겨있는 경우")
+  void getLockStatus_whenUserIsLocked() {
+    // given: 1번 유저가 잠겨있고, 남은 시간이 3600초인 상황을 가정
+    Long userId = 1L;
+    Long remainingSeconds = 3600L;
+    given(redisHelper.getLockTimeRemaining(userId)).willReturn(Optional.of(remainingSeconds));
+
+    // when: 서비스 메서드를 실행하면
+    LockStatusResponse response = sut.getLockStatus(userId);
+
+    // then: isLocked는 true이고, 남은 시간이 정확히 반환되어야 한다
+    assertThat(response.isLocked()).isTrue();
+    assertThat(response.getRemainingSeconds()).isEqualTo(remainingSeconds);
+  }
+
+  @Test
+  @DisplayName("잠금 상태 조회: 사용자가 잠겨있지 않은 경우")
+  void getLockStatus_whenUserIsNotLocked() {
+    // given: 2번 유저가 잠겨있지 않은 상황 (Redis에 키가 없음)
+    Long userId = 2L;
+    given(redisHelper.getLockTimeRemaining(userId)).willReturn(Optional.empty());
+
+    // when: 서비스 메서드를 실행하면
+    LockStatusResponse response = sut.getLockStatus(userId);
+
+    // then: isLocked는 false이고, 남은 시간은 0이어야 한다
+    assertThat(response.isLocked()).isFalse();
+    assertThat(response.getRemainingSeconds()).isEqualTo(0L);
+  }
+}

--- a/back/src/test/java/com/qmate/domain/match/service/MatchServiceValidateTest.java
+++ b/back/src/test/java/com/qmate/domain/match/service/MatchServiceValidateTest.java
@@ -1,0 +1,84 @@
+package com.qmate.domain.match.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import com.qmate.common.redis.RedisHelper;
+import com.qmate.domain.match.Match;
+import com.qmate.domain.match.MatchMember;
+import com.qmate.domain.match.model.response.InviteCodeValidationResponse;
+import com.qmate.domain.match.repository.MatchRepository;
+import com.qmate.domain.user.User;
+import com.qmate.exception.BusinessGlobalException;
+import com.qmate.exception.custom.matchinstance.InviteCodeExpiredException;
+import java.util.Collections;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MatchServiceValidateTest {
+
+  @InjectMocks
+  private MatchService sut;
+
+  @Mock
+  private RedisHelper redisHelper;
+  @Mock
+  private MatchRepository matchRepository;
+
+  @Test
+  @DisplayName("초대 코드 유효성 검증 성공")
+  void validateInviteCode_success() {
+    // given: 유효한 초대 코드가 주어졌고, 해당 매칭에 초대자 1명이 있는 정상적인 상황
+    String validCode = "123456";
+    Long matchId = 1L;
+    User inviter = User.builder().id(10L).nickname("초대자닉네임").build();
+    Match match = Match.builder().id(matchId).build();
+    match.addMember(MatchMember.create(inviter, match));
+
+    given(redisHelper.getMatchIdByInviteCode(validCode)).willReturn(Optional.of(matchId));
+    given(matchRepository.findWithMembersAndUsersById(matchId)).willReturn(Optional.of(match));
+
+    // when: 서비스 메서드를 실행하면
+    InviteCodeValidationResponse response = sut.validateInviteCode(validCode);
+
+    // then: 유효성 결과는 true이고, 파트너 닉네임이 정확히 반환되어야 한다
+    assertThat(response.isValid()).isTrue();
+    assertThat(response.getPartnerNickname()).isEqualTo("초대자닉네임");
+  }
+
+  @Test
+  @DisplayName("초대 코드 유효성 검증 실패: 코드가 존재하지 않거나 만료된 경우")
+  void validateInviteCode_fail_codeNotFound() {
+    // given: 존재하지 않는 초대 코드가 주어짐
+    String invalidCode = "000000";
+    given(redisHelper.getMatchIdByInviteCode(invalidCode)).willReturn(Optional.empty());
+
+    // expect: InviteCodeExpiredException 예외가 발생해야 함
+    assertThatThrownBy(() -> sut.validateInviteCode(invalidCode))
+        .isInstanceOf(InviteCodeExpiredException.class);
+  }
+
+  @Test
+  @DisplayName("초대 코드 유효성 검증 실패: 매칭에 멤버가 없는 비정상적인 경우 (500)")
+  void validateInviteCode_fail_noMemberInMatch() {
+    // given: 코드는 유효하지만, 어찌된 일인지 해당 매칭에 멤버가 한 명도 없는 데이터 꼬인 상황
+    String validCode = "123456";
+    Long matchId = 1L;
+    Match matchWithNoMembers = Match.builder().id(matchId).members(Collections.emptyList()).build();
+
+    given(redisHelper.getMatchIdByInviteCode(validCode)).willReturn(Optional.of(matchId));
+    given(matchRepository.findWithMembersAndUsersById(matchId)).willReturn(Optional.of(matchWithNoMembers));
+
+    // expect: BusinessGlobalException (500 서버 에러) 예외가 발생해야 함
+    assertThatThrownBy(() -> sut.validateInviteCode(validCode))
+        .isInstanceOf(BusinessGlobalException.class)
+        .hasMessageContaining("매칭에 참여한 사용자가 없습니다.");
+  }
+}


### PR DESCRIPTION
### 개요

회의시 피드백을 반영하여, **프론트엔드의 사용성 개선과 백엔드 데이터 관리 효율화를 위한 기능들을 구현 및 개선**했습니다.

주요 작업으로는 **(1) 매칭 정보 조회 API의 응답 데이터 보강**, **(2) 매칭 상태에 따른 `User`의 `current_match_id` 자동 업데이트**, 그리고 프론트엔드 편의를 위한 **(3) 초대 코드 유효성 검증 API**와 **(4) 잠금 상태 조회 API** 신규 개발이 있습니다. 또한, API 명세서의 가독성을 높이기 위해 Swagger 문서 보강 작업을 진행했습니다.

### 변경 사항

#### API
- **`GET /api/matches/{matchId}` (수정)**
    - 프론트엔드에서 매칭 상태 및 질문 시간 설정을 표시할 수 있도록, 응답 DTO(`MatchInfoResponse`)에 `status`와 `dailyQuestionHour` 필드를 추가했습니다.
- **`POST /api/invites/validate` (신규)**
    - 사용자가 매칭에 참여하기 전에, 초대 코드의 유효성과 상대방의 닉네임을 미리 확인할 수 있는 API를 추가했습니다.
- **`GET /auth/lock-status` (신규)**
    - 초대 코드 입력 5회 실패로 계정이 잠겼을 경우, 프론트엔드에서 남은 잠금 시간을 사용자에게 안내할 수 있는 API를 추가했습니다.(반환 타입은 Long 타입 프론트 쪽에서 핸들링 가능하게금 처리.)

#### DTO
- **`MatchInfoResponse` (수정):** `status`, `dailyQuestionHour` 필드를 추가했습니다.
- **`InviteCodeValidationRequest/Response` (신규):** 초대 코드 유효성 검증을 위한 DTO를 추가했습니다.
- **`LockStatusResponse` (신규):** 잠금 상태 조회를 위한 DTO를 추가했습니다.

#### Service
- **`MatchService` (수정)**
    - `joinMatch`: 매칭이 성사(`ACTIVE`)되면, 두 `User`의 `current_match_id`가 해당 `matchId`로 업데이트되도록 로직을 추가했습니다.
    - `disconnectMatch`: 매칭 연결이 끊어지면, 두 `User`의 `current_match_id`가 `null`로 초기화되도록 로직을 추가했습니다.
- **`MatchService` (신규)**
    - `validateInviteCode`: Redis의 초대 코드를 검증하고 상대방 닉네임을 반환하는 로직을 구현했습니다.
- **`AuthService` (신규)**
    - `getLockStatus`: Redis의 `LOCK` 키에 대한 TTL을 조회하여 남은 잠금 시간을 반환하는 로직을 구현했습니다.

#### Entity
- **`User.java`:** `current_match_id`를 쉽게 변경할 수 있는 `joinMatch(Match)`와 `leaveMatch()` 편의 메서드를 추가했습니다.
- **`Match.java`:** `MatchSetting` 정보에 쉽게 접근할 수 있도록 `1:1` 양방향 연관관계를 설정했습니다.

#### API 문서 (OpenAPI / Swagger)
- `MatchController`와 `InviteController`에 `@Tag`와 `@Operation` 어노테이션을 추가하여, 각 API의 역할과 설명을 명확하게 문서화했습니다.

### 테스트
- **[X] 서비스 단위 테스트**
    - `dailyQuestionHour`가 추가된 `MatchInfoResponse` 검증 테스트를 보강했습니다.
    - `current_match_id`가 `joinMatch`와 `disconnectMatch` 시점에 올바르게 변경/초기화되는지 검증하는 테스트를 추가했습니다.
    - `validateInviteCode`, `getLockStatus` 등 신규 서비스 로직에 대한 성공/실패 케이스를 모두 검증했습니다.
- **[X] 컨트롤러 단위 테스트**
    - 신규 API 엔드포인트(`validate`, `lock-status`)에 대한 테스트를 추가하고, 모든 테스트가 `AuthTestUtils`를 사용하여 인증된 사용자 컨텍스트에서 동작하도록 개선했습니다.
- **[X] API 테스트 (Postman)**
    - 실제 이메일 인증부터 회원가입, 로그인, 토큰 발급, API 호출까지 이어지는 전체 시나리오를 통해 모든 기능의 정상 동작을 최종 검증했습니다.