### PR TITLE
feat(user): profile(nickname, birthdate) update api, nickname update api

### DIFF
--- a/back/src/main/java/com/qmate/api/UserProfileController.java
+++ b/back/src/main/java/com/qmate/api/UserProfileController.java
@@ -1,0 +1,57 @@
+package com.qmate.api;
+
+import com.qmate.domain.user.ProfileService;
+import com.qmate.security.UserPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/users/me")
+@Tag(name = "UserProfile", description = "User 데이터 변경 API")
+public class UserProfileController {
+  private final ProfileService profileService;
+
+  @PatchMapping("/profile")
+  @Operation(
+      summary = "프로필 데이터 수정(nickname, birthdate)",
+      description = ""
+  )
+  public UpdateProfileRes updateProfile(@AuthenticationPrincipal UserPrincipal me,
+      @RequestBody UpdateProfileReq req) {
+    boolean updated = profileService.updateProfile(me.userId(), normalizeNick(req.nickname()), parseDate(req.birthDate()));
+    return new UpdateProfileRes(me.userId(), updated);
+  }
+
+  @PatchMapping("/nickname")
+  @Operation(
+      summary = "별명만 수정",
+      description = ""
+  )
+  public UpdateProfileRes updateNickname(@AuthenticationPrincipal UserPrincipal me, @RequestBody UpdateNicknameReq req) {
+    boolean updated = profileService.updateProfile(me.userId(), normalizeNick(req.nickname()), null);
+    return new UpdateProfileRes(me.userId(), updated);
+  }
+
+  private String normalizeNick(String s) {
+    if (s == null) return null;
+    String t = s.trim();
+    return t.isEmpty() ? null : t;
+  }
+  private LocalDate parseDate(String s) {
+    if (s == null || s.isBlank()) return null;
+    return LocalDate.parse(s);
+  }
+
+  public record UpdateProfileReq(String nickname, String birthDate) {}
+  public record UpdateProfileRes(Long id, boolean updated) {}
+  public record UpdateNicknameReq(String nickname) {}
+}
+

--- a/back/src/main/java/com/qmate/domain/user/ProfileService.java
+++ b/back/src/main/java/com/qmate/domain/user/ProfileService.java
@@ -1,0 +1,35 @@
+package com.qmate.domain.user;
+
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ProfileService {
+  private final UserRepository userRepository;
+
+  @Transactional
+  public boolean updateProfile(Long userId, String nickname, LocalDate birthDate) {
+    User u = userRepository.findById(userId).orElseThrow();
+    boolean changed = false;
+
+    if (nickname != null) {
+      if (nickname.length() > 50) throw new IllegalArgumentException("닉네임은 50자 이내");
+      if (!nickname.equals(u.getNickname())) {
+        u.setNickname(nickname);
+        changed = true;
+      }
+    }
+
+    if (birthDate != null) {
+      if (birthDate.isAfter(LocalDate.now())) throw new IllegalArgumentException("미래 날짜 불가");
+      if (!birthDate.equals(u.getBirthDate())) {
+        u.setBirthDate(birthDate);
+        changed = true;
+      }
+    }
+    return changed;
+  }
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

- 프로필(별명, 생년월일) 변경 API 부재
- 소유자 검증을 클라이언트 입력 id로 하지 않음(설계 불가)


**TO-BE**

- PATCH /api/users/me/profile: 별명(nickname), 생년월일(birthDate) 부분 수정

> Request: {"nickname":"수아","birthDate":"1999-08-27"} (둘 중 제공된 필드만 반영, 빈 문자열은 무시)
> Response: {"id": <Long>, "updated": true|false}
> 검증: 닉네임 최대 50자, 생일 포맷 yyyy-MM-dd, 미래 날짜 불가

- PATCH /api/users/me/nickname: 별명만 부분 수정

> Request: {"nickname":"수아"}
> Response: {"id": <Long>, "updated": true|false}

- 권한/보안: @AuthenticationPrincipal의 userId 사용 → 본인만 수정 가능
- 서비스 레이어 도입: ProfileService.updateProfile(...)에서 트랜잭션 + 더티체킹으로 업데이트

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- API 테스트 :브라우저로 소셜 로그인 후 발급된 액세스 토큰을 postman에 넣어 api 테스트 완료