### PR TITLE
feat: 푸시 알림 설정 필드 추가 및 조회/수정 API 구현(+ 로그인 응답 노출, 테스트)

### DIFF
--- a/back/src/main/java/com/qmate/api/notification/PushSettingController.java
+++ b/back/src/main/java/com/qmate/api/notification/PushSettingController.java
@@ -1,0 +1,49 @@
+package com.qmate.api.notification;
+
+import com.qmate.common.constants.notification.PushConstants;
+import com.qmate.domain.notification.model.request.PushSettingUpdateRequest;
+import com.qmate.domain.notification.model.response.PushSettingResponse;
+import com.qmate.domain.notification.service.PushSettingService;
+import com.qmate.security.UserPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/push-settings")
+@RequiredArgsConstructor
+@SecurityRequirement(name = "bearerAuth")
+@Tag(name = "Push Setting", description = "알림 설정 관련 API")
+public class PushSettingController {
+
+  private final PushSettingService pushSettingService;
+
+  @Operation(summary = "알림 설정 조회", description = "사용자의 현재 알림 설정을 조회합니다.")
+  @GetMapping
+  public ResponseEntity<PushSettingResponse> get(
+      @AuthenticationPrincipal UserPrincipal principal) {
+    PushSettingResponse body = pushSettingService.get(principal.userId());
+    return ResponseEntity.ok(body);
+  }
+
+  @Operation(
+      summary = "알림 설정 수정",
+      description = PushConstants.UPDATE_PUSH_SETTING_MD
+  )
+  @PatchMapping
+  public ResponseEntity<PushSettingResponse> update(
+      @AuthenticationPrincipal UserPrincipal principal,
+      @Valid @RequestBody PushSettingUpdateRequest request) {
+    PushSettingResponse body = pushSettingService.update(principal.userId(), request.getPushEnabled());
+    return ResponseEntity.ok(body);
+  }
+}

--- a/back/src/main/java/com/qmate/common/constants/notification/PushConstants.java
+++ b/back/src/main/java/com/qmate/common/constants/notification/PushConstants.java
@@ -1,0 +1,18 @@
+package com.qmate.common.constants.notification;
+
+import com.qmate.common.constants.HttpStatusCode;
+import com.qmate.exception.CommonErrorCode;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
+public class PushConstants {
+
+  // api docs
+  public static final String UPDATE_PUSH_SETTING_MD =
+  "사용자의 알림 사용 여부를 변경합니다.\n\n"
+      + "### 에러 응답\n\n"
+      + "| HTTP | errorCode | message |\n"
+      + "|-----:|-----------|---------|\n"
+      + "| " + HttpStatusCode.BAD_REQUEST + " | " + CommonErrorCode.INVALID_INPUT_ERROR_CODE + " | "
+      + CommonErrorCode.INVALID_INPUT_MESSAGE + " |\n";
+}

--- a/back/src/main/java/com/qmate/domain/auth/AuthService.java
+++ b/back/src/main/java/com/qmate/domain/auth/AuthService.java
@@ -33,6 +33,7 @@ public class AuthService {
         .nickname(user.getNickname())
         .role(user.getRole().name())
         .currentMatchId(user.getCurrentMatchId())
+        .pushEnabled(user.isPushEnabled())
         .build();
 
     return LoginResponse.builder()

--- a/back/src/main/java/com/qmate/domain/auth/model/response/LoginResponse.java
+++ b/back/src/main/java/com/qmate/domain/auth/model/response/LoginResponse.java
@@ -26,5 +26,6 @@ public class LoginResponse {
     private final LocalDate birthDate;
     private final String role;//"USER", "ADMIN"
     private final Long currentMatchId; //null 가능
+    private final boolean pushEnabled;
   }
 }

--- a/back/src/main/java/com/qmate/domain/notification/model/request/PushSettingUpdateRequest.java
+++ b/back/src/main/java/com/qmate/domain/notification/model/request/PushSettingUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.qmate.domain.notification.model.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PushSettingUpdateRequest {
+  @NotNull
+  private Boolean pushEnabled;
+}

--- a/back/src/main/java/com/qmate/domain/notification/model/response/PushSettingResponse.java
+++ b/back/src/main/java/com/qmate/domain/notification/model/response/PushSettingResponse.java
@@ -1,0 +1,14 @@
+package com.qmate.domain.notification.model.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class PushSettingResponse {
+  private boolean pushEnabled;
+}

