### PR TITLE
# feat: 일정(Event) 엔티티 추가 및 CRUD API 구현

### DIFF
--- a/back/src/main/java/com/qmate/api/event/EventController.java
+++ b/back/src/main/java/com/qmate/api/event/EventController.java
@@ -1,13 +1,19 @@
 package com.qmate.api.event;
 
+import com.qmate.common.constants.event.EventConstants;
 import com.qmate.domain.event.model.request.EventCreateRequest;
 import com.qmate.domain.event.model.request.EventUpdateRequest;
 import com.qmate.domain.event.model.response.EventResponse;
 import com.qmate.domain.event.service.EventService;
 import com.qmate.security.UserPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -17,11 +23,13 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "Event", description = "일정 API")
+@SecurityRequirement(name = "bearerAuth")
 @RequestMapping("/api")
 public class EventController {
 
@@ -30,6 +38,14 @@ public class EventController {
   /**
    * 일정 생성
    */
+  @ResponseStatus(HttpStatus.CREATED)
+  @Operation(
+      summary = "일정 생성",
+      description = EventConstants.CREATE_MD,
+      parameters = {
+          @Parameter(name = "matchId", description = "매치 ID")
+      }
+  )
   @PostMapping("/matches/{matchId}/events")
   public ResponseEntity<EventResponse> createEvent(
       @PathVariable Long matchId,
@@ -48,6 +64,14 @@ public class EventController {
   /**
    * 일정 단건 조회
    */
+  @Operation(
+      summary = "일정 단건 조회",
+      description = EventConstants.GET_DETAIL_MD,
+      parameters = {
+          @Parameter(name = "matchId", description = "매치 ID"),
+          @Parameter(name = "eventId", description = "일정 ID")
+      }
+  )
   @GetMapping("/matches/{matchId}/events/{eventId}")
   public ResponseEntity<EventResponse> getEvent(
       @PathVariable Long matchId,
@@ -63,6 +87,14 @@ public class EventController {
    * 일정 수정
    * - 기념일 이벤트(anniversary=true)는 반복 설정(repeatType) 변경 불가
    */
+  @Operation(
+      summary = "일정 수정",
+      description = EventConstants.UPDATE_MD,
+      parameters = {
+          @Parameter(name = "matchId", description = "매치 ID"),
+          @Parameter(name = "eventId", description = "일정 ID")
+      }
+  )
   @PatchMapping("/matches/{matchId}/events/{eventId}")
   public ResponseEntity<EventResponse> updateEvent(
       @PathVariable Long matchId,
@@ -79,6 +111,15 @@ public class EventController {
    * 일정 삭제
    * - 기념일 이벤트(anniversary=true)는 삭제 불가
    */
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  @Operation(
+      summary = "일정 삭제",
+      description = EventConstants.DELETE_MD,
+      parameters = {
+          @Parameter(name = "matchId", description = "매치 ID"),
+          @Parameter(name = "eventId", description = "일정 ID")
+      }
+  )
   @DeleteMapping("/matches/{matchId}/events/{eventId}")
   public ResponseEntity<Void> deleteEvent(
       @PathVariable Long matchId,

--- a/back/src/main/java/com/qmate/api/event/EventController.java
+++ b/back/src/main/java/com/qmate/api/event/EventController.java
@@ -36,10 +36,7 @@ public class EventController {
 
     EventResponse response = eventService.createEvent(matchId, userId, request);
 
-    URI location = ServletUriComponentsBuilder.fromCurrentContextPath()
-        .path("/api/events/{id}")
-        .buildAndExpand(response.getEventId())
-        .toUri();
+    URI location = URI.create("/api/events/" + response.getEventId());
 
     return ResponseEntity.created(location).body(response);
   }

--- a/back/src/main/java/com/qmate/api/event/EventController.java
+++ b/back/src/main/java/com/qmate/api/event/EventController.java
@@ -1,0 +1,46 @@
+package com.qmate.api.event;
+
+import com.qmate.domain.event.model.request.EventCreateRequest;
+import com.qmate.domain.event.model.response.EventResponse;
+import com.qmate.domain.event.service.EventService;
+import com.qmate.security.UserPrincipal;
+import jakarta.validation.Valid;
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class EventController {
+
+  private final EventService eventService;
+
+  /**
+   * 일정 생성
+   */
+  @PostMapping("/matches/{matchId}/events")
+  public ResponseEntity<EventResponse> createEvent(
+      @PathVariable Long matchId,
+      @AuthenticationPrincipal UserPrincipal principal,
+      @Valid @RequestBody EventCreateRequest request
+  ) {
+    Long userId = principal.userId();
+
+    EventResponse response = eventService.createEvent(matchId, userId, request);
+
+    URI location = ServletUriComponentsBuilder.fromCurrentContextPath()
+        .path("/api/events/{id}")
+        .buildAndExpand(response.getEventId())
+        .toUri();
+
+    return ResponseEntity.created(location).body(response);
+  }
+}

--- a/back/src/main/java/com/qmate/api/event/EventController.java
+++ b/back/src/main/java/com/qmate/api/event/EventController.java
@@ -9,6 +9,7 @@ import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -39,5 +40,19 @@ public class EventController {
     URI location = URI.create("/api/events/" + response.getEventId());
 
     return ResponseEntity.created(location).body(response);
+  }
+
+  /**
+   * 일정 단건 조회
+   */
+  @GetMapping("/matches/{matchId}/events/{eventId}")
+  public ResponseEntity<EventResponse> getEvent(
+      @PathVariable Long matchId,
+      @PathVariable Long eventId,
+      @AuthenticationPrincipal UserPrincipal principal
+  ) {
+    Long userId = principal.userId();
+    EventResponse response = eventService.getEvent(matchId, userId, eventId);
+    return ResponseEntity.ok(response);
   }
 }

--- a/back/src/main/java/com/qmate/api/event/EventController.java
+++ b/back/src/main/java/com/qmate/api/event/EventController.java
@@ -1,6 +1,7 @@
 package com.qmate.api.event;
 
 import com.qmate.domain.event.model.request.EventCreateRequest;
+import com.qmate.domain.event.model.request.EventUpdateRequest;
 import com.qmate.domain.event.model.response.EventResponse;
 import com.qmate.domain.event.service.EventService;
 import com.qmate.security.UserPrincipal;
@@ -9,7 +10,9 @@ import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -54,5 +57,36 @@ public class EventController {
     Long userId = principal.userId();
     EventResponse response = eventService.getEvent(matchId, userId, eventId);
     return ResponseEntity.ok(response);
+  }
+
+  /**
+   * 일정 수정
+   * - 기념일 이벤트(anniversary=true)는 반복 설정(repeatType) 변경 불가
+   */
+  @PatchMapping("/matches/{matchId}/events/{eventId}")
+  public ResponseEntity<EventResponse> updateEvent(
+      @PathVariable Long matchId,
+      @PathVariable Long eventId,
+      @AuthenticationPrincipal UserPrincipal principal,
+      @Valid @RequestBody EventUpdateRequest request
+  ) {
+    Long userId = principal.userId();
+    EventResponse response = eventService.updateEvent(matchId, userId, eventId, request);
+    return ResponseEntity.ok(response);
+  }
+
+  /**
+   * 일정 삭제
+   * - 기념일 이벤트(anniversary=true)는 삭제 불가
+   */
+  @DeleteMapping("/matches/{matchId}/events/{eventId}")
+  public ResponseEntity<Void> deleteEvent(
+      @PathVariable Long matchId,
+      @PathVariable Long eventId,
+      @AuthenticationPrincipal UserPrincipal principal
+  ) {
+    Long userId = principal.userId();
+    eventService.deleteEvent(matchId, userId, eventId);
+    return ResponseEntity.noContent().build();
   }
 }

--- a/back/src/main/java/com/qmate/common/constants/event/EventConstants.java
+++ b/back/src/main/java/com/qmate/common/constants/event/EventConstants.java
@@ -1,0 +1,65 @@
+package com.qmate.common.constants.event;
+
+import com.qmate.common.constants.HttpStatusCode;
+import com.qmate.exception.MatchErrorCode;
+import com.qmate.exception.errorcode.CustomQuestionErrorCode;
+import com.qmate.exception.errorcode.EventErrorCode;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
+public class EventConstants {
+
+  // 상수
+  public static final int EVENT_TITLE_MAX_LENGTH = 120;
+  public static final int EVENT_DESCRIPTION_MAX_LENGTH = 1000;
+
+  // validation message
+  // 제목 공백 불가
+  public static final String EVENT_TITLE_NOT_BLANK_MESSAGE = "일정 제목은 필수 입력 값입니다.";
+  public static final String EVENT_TITLE_SIZE_MESSAGE = "일정 제목은 최대 " + EVENT_TITLE_MAX_LENGTH + "자까지 가능합니다.";
+  public static final String EVENT_DESCRIPTION_SIZE_MESSAGE = "일정 설명은 최대 " + EVENT_DESCRIPTION_MAX_LENGTH + "자까지 가능합니다.";
+
+  // api doc
+  // TODO MatchErrorCode 변경 시 참조 필요
+  public static final String CREATE_MD =
+      "매치 하위에 일정을 생성합니다.\n\n"
+          + "- matchId, userId(인증)로 권한과 존재를 함께 검증합니다.\n\n"
+          + "### 에러 응답\n\n"
+          + "| HTTP | errorCode | message |\n"
+          + "|-----:|-----------|---------|\n"
+          + "| " + HttpStatusCode.NOT_FOUND + " | " + "MATCH_002" + " | "
+          + "해당 매칭을 찾을 수 없습니다." + " |\n";
+
+  public static final String GET_DETAIL_MD =
+      "일정을 조회합니다.\n\n"
+          + "- matchId, userId(인증), eventId로 권한과 존재를 함께 검증합니다.\n\n"
+          + "### 에러 응답\n\n"
+          + "| HTTP | errorCode | message |\n"
+          + "|-----:|-----------|---------|\n"
+          + "| " + HttpStatusCode.NOT_FOUND + " | " + EventErrorCode.EVENT_NOT_FOUND_ERROR_CODE + " | "
+          + EventErrorCode.EVENT_NOT_FOUND_MESSAGE + " |\n";
+
+  public static final String UPDATE_MD =
+      "일정을 수정합니다.\n\n"
+          + "- matchId, userId(인증), eventId로 권한과 존재를 함께 검증합니다.\n"
+          + "- 기념일의 반복 설정은 변경할 수 없습니다.\n\n"
+          + "### 에러 응답\n\n"
+          + "| HTTP | errorCode | message |\n"
+          + "|-----:|-----------|---------|\n"
+          + "| " + HttpStatusCode.NOT_FOUND + " | " + EventErrorCode.EVENT_NOT_FOUND_ERROR_CODE + " | "
+          + EventErrorCode.EVENT_NOT_FOUND_MESSAGE + " |\n"
+          + "| " + HttpStatusCode.CONFLICT + " | " + EventErrorCode.EVENT_REPEAT_MODIFICATION_NOT_ALLOWED_ERROR_CODE + " | "
+          + EventErrorCode.EVENT_REPEAT_MODIFICATION_NOT_ALLOWED_MESSAGE + " |\n";
+
+  public static final String DELETE_MD =
+      "일정을 수정합니다.\n\n"
+          + "- matchId, userId(인증), eventId로 권한과 존재를 함께 검증합니다.\n"
+          + "- 기념일은 삭제할 수 없습니다.\n\n"
+          + "### 에러 응답\n\n"
+          + "| HTTP | errorCode | message |\n"
+          + "|-----:|-----------|---------|\n"
+          + "| " + HttpStatusCode.NOT_FOUND + " | " + EventErrorCode.EVENT_NOT_FOUND_ERROR_CODE + " | "
+          + EventErrorCode.EVENT_NOT_FOUND_MESSAGE + " |\n"
+          + "| " + HttpStatusCode.CONFLICT + " | " + EventErrorCode.EVENT_DELETION_NOT_ALLOWED_ERROR_CODE + " | "
+          + EventErrorCode.EVENT_DELETION_NOT_ALLOWED_MESSAGE + " |\n";
+}

--- a/back/src/main/java/com/qmate/domain/event/entity/Event.java
+++ b/back/src/main/java/com/qmate/domain/event/entity/Event.java
@@ -20,11 +20,13 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
+@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder

--- a/back/src/main/java/com/qmate/domain/event/entity/Event.java
+++ b/back/src/main/java/com/qmate/domain/event/entity/Event.java
@@ -1,0 +1,74 @@
+package com.qmate.domain.event.entity;
+
+import com.qmate.domain.match.Match;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "`event`")
+public class Event {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "event_id")
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "match_id", nullable = false)
+  private Match match;
+
+  @Column(name = "title", nullable = false, length = 120)
+  private String title;
+
+  @Column(name = "description", length = 1000)
+  private String description;
+
+  @Column(name = "event_at", nullable = false)
+  private LocalDate eventAt;
+
+  @Enumerated(EnumType.STRING)
+  @Builder.Default
+  @Column(name = "repeat_type", nullable = false, length = 16)
+  private EventRepeatType repeatType = EventRepeatType.NONE;
+
+  @Enumerated(EnumType.STRING)
+  @Builder.Default
+  @Column(name = "alarm_option", nullable = false, length = 20)
+  private EventAlarmOption alarmOption = EventAlarmOption.WEEK_BEFORE;
+
+  @Column(name = "is_anniversary", nullable = false)
+  private boolean anniversary;
+
+  @CreatedDate
+  @Column(name = "created_at", nullable = false)
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate
+  @Column(name = "updated_at", nullable = false)
+  private LocalDateTime updatedAt;
+}

--- a/back/src/main/java/com/qmate/domain/event/entity/EventAlarmOption.java
+++ b/back/src/main/java/com/qmate/domain/event/entity/EventAlarmOption.java
@@ -1,0 +1,5 @@
+package com.qmate.domain.event.entity;
+
+public enum EventAlarmOption {
+  NONE, WEEK_BEFORE, THREE_DAYS_BEFORE, SAME_DAY
+}

--- a/back/src/main/java/com/qmate/domain/event/entity/EventRepeatType.java
+++ b/back/src/main/java/com/qmate/domain/event/entity/EventRepeatType.java
@@ -1,0 +1,5 @@
+package com.qmate.domain.event.entity;
+
+public enum EventRepeatType {
+  NONE, WEEKLY, MONTHLY, YEARLY
+}

--- a/back/src/main/java/com/qmate/domain/event/mapper/EventMapper.java
+++ b/back/src/main/java/com/qmate/domain/event/mapper/EventMapper.java
@@ -1,0 +1,28 @@
+package com.qmate.domain.event.mapper;
+
+import com.qmate.domain.event.entity.Event;
+import com.qmate.domain.event.model.response.EventResponse;
+import java.util.Objects;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
+public class EventMapper {
+
+  public static EventResponse toResponse(Event e) {
+    if (Objects.isNull(e)) {
+      return null;
+    }
+
+    return EventResponse.builder()
+        .eventId(e.getId())
+        .title(e.getTitle())
+        .description(e.getDescription())
+        .eventAt(e.getEventAt())
+        .repeatType(e.getRepeatType())
+        .alarmOption(e.getAlarmOption())
+        .anniversary(e.isAnniversary())
+        .createdAt(e.getCreatedAt())
+        .updatedAt(e.getUpdatedAt())
+        .build();
+  }
+}

--- a/back/src/main/java/com/qmate/domain/event/mapper/EventMapper.java
+++ b/back/src/main/java/com/qmate/domain/event/mapper/EventMapper.java
@@ -1,13 +1,18 @@
 package com.qmate.domain.event.mapper;
 
 import com.qmate.domain.event.entity.Event;
+import com.qmate.domain.event.model.request.EventCreateRequest;
 import com.qmate.domain.event.model.response.EventResponse;
+import com.qmate.domain.match.Match;
 import java.util.Objects;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
 public class EventMapper {
 
+  /**
+   * Event Entity -> Event Response
+   */
   public static EventResponse toResponse(Event e) {
     if (Objects.isNull(e)) {
       return null;
@@ -23,6 +28,20 @@ public class EventMapper {
         .anniversary(e.isAnniversary())
         .createdAt(e.getCreatedAt())
         .updatedAt(e.getUpdatedAt())
+        .build();
+  }
+
+  /**
+   * Event Create Request -> Event Entity
+   */
+  public static Event toEntity(Match match, EventCreateRequest req) {
+    return Event.builder()
+        .match(match)
+        .title(req.getTitle())
+        .description(req.getDescription())
+        .eventAt(req.getEventAt())
+        .repeatType(req.getRepeatType())
+        .alarmOption(req.getAlarmOption())
         .build();
   }
 }

--- a/back/src/main/java/com/qmate/domain/event/model/request/EventCreateRequest.java
+++ b/back/src/main/java/com/qmate/domain/event/model/request/EventCreateRequest.java
@@ -7,11 +7,15 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class EventCreateRequest {
 
   @NotBlank

--- a/back/src/main/java/com/qmate/domain/event/model/request/EventCreateRequest.java
+++ b/back/src/main/java/com/qmate/domain/event/model/request/EventCreateRequest.java
@@ -1,5 +1,6 @@
 package com.qmate.domain.event.model.request;
 
+import com.qmate.common.constants.event.EventConstants;
 import com.qmate.domain.event.entity.EventAlarmOption;
 import com.qmate.domain.event.entity.EventRepeatType;
 import jakarta.annotation.Nullable;
@@ -18,12 +19,12 @@ import lombok.NoArgsConstructor;
 @Builder
 public class EventCreateRequest {
 
-  @NotBlank
-  @Size(max = 120)
+  @NotBlank(message = EventConstants.EVENT_TITLE_NOT_BLANK_MESSAGE)
+  @Size(max = EventConstants.EVENT_TITLE_MAX_LENGTH, message = EventConstants.EVENT_TITLE_SIZE_MESSAGE)
   private String title;
 
   @Nullable
-  @Size(max = 1000)
+  @Size(max = EventConstants.EVENT_DESCRIPTION_MAX_LENGTH, message = EventConstants.EVENT_DESCRIPTION_SIZE_MESSAGE)
   private String description; // nullable 허용
 
   @NotNull

--- a/back/src/main/java/com/qmate/domain/event/model/request/EventCreateRequest.java
+++ b/back/src/main/java/com/qmate/domain/event/model/request/EventCreateRequest.java
@@ -1,0 +1,33 @@
+package com.qmate.domain.event.model.request;
+
+import com.qmate.domain.event.entity.EventAlarmOption;
+import com.qmate.domain.event.entity.EventRepeatType;
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class EventCreateRequest {
+
+  @NotBlank
+  @Size(max = 120)
+  private String title;
+
+  @Nullable
+  @Size(max = 1000)
+  private String description; // nullable 허용
+
+  @NotNull
+  private LocalDate eventAt; // YYYY-MM-DD
+
+  @NotNull
+  private EventRepeatType repeatType;  // NONE | WEEKLY | MONTHLY | YEARLY
+
+  @NotNull
+  private EventAlarmOption alarmOption; // NONE | WEEK_BEFORE | THREE_DAYS_BEFORE | SAME_DAY
+}

--- a/back/src/main/java/com/qmate/domain/event/model/request/EventUpdateRequest.java
+++ b/back/src/main/java/com/qmate/domain/event/model/request/EventUpdateRequest.java
@@ -7,11 +7,15 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class EventUpdateRequest {
 
   @Nullable

--- a/back/src/main/java/com/qmate/domain/event/model/request/EventUpdateRequest.java
+++ b/back/src/main/java/com/qmate/domain/event/model/request/EventUpdateRequest.java
@@ -1,5 +1,6 @@
 package com.qmate.domain.event.model.request;
 
+import com.qmate.common.constants.event.EventConstants;
 import com.qmate.domain.event.entity.EventAlarmOption;
 import com.qmate.domain.event.entity.EventRepeatType;
 import jakarta.annotation.Nullable;
@@ -19,11 +20,11 @@ import lombok.NoArgsConstructor;
 public class EventUpdateRequest {
 
   @Nullable
-  @Size(max = 120)
+  @Size(max = EventConstants.EVENT_TITLE_MAX_LENGTH, message = EventConstants.EVENT_TITLE_SIZE_MESSAGE)
   private String title;            // null이면 변경 없음
 
   @Nullable
-  @Size(max = 1000)
+  @Size(max = EventConstants.EVENT_DESCRIPTION_MAX_LENGTH, message = EventConstants.EVENT_DESCRIPTION_SIZE_MESSAGE)
   private String description;      // null이면 변경 없음 (비우기 불가)
 
   @Nullable

--- a/back/src/main/java/com/qmate/domain/event/model/request/EventUpdateRequest.java
+++ b/back/src/main/java/com/qmate/domain/event/model/request/EventUpdateRequest.java
@@ -1,0 +1,33 @@
+package com.qmate.domain.event.model.request;
+
+import com.qmate.domain.event.entity.EventAlarmOption;
+import com.qmate.domain.event.entity.EventRepeatType;
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class EventUpdateRequest {
+
+  @Nullable
+  @Size(max = 120)
+  private String title;            // null이면 변경 없음
+
+  @Nullable
+  @Size(max = 1000)
+  private String description;      // null이면 변경 없음 (비우기 불가)
+
+  @Nullable
+  private LocalDate eventAt;       // null이면 변경 없음
+
+  @Nullable
+  private EventRepeatType repeatType;   // null이면 변경 없음
+
+  @Nullable
+  private EventAlarmOption alarmOption; // null이면 변경 없음
+}

--- a/back/src/main/java/com/qmate/domain/event/model/response/EventResponse.java
+++ b/back/src/main/java/com/qmate/domain/event/model/response/EventResponse.java
@@ -1,0 +1,27 @@
+package com.qmate.domain.event.model.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.qmate.domain.event.entity.EventAlarmOption;
+import com.qmate.domain.event.entity.EventRepeatType;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class EventResponse {
+
+  private final Long eventId;
+  private final String title;
+  private final String description;
+  private final LocalDate eventAt;
+  private final EventRepeatType repeatType;
+  private final EventAlarmOption alarmOption;
+
+  @JsonProperty("isAnniversary")
+  private final boolean anniversary;
+
+  private final LocalDateTime createdAt;
+  private final LocalDateTime updatedAt;
+}

--- a/back/src/main/java/com/qmate/domain/event/repository/EventRepository.java
+++ b/back/src/main/java/com/qmate/domain/event/repository/EventRepository.java
@@ -1,8 +1,24 @@
 package com.qmate.domain.event.repository;
 
 import com.qmate.domain.event.entity.Event;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface EventRepository extends JpaRepository<Event, Long> {
 
+  @Query("""
+      select e
+      from Event e
+        join e.match m
+        join MatchMember mm on mm.match = m and mm.user.id = :userId
+        join User u on u.id = :userId
+      where e.id = :eventId
+        and m.id = :matchId
+        and u.currentMatchId = :matchId
+      """)
+  Optional<Event> findAuthorizedById(@Param("matchId") Long matchId,
+      @Param("userId") Long userId,
+      @Param("eventId") Long eventId);
 }

--- a/back/src/main/java/com/qmate/domain/event/repository/EventRepository.java
+++ b/back/src/main/java/com/qmate/domain/event/repository/EventRepository.java
@@ -1,0 +1,8 @@
+package com.qmate.domain.event.repository;
+
+import com.qmate.domain.event.entity.Event;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EventRepository extends JpaRepository<Event, Long> {
+
+}

--- a/back/src/main/java/com/qmate/domain/event/service/EventService.java
+++ b/back/src/main/java/com/qmate/domain/event/service/EventService.java
@@ -1,0 +1,33 @@
+package com.qmate.domain.event.service;
+
+import com.qmate.domain.event.entity.Event;
+import com.qmate.domain.event.mapper.EventMapper;
+import com.qmate.domain.event.model.request.EventCreateRequest;
+import com.qmate.domain.event.model.response.EventResponse;
+import com.qmate.domain.event.repository.EventRepository;
+import com.qmate.domain.match.Match;
+import com.qmate.domain.match.repository.MatchRepository;
+import com.qmate.exception.custom.matchinstance.MatchNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EventService {
+
+  private final EventRepository eventRepository;
+  private final MatchRepository matchRepository;
+
+  /**
+   * 일정 생성
+   */
+  public EventResponse createEvent(Long matchId, Long userId, EventCreateRequest request) {
+    Match match = matchRepository.findAuthorizedById(matchId, userId)
+        .orElseThrow(MatchNotFoundException::new); // 권한/존재 통합 검증 쿼리
+
+    Event event = EventMapper.toEntity(match, request);
+    Event saved = eventRepository.save(event);
+
+    return EventMapper.toResponse(saved);
+  }
+}

--- a/back/src/main/java/com/qmate/domain/event/service/EventService.java
+++ b/back/src/main/java/com/qmate/domain/event/service/EventService.java
@@ -3,11 +3,14 @@ package com.qmate.domain.event.service;
 import com.qmate.domain.event.entity.Event;
 import com.qmate.domain.event.mapper.EventMapper;
 import com.qmate.domain.event.model.request.EventCreateRequest;
+import com.qmate.domain.event.model.request.EventUpdateRequest;
 import com.qmate.domain.event.model.response.EventResponse;
 import com.qmate.domain.event.repository.EventRepository;
 import com.qmate.domain.match.Match;
 import com.qmate.domain.match.repository.MatchRepository;
+import com.qmate.exception.custom.event.EventDeletionNotAllowedException;
 import com.qmate.exception.custom.event.EventNotFoundException;
+import com.qmate.exception.custom.event.EventRepeatModificationNotAllowedException;
 import com.qmate.exception.custom.matchinstance.MatchNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -41,5 +44,49 @@ public class EventService {
     Event event = eventRepository.findAuthorizedById(matchId, userId, eventId)
         .orElseThrow(EventNotFoundException::new);
     return EventMapper.toResponse(event);
+  }
+
+  /**
+   * 일정 수정
+   */
+  @Transactional
+  public EventResponse updateEvent(Long matchId, Long userId, Long eventId, EventUpdateRequest req) {
+    Event event = eventRepository.findAuthorizedById(matchId, userId, eventId)
+        .orElseThrow(EventNotFoundException::new);
+
+    // 기념일이면 반복 설정 변경 금지
+    if (event.isAnniversary() && req.getRepeatType() != null
+        && req.getRepeatType() != event.getRepeatType()) {
+      throw new EventRepeatModificationNotAllowedException();
+    }
+
+    // null 이 아닌 항목만 반영
+    if (req.getTitle() != null) {
+      event.setTitle(req.getTitle());
+    }
+    if (req.getDescription() != null) {
+      event.setDescription(req.getDescription());
+    }
+    if (req.getEventAt() != null) {
+      event.setEventAt(req.getEventAt());
+    }
+    if (req.getRepeatType() != null) {
+      event.setRepeatType(req.getRepeatType());
+    }
+    if (req.getAlarmOption() != null) {
+      event.setAlarmOption(req.getAlarmOption());
+    }
+    return EventMapper.toResponse(eventRepository.saveAndFlush(event));
+  }
+
+  public void deleteEvent(Long matchId, Long userId, Long eventId) {
+    Event event = eventRepository.findAuthorizedById(matchId, userId, eventId)
+        .orElseThrow(EventNotFoundException::new);
+
+    if (event.isAnniversary()) {
+      throw new EventDeletionNotAllowedException();
+    }
+
+    eventRepository.delete(event);
   }
 }

--- a/back/src/main/java/com/qmate/domain/event/service/EventService.java
+++ b/back/src/main/java/com/qmate/domain/event/service/EventService.java
@@ -7,9 +7,11 @@ import com.qmate.domain.event.model.response.EventResponse;
 import com.qmate.domain.event.repository.EventRepository;
 import com.qmate.domain.match.Match;
 import com.qmate.domain.match.repository.MatchRepository;
+import com.qmate.exception.custom.event.EventNotFoundException;
 import com.qmate.exception.custom.matchinstance.MatchNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -29,5 +31,15 @@ public class EventService {
     Event saved = eventRepository.save(event);
 
     return EventMapper.toResponse(saved);
+  }
+
+  /**
+   * 일정 단건 조회
+   */
+  @Transactional(readOnly = true)
+  public EventResponse getEvent(Long matchId, Long userId, Long eventId) {
+    Event event = eventRepository.findAuthorizedById(matchId, userId, eventId)
+        .orElseThrow(EventNotFoundException::new);
+    return EventMapper.toResponse(event);
   }
 }

--- a/back/src/main/java/com/qmate/exception/GlobalExceptionHandler.java
+++ b/back/src/main/java/com/qmate/exception/GlobalExceptionHandler.java
@@ -1,5 +1,7 @@
 package com.qmate.exception;
 
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -7,6 +9,7 @@ import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -53,7 +56,7 @@ public class GlobalExceptionHandler {
 
   }
 
-  // 컨트롤러에서 타입 미스매치 예외를 처리하는 핸들러
+  // 컨트롤러에서 타입 미스매치 예외를 처리하는 핸들러 (파라미터 전용)
   @ExceptionHandler(MethodArgumentTypeMismatchException.class)
   public ResponseEntity<ErrorResponse> handleTypeMismatch(MethodArgumentTypeMismatchException ex) {
     log.warn("파라미터 타입 불일치: {}", ex.getMessage());
@@ -81,6 +84,44 @@ public class GlobalExceptionHandler {
 
     return new ResponseEntity<>(
         new ErrorResponse(errorCode.getCode(), errorCode.getMessage(), errors),
+        errorCode.getHttpStatus()
+    );
+  }
+
+  // 컨트롤러에서 본문(JSON) 파싱/바인딩 실패 예외를 처리하는 핸들러 (RequestBody 전용)
+  @ExceptionHandler(HttpMessageNotReadableException.class)
+  public ResponseEntity<ErrorResponse> handleJsonEnumMismatch(HttpMessageNotReadableException ex) throws HttpMessageNotReadableException {
+    Throwable cause = ex.getMostSpecificCause();
+
+    if (!(cause instanceof InvalidFormatException ife)) {
+      // enum 케이스가 아니면 전파
+      throw ex;
+    }
+
+    Class<?> targetType = ife.getTargetType();
+    if (targetType == null || !targetType.isEnum()) {
+      // enum 타깃이 아니면 전파
+      throw ex;
+    }
+
+    // enum만 메시지로 가공
+    String field = ife.getPath() == null || ife.getPath().isEmpty()
+        ? "$"
+        : ife.getPath().getLast().getFieldName();
+    String rejected = String.valueOf(ife.getValue());
+    String allowed = java.util.Arrays.stream(targetType.getEnumConstants())
+        .map(Object::toString)
+        .collect(Collectors.joining(", "));
+
+    ErrorCode errorCode = CommonErrorCode.invalidInput();
+    ErrorResponse.FieldErrorDetail detail = new ErrorResponse.FieldErrorDetail(
+        field,
+        String.format("입력값 '%s'은(는) 유효한 %s 값이 아닙니다. 허용 가능한 값: %s",
+            rejected, targetType.getSimpleName(), allowed)
+    );
+
+    return new ResponseEntity<>(
+        new ErrorResponse(errorCode.getCode(), errorCode.getMessage(), java.util.List.of(detail)),
         errorCode.getHttpStatus()
     );
   }

--- a/back/src/main/java/com/qmate/exception/GlobalExceptionHandler.java
+++ b/back/src/main/java/com/qmate/exception/GlobalExceptionHandler.java
@@ -1,6 +1,8 @@
 package com.qmate.exception;
 
+import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -90,40 +92,74 @@ public class GlobalExceptionHandler {
 
   // 컨트롤러에서 본문(JSON) 파싱/바인딩 실패 예외를 처리하는 핸들러 (RequestBody 전용)
   @ExceptionHandler(HttpMessageNotReadableException.class)
-  public ResponseEntity<ErrorResponse> handleJsonEnumMismatch(HttpMessageNotReadableException ex) throws HttpMessageNotReadableException {
+  public ResponseEntity<ErrorResponse> handleNotReadable(HttpMessageNotReadableException ex) {
     Throwable cause = ex.getMostSpecificCause();
-
-    if (!(cause instanceof InvalidFormatException ife)) {
-      // enum 케이스가 아니면 전파
-      throw ex;
-    }
-
-    Class<?> targetType = ife.getTargetType();
-    if (targetType == null || !targetType.isEnum()) {
-      // enum 타깃이 아니면 전파
-      throw ex;
-    }
-
-    // enum만 메시지로 가공
-    String field = ife.getPath() == null || ife.getPath().isEmpty()
-        ? "$"
-        : ife.getPath().getLast().getFieldName();
-    String rejected = String.valueOf(ife.getValue());
-    String allowed = java.util.Arrays.stream(targetType.getEnumConstants())
-        .map(Object::toString)
-        .collect(Collectors.joining(", "));
-
     ErrorCode errorCode = CommonErrorCode.invalidInput();
-    ErrorResponse.FieldErrorDetail detail = new ErrorResponse.FieldErrorDetail(
-        field,
-        String.format("입력값 '%s'은(는) 유효한 %s 값이 아닙니다. 허용 가능한 값: %s",
-            rejected, targetType.getSimpleName(), allowed)
-    );
+    List<ErrorResponse.FieldErrorDetail> details = new ArrayList<>();
 
-    return new ResponseEntity<>(
-        new ErrorResponse(errorCode.getCode(), errorCode.getMessage(), java.util.List.of(detail)),
-        errorCode.getHttpStatus()
-    );
+    // 1) JSON 문법 오류
+    if (cause instanceof JsonParseException) {
+      details.add(new ErrorResponse.FieldErrorDetail("$", "요청 본문 JSON 형식이 올바르지 않습니다."));
+      return ResponseEntity.status(errorCode.getHttpStatus())
+          .body(new ErrorResponse(errorCode.getCode(), errorCode.getMessage(), details));
+    }
+
+    // 2) 타입 불일치(ENUM/숫자/불리언 등)
+    if (cause instanceof InvalidFormatException) {
+      InvalidFormatException ife = (InvalidFormatException) cause;
+
+      String field = "$";
+      if (ife.getPath() != null && !ife.getPath().isEmpty()) {
+        field = ife.getPath().getLast().getFieldName();
+        if (field == null) field = "$";
+      }
+
+      Object rejectedValue = ife.getValue();
+      Class<?> targetType = ife.getTargetType();
+
+      if (targetType != null && targetType.isEnum()) {
+        String allowed = Arrays.stream(targetType.getEnumConstants())
+            .map(Object::toString)
+            .collect(Collectors.joining(", "));
+        String msg = "입력값 '" + rejectedValue + "'은(는) 유효한 " + targetType.getSimpleName()
+            + " 값이 아닙니다. 허용 가능한 값: " + allowed;
+        details.add(new ErrorResponse.FieldErrorDetail(field, msg));
+      } else {
+        String expected = (targetType == null) ? "올바른 타입" : targetType.getSimpleName();
+        String msg = "필드 타입이 올바르지 않습니다. value=" + rejectedValue + ", expected=" + expected;
+        details.add(new ErrorResponse.FieldErrorDetail(field, msg));
+      }
+
+      return ResponseEntity.status(errorCode.getHttpStatus())
+          .body(new ErrorResponse(errorCode.getCode(), errorCode.getMessage(), details));
+    }
+
+    // 3) 본문 누락/매칭 불가
+    if (cause instanceof MismatchedInputException) {
+      MismatchedInputException mie = (MismatchedInputException) cause;
+
+      String field = "$";
+      if (mie.getPath() != null && !mie.getPath().isEmpty()) {
+        field = mie.getPath().getLast().getFieldName();
+        if (field == null) field = "$";
+      }
+
+      String msg;
+      if ("$".equals(field)) {
+        msg = "요청 본문이 필요합니다.";
+      } else {
+        msg = "필드 '" + field + "'의 값이 올바르지 않습니다.";
+      }
+
+      details.add(new ErrorResponse.FieldErrorDetail(field, msg));
+      return ResponseEntity.status(errorCode.getHttpStatus())
+          .body(new ErrorResponse(errorCode.getCode(), errorCode.getMessage(), details));
+    }
+
+    // 4) 그 외 NotReadable → 400 통일
+    details.add(new ErrorResponse.FieldErrorDetail("$", "요청 본문을 해석할 수 없습니다."));
+    return ResponseEntity.status(errorCode.getHttpStatus())
+        .body(new ErrorResponse(errorCode.getCode(), errorCode.getMessage(), details));
   }
 
   //인증 실패 예외를 처리하는 핸들러(401)

--- a/back/src/main/java/com/qmate/exception/custom/event/EventDeletionNotAllowedException.java
+++ b/back/src/main/java/com/qmate/exception/custom/event/EventDeletionNotAllowedException.java
@@ -1,0 +1,12 @@
+package com.qmate.exception.custom.event;
+
+import com.qmate.exception.BusinessGlobalException;
+import com.qmate.exception.errorcode.EventErrorCode;
+
+public class EventDeletionNotAllowedException extends BusinessGlobalException {
+
+  public EventDeletionNotAllowedException() {
+    super(EventErrorCode.eventDeletionNotAllowed());
+  }
+
+}

--- a/back/src/main/java/com/qmate/exception/custom/event/EventNotFoundException.java
+++ b/back/src/main/java/com/qmate/exception/custom/event/EventNotFoundException.java
@@ -1,0 +1,11 @@
+package com.qmate.exception.custom.event;
+
+import com.qmate.exception.BusinessGlobalException;
+import com.qmate.exception.errorcode.EventErrorCode;
+
+public class EventNotFoundException extends BusinessGlobalException {
+
+  public EventNotFoundException() {
+    super(EventErrorCode.eventNotFound());
+  }
+}

--- a/back/src/main/java/com/qmate/exception/custom/event/EventRepeatModificationNotAllowedException.java
+++ b/back/src/main/java/com/qmate/exception/custom/event/EventRepeatModificationNotAllowedException.java
@@ -1,0 +1,12 @@
+package com.qmate.exception.custom.event;
+
+import com.qmate.exception.BusinessGlobalException;
+import com.qmate.exception.errorcode.EventErrorCode;
+
+public class EventRepeatModificationNotAllowedException extends BusinessGlobalException {
+
+  public EventRepeatModificationNotAllowedException() {
+    super(EventErrorCode.eventRepeatModificationNotAllowed());
+  }
+
+}

--- a/back/src/main/java/com/qmate/exception/errorcode/EventErrorCode.java
+++ b/back/src/main/java/com/qmate/exception/errorcode/EventErrorCode.java
@@ -1,0 +1,24 @@
+package com.qmate.exception.errorcode;
+
+import com.qmate.exception.ErrorCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class EventErrorCode extends ErrorCode {
+
+  // message
+  public static final String EVENT_NOT_FOUND_MESSAGE = "일정을 찾을 수 없습니다.";
+
+  // error code
+  public static final String EVENT_NOT_FOUND_ERROR_CODE = "EVENT_001";
+
+  // factory method
+  public static ErrorCode eventNotFound() {
+    return new EventErrorCode(HttpStatus.NOT_FOUND, EVENT_NOT_FOUND_ERROR_CODE, EVENT_NOT_FOUND_MESSAGE);
+  }
+
+  protected EventErrorCode(HttpStatus httpStatus, String code, String message) {
+    super(httpStatus, code, message);
+  }
+}

--- a/back/src/main/java/com/qmate/exception/errorcode/EventErrorCode.java
+++ b/back/src/main/java/com/qmate/exception/errorcode/EventErrorCode.java
@@ -9,13 +9,27 @@ public class EventErrorCode extends ErrorCode {
 
   // message
   public static final String EVENT_NOT_FOUND_MESSAGE = "일정을 찾을 수 없습니다.";
+  public static final String EVENT_REPEAT_MODIFICATION_NOT_ALLOWED_MESSAGE = "기념일의 반복 설정은 변경할 수 없습니다.";
+  public static final String EVENT_DELETION_NOT_ALLOWED_MESSAGE = "기념일은 삭제할 수 없습니다.";
 
   // error code
   public static final String EVENT_NOT_FOUND_ERROR_CODE = "EVENT_001";
+  public static final String EVENT_REPEAT_MODIFICATION_NOT_ALLOWED_ERROR_CODE = "EVENT_002";
+  public static final String EVENT_DELETION_NOT_ALLOWED_ERROR_CODE = "EVENT_003";
 
   // factory method
   public static ErrorCode eventNotFound() {
     return new EventErrorCode(HttpStatus.NOT_FOUND, EVENT_NOT_FOUND_ERROR_CODE, EVENT_NOT_FOUND_MESSAGE);
+  }
+
+  public static ErrorCode eventRepeatModificationNotAllowed() {
+    return new EventErrorCode(HttpStatus.CONFLICT, EVENT_REPEAT_MODIFICATION_NOT_ALLOWED_ERROR_CODE,
+        EVENT_REPEAT_MODIFICATION_NOT_ALLOWED_MESSAGE);
+  }
+
+  public static ErrorCode eventDeletionNotAllowed() {
+    return new EventErrorCode(HttpStatus.CONFLICT, EVENT_DELETION_NOT_ALLOWED_ERROR_CODE,
+        EVENT_DELETION_NOT_ALLOWED_MESSAGE);
   }
 
   protected EventErrorCode(HttpStatus httpStatus, String code, String message) {

--- a/back/src/test/java/com/qmate/api/event/EventControllerTest.java
+++ b/back/src/test/java/com/qmate/api/event/EventControllerTest.java
@@ -5,7 +5,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -18,6 +20,7 @@ import com.qmate.domain.event.entity.EventRepeatType;
 import com.qmate.domain.event.model.request.EventCreateRequest;
 import com.qmate.domain.event.model.response.EventResponse;
 import com.qmate.domain.event.service.EventService;
+import com.qmate.exception.custom.event.EventNotFoundException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
@@ -103,5 +106,51 @@ class EventControllerTest {
         .andExpect(jsonPath("$.errorCode").exists())
         .andExpect(jsonPath("$.message").exists())
         .andExpect(jsonPath("$.errors[0].field").exists());
+  }
+
+  @Test
+  @DisplayName("상세 조회 API - 200 OK")
+  void getEvent_ok() throws Exception {
+    long matchId = 1L, eventId = 10L, userId = 99L;
+
+    EventResponse stub = EventResponse.builder()
+        .eventId(eventId)
+        .title("제목")
+        .description("설명")
+        .eventAt(LocalDate.of(2025, 10, 9))
+        .repeatType(EventRepeatType.NONE)
+        .alarmOption(EventAlarmOption.WEEK_BEFORE)
+        .anniversary(false)
+        .createdAt(LocalDateTime.now())
+        .updatedAt(LocalDateTime.now())
+        .build();
+
+    given(eventService.getEvent(matchId, userId, eventId)).willReturn(stub);
+
+    mockMvc.perform(get("/api/matches/{matchId}/events/{eventId}", matchId, eventId)
+            .with(AuthTestUtils.userPrincipal(userId))
+            .accept(APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(APPLICATION_JSON))
+        .andExpect(jsonPath("$.eventId").value((int) eventId))
+        .andExpect(jsonPath("$.title").value("제목"))
+        .andExpect(jsonPath("$.repeatType").value("NONE"))
+        .andExpect(jsonPath("$.alarmOption").value("WEEK_BEFORE"));
+  }
+
+  @Test
+  @DisplayName("상세 조회 API - 404 Not Found")
+  void getEvent_notFound() throws Exception {
+    long matchId = 1L, eventId = 10L, userId = 99L;
+
+    given(eventService.getEvent(matchId, userId, eventId))
+        .willThrow(new EventNotFoundException());
+
+    mockMvc.perform(get("/api/matches/{matchId}/events/{eventId}", matchId, eventId)
+            .with(AuthTestUtils.userPrincipal(userId))
+            .accept(APPLICATION_JSON))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.errorCode").exists())
+        .andExpect(jsonPath("$.message").exists());
   }
 }

--- a/back/src/test/java/com/qmate/api/event/EventControllerTest.java
+++ b/back/src/test/java/com/qmate/api/event/EventControllerTest.java
@@ -4,8 +4,11 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
@@ -18,9 +21,12 @@ import com.qmate.SecuritySliceTestConfig;
 import com.qmate.domain.event.entity.EventAlarmOption;
 import com.qmate.domain.event.entity.EventRepeatType;
 import com.qmate.domain.event.model.request.EventCreateRequest;
+import com.qmate.domain.event.model.request.EventUpdateRequest;
 import com.qmate.domain.event.model.response.EventResponse;
 import com.qmate.domain.event.service.EventService;
+import com.qmate.exception.custom.event.EventDeletionNotAllowedException;
 import com.qmate.exception.custom.event.EventNotFoundException;
+import com.qmate.exception.custom.event.EventRepeatModificationNotAllowedException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
@@ -150,6 +156,88 @@ class EventControllerTest {
             .with(AuthTestUtils.userPrincipal(userId))
             .accept(APPLICATION_JSON))
         .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.errorCode").exists())
+        .andExpect(jsonPath("$.message").exists());
+  }
+
+  @Test
+  @DisplayName("일정 수정 API - 200 OK")
+  void updateEvent_ok() throws Exception {
+    long matchId = 1L, eventId = 10L, userId = 99L;
+
+    EventUpdateRequest req = EventUpdateRequest.builder()
+        .title("new-title")
+        .repeatType(EventRepeatType.MONTHLY)
+        .build();
+
+    EventResponse stub = EventResponse.builder()
+        .eventId(eventId)
+        .title("new-title")
+        .description("설명")
+        .eventAt(LocalDate.of(2025,10,9))
+        .repeatType(EventRepeatType.MONTHLY)
+        .alarmOption(EventAlarmOption.WEEK_BEFORE)
+        .anniversary(false)
+        .createdAt(LocalDateTime.now())
+        .updatedAt(LocalDateTime.now())
+        .build();
+
+    given(eventService.updateEvent(anyLong(), anyLong(), anyLong(), any())).willReturn(stub);
+
+    mockMvc.perform(patch("/api/matches/{matchId}/events/{eventId}", matchId, eventId)
+            .with(AuthTestUtils.userPrincipal(userId))
+            .contentType(APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(req)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.eventId").value((int) eventId))
+        .andExpect(jsonPath("$.title").value("new-title"))
+        .andExpect(jsonPath("$.repeatType").value("MONTHLY"));
+  }
+
+  @Test
+  @DisplayName("일정 수정 API - 기념일 repeatType 변경 시 409")
+  void updateEvent_anniversary_repeat_forbidden_409() throws Exception {
+    long matchId = 1L, eventId = 10L, userId = 99L;
+
+    EventUpdateRequest req = EventUpdateRequest.builder()
+        .repeatType(EventRepeatType.YEARLY)
+        .build();
+
+    given(eventService.updateEvent(anyLong(), anyLong(), anyLong(), any()))
+        .willThrow(new EventRepeatModificationNotAllowedException());
+
+    mockMvc.perform(patch("/api/matches/{matchId}/events/{eventId}", matchId, eventId)
+            .with(AuthTestUtils.userPrincipal(userId))
+            .contentType(APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(req)))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.errorCode").exists())
+        .andExpect(jsonPath("$.message").exists());
+  }
+
+  @Test
+  @DisplayName("일정 삭제 API - 204 No Content")
+  void deleteEvent_noContent() throws Exception {
+    long matchId = 1L, eventId = 10L, userId = 99L;
+
+    mockMvc.perform(delete("/api/matches/{matchId}/events/{eventId}", matchId, eventId)
+            .with(AuthTestUtils.userPrincipal(userId)))
+        .andExpect(status().isNoContent());
+  }
+
+  @Test
+  @DisplayName("일정 삭제 API - 기념일 삭제 시 409")
+  void deleteEvent_anniversary_forbidden_409() throws Exception {
+    long matchId = 1L, eventId = 10L, userId = 99L;
+
+    // 서비스에서 예외 던지도록
+    willThrow(new EventDeletionNotAllowedException())
+        .given(eventService)
+        .deleteEvent(anyLong(), anyLong(), anyLong());
+
+    mockMvc.perform(delete("/api/matches/{matchId}/events/{eventId}", matchId, eventId)
+            .with(AuthTestUtils.userPrincipal(userId)))
+        .andExpect(status().isConflict())
         .andExpect(jsonPath("$.errorCode").exists())
         .andExpect(jsonPath("$.message").exists());
   }

--- a/back/src/test/java/com/qmate/api/event/EventControllerTest.java
+++ b/back/src/test/java/com/qmate/api/event/EventControllerTest.java
@@ -1,0 +1,107 @@
+package com.qmate.api.event;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.qmate.AuthTestUtils;
+import com.qmate.SecuritySliceTestConfig;
+import com.qmate.domain.event.entity.EventAlarmOption;
+import com.qmate.domain.event.entity.EventRepeatType;
+import com.qmate.domain.event.model.request.EventCreateRequest;
+import com.qmate.domain.event.model.response.EventResponse;
+import com.qmate.domain.event.service.EventService;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = EventController.class)
+@AutoConfigureMockMvc
+@Import(SecuritySliceTestConfig.class)
+class EventControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+  @Autowired private ObjectMapper objectMapper;
+
+  @MockitoBean
+  private EventService eventService;
+
+  @Test
+  @DisplayName("일정 생성 API - 201 Created + Location 헤더")
+  void createEvent_created() throws Exception {
+    long matchId = 1L;
+    long userId = 99L;
+
+    EventCreateRequest req = EventCreateRequest.builder()
+        .title("제목")
+        .description("설명")
+        .eventAt(LocalDate.of(2025, 10, 9))
+        .repeatType(EventRepeatType.NONE)
+        .alarmOption(EventAlarmOption.WEEK_BEFORE)
+        .build();
+
+    EventResponse stub = EventResponse.builder()
+        .eventId(10L)
+        .title("제목")
+        .description("설명")
+        .eventAt(LocalDate.of(2025, 10, 9))
+        .repeatType(EventRepeatType.NONE)
+        .alarmOption(EventAlarmOption.WEEK_BEFORE)
+        .anniversary(false)
+        .createdAt(LocalDateTime.now())
+        .updatedAt(LocalDateTime.now())
+        .build();
+
+    given(eventService.createEvent(anyLong(), anyLong(), any())).willReturn(stub);
+
+    mockMvc.perform(post("/api/matches/{matchId}/events", matchId)
+            .with(AuthTestUtils.userPrincipal(userId))
+            .contentType(APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(req)))
+        .andExpect(status().isCreated())
+        .andExpect(header().string("Location", equalTo("/api/events/10")))
+        .andExpect(jsonPath("$.eventId").value(10))
+        .andExpect(jsonPath("$.title").value("제목"))
+        .andExpect(jsonPath("$.repeatType").value("NONE"))
+        .andExpect(jsonPath("$.alarmOption").value("WEEK_BEFORE"));
+  }
+
+  @Test
+  @DisplayName("일정 생성 API - JSON 본문 enum 미스매치 시 400")
+  void createEvent_enumMismatch_returns400() throws Exception {
+    long matchId = 1L;
+
+    // repeatType에 잘못된 값 주입 (문자열 직접 작성)
+    String badJson = """
+      {
+        "title": "제목",
+        "eventAt": "2025-10-09",
+        "repeatType": "NOT_A_VALID_ENUM",
+        "alarmOption": "WEEK_BEFORE"
+      }
+      """;
+
+    mockMvc.perform(post("/api/matches/{matchId}/events", matchId)
+            .with(AuthTestUtils.userPrincipal((99L)))
+            .contentType(APPLICATION_JSON)
+            .content(badJson))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.errorCode").exists())
+        .andExpect(jsonPath("$.message").exists())
+        .andExpect(jsonPath("$.errors[0].field").exists());
+  }
+}

--- a/back/src/test/java/com/qmate/domain/event/EventServiceTest.java
+++ b/back/src/test/java/com/qmate/domain/event/EventServiceTest.java
@@ -1,4 +1,4 @@
-package com.qmate.domain.event.service;
+package com.qmate.domain.event;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -11,8 +11,10 @@ import com.qmate.domain.event.entity.Event;
 import com.qmate.domain.event.entity.EventAlarmOption;
 import com.qmate.domain.event.entity.EventRepeatType;
 import com.qmate.domain.event.repository.EventRepository;
+import com.qmate.domain.event.service.EventService;
 import com.qmate.domain.match.Match;
 import com.qmate.domain.match.repository.MatchRepository;
+import com.qmate.exception.custom.event.EventNotFoundException;
 import com.qmate.exception.custom.matchinstance.MatchNotFoundException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -96,5 +98,53 @@ class EventServiceTest {
     // expect
     assertThatThrownBy(() -> eventService.createEvent(matchId, userId, req))
         .isInstanceOf(MatchNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("상세 조회 - 성공")
+  void getEvent_success() {
+    // given
+    Long matchId = 1L, userId = 99L, eventId = 10L;
+
+    Match match = Match.builder().id(matchId).build();
+    Event event = Event.builder()
+        .id(eventId)
+        .match(match)
+        .title("제목")
+        .description("설명")
+        .eventAt(LocalDate.of(2025, 10, 9))
+        .repeatType(EventRepeatType.NONE)
+        .alarmOption(EventAlarmOption.WEEK_BEFORE)
+        .anniversary(false)
+        .createdAt(LocalDateTime.now())
+        .updatedAt(LocalDateTime.now())
+        .build();
+
+    given(eventRepository.findAuthorizedById(matchId, userId, eventId))
+        .willReturn(Optional.of(event));
+
+    // when
+    EventResponse res = eventService.getEvent(matchId, userId, eventId);
+
+    // then
+    assertThat(res.getEventId()).isEqualTo(eventId);
+    assertThat(res.getTitle()).isEqualTo("제목");
+    assertThat(res.getRepeatType()).isEqualTo(EventRepeatType.NONE);
+    assertThat(res.getAlarmOption()).isEqualTo(EventAlarmOption.WEEK_BEFORE);
+
+    then(eventRepository).should().findAuthorizedById(matchId, userId, eventId);
+  }
+
+  @Test
+  @DisplayName("상세 조회 - 권한/존재 실패 시 404")
+  void getEvent_notFound() {
+    // given
+    Long matchId = 1L, userId = 99L, eventId = 10L;
+    given(eventRepository.findAuthorizedById(matchId, userId, eventId))
+        .willReturn(Optional.empty());
+
+    // expect
+    assertThatThrownBy(() -> eventService.getEvent(matchId, userId, eventId))
+        .isInstanceOf(EventNotFoundException.class);
   }
 }

--- a/back/src/test/java/com/qmate/domain/event/EventServiceTest.java
+++ b/back/src/test/java/com/qmate/domain/event/EventServiceTest.java
@@ -4,8 +4,10 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
 
 import com.qmate.domain.event.model.request.EventCreateRequest;
+import com.qmate.domain.event.model.request.EventUpdateRequest;
 import com.qmate.domain.event.model.response.EventResponse;
 import com.qmate.domain.event.entity.Event;
 import com.qmate.domain.event.entity.EventAlarmOption;
@@ -14,7 +16,9 @@ import com.qmate.domain.event.repository.EventRepository;
 import com.qmate.domain.event.service.EventService;
 import com.qmate.domain.match.Match;
 import com.qmate.domain.match.repository.MatchRepository;
+import com.qmate.exception.custom.event.EventDeletionNotAllowedException;
 import com.qmate.exception.custom.event.EventNotFoundException;
+import com.qmate.exception.custom.event.EventRepeatModificationNotAllowedException;
 import com.qmate.exception.custom.matchinstance.MatchNotFoundException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -146,5 +150,132 @@ class EventServiceTest {
     // expect
     assertThatThrownBy(() -> eventService.getEvent(matchId, userId, eventId))
         .isInstanceOf(EventNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("일정 수정 - 성공(일부 필드만 갱신, updatedAt 갱신)")
+  void updateEvent_success() {
+    // given
+    Long matchId = 1L, userId = 99L, eventId = 10L;
+    Match match = Match.builder().id(matchId).build();
+    Event event = Event.builder()
+        .id(eventId)
+        .match(match)
+        .title("old")
+        .description("desc")
+        .eventAt(LocalDate.of(2025, 10, 9))
+        .repeatType(EventRepeatType.NONE)
+        .alarmOption(EventAlarmOption.WEEK_BEFORE)
+        .anniversary(false)
+        .createdAt(LocalDateTime.now())
+        .updatedAt(LocalDateTime.now().minusDays(1))
+        .build();
+
+    given(eventRepository.findAuthorizedById(matchId, userId, eventId))
+        .willReturn(Optional.of(event));
+
+    EventUpdateRequest req = EventUpdateRequest.builder()
+        .title("new-title")
+        .repeatType(EventRepeatType.MONTHLY) // 기념일 아님 → 변경 허용
+        .build();
+
+    // saveAndFlush 후 updatedAt이 최신으로 들어간다고 가정하고 same event 반환
+    given(eventRepository.saveAndFlush(any(Event.class))).willAnswer(inv -> inv.getArgument(0));
+
+    // when
+    EventResponse res = eventService.updateEvent(matchId, userId, eventId, req);
+
+    // then
+    assertThat(res.getTitle()).isEqualTo("new-title");
+    assertThat(res.getRepeatType()).isEqualTo(EventRepeatType.MONTHLY);
+    then(eventRepository).should().findAuthorizedById(matchId, userId, eventId);
+    then(eventRepository).should().saveAndFlush(any(Event.class));
+  }
+
+  @Test
+  @DisplayName("일정 수정 - 기념일 이벤트는 repeatType 변경 불가")
+  void updateEvent_anniversary_repeatChange_forbidden() {
+    // given
+    Long matchId = 1L, userId = 99L, eventId = 10L;
+    Match match = Match.builder().id(matchId).build();
+    Event anniversary = Event.builder()
+        .id(eventId)
+        .match(match)
+        .title("anniv")
+        .eventAt(LocalDate.of(2025,10,9))
+        .repeatType(EventRepeatType.NONE)
+        .alarmOption(EventAlarmOption.WEEK_BEFORE)
+        .anniversary(true)
+        .createdAt(LocalDateTime.now())
+        .updatedAt(LocalDateTime.now())
+        .build();
+
+    given(eventRepository.findAuthorizedById(matchId, userId, eventId))
+        .willReturn(Optional.of(anniversary));
+
+    EventUpdateRequest req = EventUpdateRequest.builder()
+        .repeatType(EventRepeatType.YEARLY) // 금지
+        .build();
+
+    // expect
+    assertThatThrownBy(() -> eventService.updateEvent(matchId, userId, eventId, req))
+        .isInstanceOf(EventRepeatModificationNotAllowedException.class);
+
+    then(eventRepository).should().findAuthorizedById(matchId, userId, eventId);
+    then(eventRepository).shouldHaveNoMoreInteractions();
+  }
+
+  @Test
+  @DisplayName("일정 삭제 - 성공")
+  void deleteEvent_success() {
+    // given
+    Long matchId = 1L, userId = 99L, eventId = 10L;
+    Event e = Event.builder()
+        .id(eventId)
+        .match(Match.builder().id(matchId).build())
+        .title("t")
+        .eventAt(LocalDate.of(2025,10,9))
+        .repeatType(EventRepeatType.NONE)
+        .alarmOption(EventAlarmOption.SAME_DAY)
+        .anniversary(false)
+        .createdAt(LocalDateTime.now())
+        .updatedAt(LocalDateTime.now())
+        .build();
+
+    given(eventRepository.findAuthorizedById(matchId, userId, eventId)).willReturn(Optional.of(e));
+
+    // when
+    eventService.deleteEvent(matchId, userId, eventId);
+
+    // then
+    then(eventRepository).should().findAuthorizedById(matchId, userId, eventId);
+    then(eventRepository).should().delete(e);
+  }
+
+  @Test
+  @DisplayName("일정 삭제 - 기념일 이벤트는 삭제 불가")
+  void deleteEvent_anniversary_forbidden() {
+    // given
+    Long matchId = 1L, userId = 99L, eventId = 10L;
+    Event e = Event.builder()
+        .id(eventId)
+        .match(Match.builder().id(matchId).build())
+        .title("anniv")
+        .eventAt(LocalDate.of(2025,10,9))
+        .repeatType(EventRepeatType.NONE)
+        .alarmOption(EventAlarmOption.WEEK_BEFORE)
+        .anniversary(true)
+        .createdAt(LocalDateTime.now())
+        .updatedAt(LocalDateTime.now())
+        .build();
+
+    given(eventRepository.findAuthorizedById(matchId, userId, eventId)).willReturn(Optional.of(e));
+
+    // expect
+    assertThatThrownBy(() -> eventService.deleteEvent(matchId, userId, eventId))
+        .isInstanceOf(EventDeletionNotAllowedException.class);
+
+    then(eventRepository).should().findAuthorizedById(matchId, userId, eventId);
+    then(eventRepository).should(never()).delete(any(Event.class));
   }
 }

--- a/back/src/test/java/com/qmate/domain/event/repository/EventRepositoryAuthQueryTest.java
+++ b/back/src/test/java/com/qmate/domain/event/repository/EventRepositoryAuthQueryTest.java
@@ -1,0 +1,130 @@
+package com.qmate.domain.event.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.qmate.config.JpaConfig;
+import com.qmate.config.QuerydslConfig;
+import com.qmate.domain.event.entity.Event;
+import com.qmate.domain.event.entity.EventAlarmOption;
+import com.qmate.domain.event.entity.EventRepeatType;
+import com.qmate.domain.match.Match;
+import com.qmate.domain.match.MatchMember;
+import com.qmate.domain.user.User;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@DataJpaTest
+@Import({JpaConfig.class, QuerydslConfig.class})
+class EventRepositoryAuthQueryTest {
+
+  @Autowired private TestEntityManager tem;
+  @Autowired private EventRepository eventRepository;
+
+  private Long matchId, userId, eventId;
+
+  @BeforeEach
+  void setUp() {
+
+    // seed: Match + User(currentMatchId=matchId) + MatchMember + Event
+    Match match = Match.builder()
+        .startDate(LocalDateTime.now())
+        .createdAt(LocalDateTime.now())
+        .updatedAt(LocalDateTime.now())
+        .build();
+    tem.persist(match);
+
+    User user = User.builder()
+        .email("user99@test.com")
+        .nickname("nick")
+        .currentMatchId(match.getId())
+        .build();
+    tem.persist(user);
+
+    MatchMember mm = MatchMember.builder()
+        .match(match)
+        .user(user)
+        .build();
+    tem.persist(mm);
+
+    Event event = Event.builder()
+        .match(match)
+        .title("제목")
+        .description("설명")
+        .eventAt(LocalDate.of(2025, 10, 9))
+        .repeatType(EventRepeatType.NONE)
+        .alarmOption(EventAlarmOption.WEEK_BEFORE)
+        .anniversary(false)
+        .createdAt(LocalDateTime.now())
+        .updatedAt(LocalDateTime.now())
+        .build();
+    tem.persist(event);
+
+    tem.flush();
+    tem.clear();
+
+    matchId = match.getId();
+    userId = user.getId();
+    eventId = event.getId();
+  }
+
+  @Test
+  @DisplayName("findAuthorizedById - matchId/userId/eventId 모두 일치 시 Event 조회")
+  void findAuthorizedById_success() {
+    Optional<Event> found = eventRepository.findAuthorizedById(matchId, userId, eventId);
+    assertThat(found).isPresent();
+    assertThat(found.get().getId()).isEqualTo(eventId);
+  }
+
+  @Test
+  @DisplayName("findAuthorizedById - currentMatch 불일치 시 empty")
+  void findAuthorizedById_currentMismatch_empty() {
+    // 사용자의 currentMatchId 변경 → 조인 조건 미충족
+    tem.getEntityManager().createQuery("update User u set u.currentMatchId = :x where u.id = :id")
+        .setParameter("x", 999L)
+        .setParameter("id", userId)
+        .executeUpdate();
+    tem.clear();
+
+    Optional<Event> found = eventRepository.findAuthorizedById(matchId, userId, eventId);
+    assertThat(found).isEmpty();
+  }
+
+  @Test
+  @DisplayName("findAuthorizedById - 다른 매치의 eventId로 조회 시 empty")
+  void findAuthorizedById_wrongMatch_empty() {
+    // 다른 매치에 이벤트를 하나 더 만들어 eventId만 바꿔 조회
+    Match other = Match.builder()
+        .startDate(LocalDateTime.now())
+        .createdAt(LocalDateTime.now())
+        .updatedAt(LocalDateTime.now())
+        .build();
+    tem.persist(other);
+
+    Event otherEvent = Event.builder()
+        .match(other)
+        .title("다른매치")
+        .eventAt(LocalDate.of(2025, 11, 1))
+        .repeatType(EventRepeatType.NONE)
+        .alarmOption(EventAlarmOption.WEEK_BEFORE)
+        .anniversary(false)
+        .createdAt(LocalDateTime.now())
+        .updatedAt(LocalDateTime.now())
+        .build();
+    tem.persist(otherEvent);
+    tem.flush();
+    tem.clear();
+
+    Optional<Event> found = eventRepository.findAuthorizedById(matchId, userId, otherEvent.getId());
+    assertThat(found).isEmpty();
+  }
+}

--- a/back/src/test/java/com/qmate/domain/event/repository/EventRepositoryAuthQueryTest.java
+++ b/back/src/test/java/com/qmate/domain/event/repository/EventRepositoryAuthQueryTest.java
@@ -15,6 +15,7 @@ import java.time.LocalDateTime;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -25,6 +26,7 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles("test")
 @DataJpaTest
 @Import({JpaConfig.class, QuerydslConfig.class})
+@Tag("local")
 class EventRepositoryAuthQueryTest {
 
   @Autowired private TestEntityManager tem;

--- a/back/src/test/java/com/qmate/domain/event/service/EventServiceTest.java
+++ b/back/src/test/java/com/qmate/domain/event/service/EventServiceTest.java
@@ -1,0 +1,100 @@
+package com.qmate.domain.event.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import com.qmate.domain.event.model.request.EventCreateRequest;
+import com.qmate.domain.event.model.response.EventResponse;
+import com.qmate.domain.event.entity.Event;
+import com.qmate.domain.event.entity.EventAlarmOption;
+import com.qmate.domain.event.entity.EventRepeatType;
+import com.qmate.domain.event.repository.EventRepository;
+import com.qmate.domain.match.Match;
+import com.qmate.domain.match.repository.MatchRepository;
+import com.qmate.exception.custom.matchinstance.MatchNotFoundException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class EventServiceTest {
+
+  @Mock private MatchRepository matchRepository;
+  @Mock private EventRepository eventRepository;
+
+  @InjectMocks private EventService eventService;
+
+  @Test
+  @DisplayName("일정 생성 - 성공")
+  void createEvent_success() {
+    // given
+    Long matchId = 1L;
+    Long userId = 99L;
+
+    Match match = Match.builder().id(matchId).build();
+    given(matchRepository.findAuthorizedById(matchId, userId)).willReturn(Optional.of(match));
+
+    EventCreateRequest req = EventCreateRequest.builder()
+        .title("제목")
+        .description("설명")
+        .eventAt(LocalDate.of(2025, 10, 9))
+        .repeatType(EventRepeatType.NONE)
+        .alarmOption(EventAlarmOption.WEEK_BEFORE)
+        .build();
+
+    Event saved = Event.builder()
+        .id(10L)
+        .match(match)
+        .title(req.getTitle())
+        .description(req.getDescription())
+        .eventAt(req.getEventAt())
+        .repeatType(req.getRepeatType())
+        .alarmOption(req.getAlarmOption())
+        .anniversary(false)
+        .createdAt(LocalDateTime.now())
+        .updatedAt(LocalDateTime.now())
+        .build();
+    given(eventRepository.save(any(Event.class))).willReturn(saved);
+
+    // when
+    EventResponse res = eventService.createEvent(matchId, userId, req);
+
+    // then
+    assertThat(res.getEventId()).isEqualTo(10L);
+    assertThat(res.getTitle()).isEqualTo("제목");
+    assertThat(res.getRepeatType()).isEqualTo(EventRepeatType.NONE);
+    assertThat(res.getAlarmOption()).isEqualTo(EventAlarmOption.WEEK_BEFORE);
+
+    // verify -> then().should()
+    then(matchRepository).should().findAuthorizedById(matchId, userId);
+    then(eventRepository).should().save(any(Event.class));
+  }
+
+  @Test
+  @DisplayName("일정 생성 - 권한/존재 실패 시 404")
+  void createEvent_matchNotFound() {
+    // given
+    Long matchId = 1L;
+    Long userId = 99L;
+    given(matchRepository.findAuthorizedById(matchId, userId)).willReturn(Optional.empty());
+
+    EventCreateRequest req = EventCreateRequest.builder()
+        .title("제목")
+        .eventAt(LocalDate.of(2025, 10, 9))
+        .repeatType(EventRepeatType.NONE)
+        .alarmOption(EventAlarmOption.WEEK_BEFORE)
+        .build();
+
+    // expect
+    assertThatThrownBy(() -> eventService.createEvent(matchId, userId, req))
+        .isInstanceOf(MatchNotFoundException.class);
+  }
+}

--- a/back/src/test/java/com/qmate/domain/match/repository/MatchRepositoryAuthQueryTest.java
+++ b/back/src/test/java/com/qmate/domain/match/repository/MatchRepositoryAuthQueryTest.java
@@ -1,0 +1,119 @@
+package com.qmate.domain.match.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.qmate.config.JpaConfig;
+import com.qmate.domain.event.entity.Event;
+import com.qmate.domain.event.entity.EventAlarmOption;
+import com.qmate.domain.event.entity.EventRepeatType;
+import com.qmate.domain.match.Match;
+import com.qmate.domain.match.MatchMember;
+import com.qmate.domain.match.MatchStatus;
+import com.qmate.domain.match.RelationType;
+import com.qmate.domain.user.User;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@DataJpaTest
+@Import(JpaConfig.class)
+@Tag("local")
+class MatchRepositoryAuthQueryTest {
+
+  @Autowired private TestEntityManager tem;
+  @Autowired private MatchRepository matchRepository;
+
+  private Long matchId;
+  private Long userId;
+
+  @TestConfiguration
+  static class QuerydslTestConfig {
+
+    @Bean
+    JPAQueryFactory jpaQueryFactory(EntityManager em) {
+      return new JPAQueryFactory(em);
+    }
+  }
+
+  @BeforeEach
+  void setUp() {
+
+    // given: User( currentMatchId = matchId ) + Match + MatchMember
+    Match match = Match.builder()
+        .relationType(RelationType.COUPLE)
+        .status(MatchStatus.ACTIVE)
+        .startDate(LocalDateTime.now())
+        .createdAt(LocalDateTime.now())
+        .updatedAt(LocalDateTime.now())
+        .build();
+    tem.persist(match);
+
+    User user = User.builder()
+        .email("user99@test.com")
+        .nickname("nick")
+        .currentMatchId(match.getId())
+        .build();
+    tem.persist(user);
+
+    MatchMember mm = MatchMember.builder()
+        .match(match)
+        .user(user)
+        .build();
+    tem.persist(mm);
+
+    // event는 이 테스트에선 필수는 아니지만, 스키마/연관 무결성 확인용으로 하나 심어둠
+    Event event = Event.builder()
+        .match(match)
+        .title("제목")
+        .description("설명")
+        .eventAt(LocalDate.of(2025, 10, 9))
+        .repeatType(EventRepeatType.NONE)
+        .alarmOption(EventAlarmOption.WEEK_BEFORE)
+        .anniversary(false)
+        .createdAt(LocalDateTime.now())
+        .updatedAt(LocalDateTime.now())
+        .build();
+    tem.persist(event);
+
+    tem.flush();
+    tem.clear();
+
+    matchId = match.getId();
+    userId = user.getId();
+  }
+
+  @Test
+  @DisplayName("findAuthorizedById - 매치 멤버 & currentMatch 일치 시 조회 성공")
+  void findAuthorizedById_success() {
+    Optional<Match> found = matchRepository.findAuthorizedById(matchId, userId);
+    assertThat(found).isPresent();
+    assertThat(found.get().getId()).isEqualTo(matchId);
+  }
+
+  @Test
+  @DisplayName("findAuthorizedById - currentMatch 불일치 시 empty")
+  void findAuthorizedById_currentMismatch_empty() {
+    // when: 사용자의 currentMatchId를 다른 값으로 바꾸면
+    User user = tem.find(User.class, userId);
+    user.setCurrentMatchId(999L);
+    tem.flush();
+    tem.clear();
+
+    Optional<Match> found = matchRepository.findAuthorizedById(matchId, userId);
+    assertThat(found).isEmpty();
+  }
+}


### PR DESCRIPTION
## 개요
일정(Event) 도메인을 신규 도입하고, 매치 하위에서 동작하는 **생성/상세/수정/삭제 API**를 추가합니다.  
권한 검증은 `matchId + userId` 기준으로 통합 쿼리로 처리하며, 예외/응답 포맷을 공통 규격에 맞춥니다.

---

## 변경 사항

### 1) 도메인/리포지토리
- `domain.event.entity.Event`
  - 필드: `id, match(N:1), title, description(nullable), eventAt(LocalDate), repeatType, alarmOption, anniversary, createdAt(@CreatedDate), updatedAt(@LastModifiedDate)`
  - 기본값: `repeatType=NONE`, `alarmOption=WEEK_BEFORE`, `anniversary=false`
- `domain.event.repository.EventRepository`
  - `findAuthorizedById(matchId, userId, eventId)` : 권한+존재 통합 조회(JPQL)
- (재사용) `domain.match.repository.MatchRepository`
  - `findAuthorizedById(matchId, userId)` : 생성 시 권한+존재 통합 조회

### 2) DTO/매퍼
- `domain.event.model.request.EventCreateRequest` (`@Builder`, 검증 어노테이션)
- `domain.event.model.request.EventUpdateRequest` (부분 갱신; null → 미변경)
- `domain.event.model.response.EventResponse`
  - 응답 키 스펙 준수: `eventId, title, description, eventAt, repeatType, alarmOption, isAnniversary, createdAt, updatedAt`
- `domain.event.mapper.EventMapper`
  - `toEntity(Match, EventCreateRequest)`
  - `toResponse(Event)`

### 3) 서비스
- `domain.event.service.EventService`
  - `createEvent(matchId, userId, req)` : 권한 검증 후 저장
  - `getEvent(matchId, userId, eventId)` : 상세 조회(읽기 전용)
  - `updateEvent(matchId, userId, eventId, req)` : 부분 수정
    - **규칙**: `anniversary=true`인 이벤트는 `repeatType` 변경 불가(409)
    - `saveAndFlush`로 `updatedAt` 최신값 반환
  - `deleteEvent(matchId, userId, eventId)` : 삭제
    - **규칙**: `anniversary=true`인 이벤트는 삭제 불가(409)

### 4) 컨트롤러 / 문서
- `api.event.EventController`
  - `POST   /api/matches/{matchId}/events` → **201 Created** (+ `Location: /api/events/{id}`)
  - `GET    /api/matches/{matchId}/events/{eventId}` → **200 OK**
  - `PATCH  /api/matches/{matchId}/events/{eventId}` → **200 OK** (기념일 반복 수정 금지)
  - `DELETE /api/matches/{matchId}/events/{eventId}` → **204 No Content** (기념일 삭제 금지)
- OpenAPI(springdoc) 문서화
  - 클래스: `@Tag("Event")`, `@SecurityRequirement("bearerAuth")`
  - 각 메서드: `@Operation` + `@Parameter` + 필요 시 요청 예시(`EventConstants.*_MD`)
  - **주의**: Swagger에서 상태코드 표기를 정확히 하기 위해 `@ResponseStatus(201/204)` 병행 사용

### 5) 예외/에러 포맷
- 전역 핸들러에 **Enum 역직렬화 실패** 전용 처리 추가
  - `HttpMessageNotReadableException` (원인 `InvalidFormatException` & target enum) → **400**  
  - 응답 예:  
    ```json
    { "errorCode": "COMMON_001", "message": "잘못된 입력 값입니다.",
      "errors": [ { "field": "repeatType", "defaultMessage": "허용 가능한 값: NONE, WEEKLY, MONTHLY, YEARLY" } ] }
    ```
- 권한/존재 통합 조회 실패: `MatchNotFoundException`/`EventNotFoundException` → **404**
- 도메인 규칙 위반:
  - `EventRepeatModificationNotAllowedException` → **409**
  - `EventDeletionNotAllowedException` → **409**

### 6) 테스트
- **서비스 테스트**
  - 생성 성공/권한 실패(404)  
  - 수정: 성공, 기념일 `repeatType` 변경 시 409  
  - 삭제: 성공, 기념일 삭제 시 409
- **컨트롤러 테스트 (통합 슬라이스)**
  - 생성: **201 + Location** 헤더 검증, Enum 미스매치 400  
  - 상세: 200 / 404  
  - 수정: 200 / 기념일 반복 수정 409  
  - 삭제: 204 / 기념일 삭제 409
- **레포지토리(JPA) 쿼리 테스트**
  - `MatchRepository.findAuthorizedById` : 성공/현재 매치 불일치(empty)
  - `EventRepository.findAuthorizedById` : 성공/현재 매치 불일치/다른 매치 이벤트(empty)