--- a/back/src/main/java/com/qmate/domain/notification/service/PushSettingService.java
+++ b/back/src/main/java/com/qmate/domain/notification/service/PushSettingService.java
@@ -1,0 +1,33 @@
+package com.qmate.domain.notification.service;
+
+import com.qmate.domain.notification.model.response.PushSettingResponse;
+import com.qmate.domain.user.User;
+import com.qmate.domain.user.UserRepository;
+import com.qmate.exception.custom.matchinstance.UserNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PushSettingService {
+
+  private final UserRepository userRepository;
+
+  @Transactional(readOnly = true)
+  public PushSettingResponse get(Long userId) {
+    boolean enabled = userRepository.findById(userId)
+        .orElseThrow(UserNotFoundException::new)
+        .isPushEnabled();
+    return PushSettingResponse.builder().pushEnabled(enabled).build();
+  }
+
+  @Transactional
+  public PushSettingResponse update(Long userId, boolean enabled) {
+    User u = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
+    if (u.isPushEnabled() != enabled) {
+      u.setPushEnabled(enabled);
+    }
+    return PushSettingResponse.builder().pushEnabled(enabled).build();
+  }
+}

--- a/back/src/main/java/com/qmate/domain/user/User.java
+++ b/back/src/main/java/com/qmate/domain/user/User.java
@@ -58,6 +58,10 @@ public class User {
 
   private Long currentMatchId;
 
+  @Builder.Default
+  @Column(name = "push_enabled", nullable = false)
+  private boolean pushEnabled = false;
+
   @CreationTimestamp
   @Column(nullable = false, updatable = false)
   private LocalDateTime createdAt;

--- a/back/src/main/java/com/qmate/security/oauth/OAuth2SuccessHandler.java
+++ b/back/src/main/java/com/qmate/security/oauth/OAuth2SuccessHandler.java
@@ -71,6 +71,7 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         .birthDate(user.getBirthDate())
         .role(user.getRole().name())
         .currentMatchId(user.getCurrentMatchId())
+        .pushEnabled(user.isPushEnabled())
         .build();
 
     LoginResponse body = LoginResponse.builder()

--- a/back/src/test/java/com/qmate/api/notification/PushSettingControllerTest.java
+++ b/back/src/test/java/com/qmate/api/notification/PushSettingControllerTest.java
@@ -69,7 +69,6 @@ class PushSettingControllerTest {
   }
 
   @Test
-  @Disabled("HttpMessageNotReadableException에 대한 처리 필요")
   @DisplayName("PATCH 본문 유효성 검증 - pushEnabled boolean 타입이 아닐 시 400")
   void patch_validation_type_mismatch_body() throws Exception {
     String json = """

--- a/back/src/test/java/com/qmate/api/notification/PushSettingControllerTest.java
+++ b/back/src/test/java/com/qmate/api/notification/PushSettingControllerTest.java
@@ -1,0 +1,84 @@
+package com.qmate.api.notification;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.qmate.domain.notification.model.response.PushSettingResponse;
+import com.qmate.domain.notification.service.PushSettingService;
+import com.qmate.security.UserPrincipal;
+import com.qmate.SecuritySliceTestConfig;
+import com.qmate.AuthTestUtils;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+
+@WebMvcTest(PushSettingController.class)
+@Import(SecuritySliceTestConfig.class)
+class PushSettingControllerTest {
+
+  @Autowired MockMvc mvc;
+  @Autowired ObjectMapper om;
+
+  @MockitoBean
+  PushSettingService pushSettingService;
+
+  private static final Long PRINCIPAL = 1L;
+
+  @Test
+  @DisplayName("GET /api/push-settings: 현재 설정 반환")
+  void get_returns_current_setting() throws Exception {
+    given(pushSettingService.get(1L)).willReturn(new PushSettingResponse(true));
+
+    mvc.perform(get("/api/push-settings")
+            .with(AuthTestUtils.userPrincipal(PRINCIPAL)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.pushEnabled").value(true));
+  }
+
+  @Test
+  @DisplayName("PATCH /api/push-settings: 설정 변경 후 결과 반환")
+  void patch_updates_and_returns() throws Exception {
+    given(pushSettingService.update(1L, false)).willReturn(new PushSettingResponse(false));
+
+    mvc.perform(patch("/api/push-settings")
+            .with(AuthTestUtils.userPrincipal(PRINCIPAL))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"pushEnabled\": false}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.pushEnabled").value(false));
+  }
+
+  @Test
+  @DisplayName("PATCH 본문 유효성 검증 - pushEnabled 누락 시 400")
+  void patch_validation_missing_body() throws Exception {
+    mvc.perform(patch("/api/push-settings")
+            .with(AuthTestUtils.userPrincipal(PRINCIPAL))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{}"))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @Disabled("HttpMessageNotReadableException에 대한 처리 필요")
+  @DisplayName("PATCH 본문 유효성 검증 - pushEnabled boolean 타입이 아닐 시 400")
+  void patch_validation_type_mismatch_body() throws Exception {
+    String json = """
+        { "pushEnabled": "notBoolean" }
+        """;
+    mvc.perform(patch("/api/push-settings")
+            .with(AuthTestUtils.userPrincipal(PRINCIPAL))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(json))
+        .andExpect(status().isBadRequest());
+  }
+}

--- a/back/src/test/java/com/qmate/domain/notification/service/PushSettingServiceTest.java
+++ b/back/src/test/java/com/qmate/domain/notification/service/PushSettingServiceTest.java
@@ -1,0 +1,68 @@
+package com.qmate.domain.notification.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import com.qmate.domain.notification.model.response.PushSettingResponse;
+import com.qmate.domain.user.User;
+import com.qmate.domain.user.UserRepository;
+import com.qmate.exception.custom.matchinstance.UserNotFoundException;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PushSettingServiceTest {
+
+  @Mock
+  UserRepository userRepository;
+
+  @InjectMocks
+  PushSettingService service;
+
+  @Test
+  @DisplayName("GET: 현재 pushEnabled 값을 반환한다")
+  void get_returns_current_flag() {
+    User u = new User();
+    u.setId(1L);
+    u.setPushEnabled(true);
+    given(userRepository.findById(1L)).willReturn(Optional.of(u));
+
+    PushSettingResponse res = service.get(1L);
+
+    assertThat(res.isPushEnabled()).isTrue();
+  }
+
+  @Test
+  @DisplayName("PATCH: 값이 다르면 변경하고 변경값을 반환한다")
+  void update_changes_when_different() {
+    User u = new User();
+    u.setId(1L);
+    u.setPushEnabled(false);
+    given(userRepository.findById(1L)).willReturn(Optional.of(u));
+
+    PushSettingResponse res = service.update(1L, true);
+
+    assertThat(u.isPushEnabled()).isTrue();
+    assertThat(res.isPushEnabled()).isTrue();
+  }
+
+  @Test
+  @DisplayName("PATCH: 값이 같으면 업데이트를 스킵하고 그대로 반환한다")
+  void update_skips_when_same() {
+    User u = new User();
+    u.setId(1L);
+    u.setPushEnabled(true);
+    given(userRepository.findById(1L)).willReturn(Optional.of(u));
+
+    PushSettingResponse res = service.update(1L, true);
+
+    assertThat(u.isPushEnabled()).isTrue();
+    assertThat(res.isPushEnabled()).isTrue();
+  }
+
+}


### PR DESCRIPTION
## 개요
사용자 푸시 알림 설정을 도메인에 추가하고, 로그인 응답 및 전용 API(조회/수정)로 노출했습니다. 설정 값이 동일할 경우 DB 업데이트를 스킵하여 불필요한 쓰기 작업을 줄였습니다. 컨트롤러/서비스 테스트 포함.

---

## 변경 사항

### 1) 도메인
- User에 `pushEnabled` 필드 추가(기본값 false)
- 게터/세터 및 매핑 추가

### 2) API
- GET /api/push-settings: 현재 사용자 푸시 설정 조회
- PATCH /api/push-settings: 푸시 설정 수정(값이 동일하면 업데이트 스킵)

### 3) 로그인 응답
- 로그인 Response에 `pushEnabled` 노출

---

## 테스트
- Service 단위 테스트: 조회, 변경 반영, 동일 값 업데이트 스킵 검증
- Controller(WebMvcTest): 
  - GET 성공 및 필드 검증
  - PATCH 성공 및 필드 검증
  - PATCH 본문 누락 시 400 검증
  - 타입 불일치 400 검증 항목은 전역 예외 처리 PR 병합 후 활성화 예정(현재 Disabled)
