### PR TITLE
refactor: Exception handling refactor

### DIFF
--- a/back/src/main/java/com/qmate/api/AuthController.java
+++ b/back/src/main/java/com/qmate/api/AuthController.java
@@ -7,6 +7,7 @@ import com.qmate.domain.auth.model.response.LoginResponse;
 import com.qmate.domain.user.UserService;
 import com.qmate.domain.user.model.request.RegisterRequest;
 import com.qmate.domain.user.model.response.RegisterResponse;
+import com.qmate.exception.custom.auth.OkTokenInvalidException;
 import com.qmate.security.UserPrincipal;
 import jakarta.validation.Valid;
 import java.util.Map;
@@ -34,7 +35,7 @@ public class AuthController {
   public ResponseEntity<RegisterResponse> register(@Valid @RequestBody RegisterRequest req){
     //ok 토큰 소비
     if(!emailVerificationService.consumeOkToken(req.getEmailVerifiedToken(), "signup", req.getEmail())){
-      throw new IllegalStateException("이메일 인증이 확인되지 않음.");
+      throw new OkTokenInvalidException();
     }
     //가입
     Long id = userService.register(req);

--- a/back/src/main/java/com/qmate/domain/auth/AuthService.java
+++ b/back/src/main/java/com/qmate/domain/auth/AuthService.java
@@ -3,6 +3,7 @@ package com.qmate.domain.auth;
 import com.qmate.domain.user.User;
 import com.qmate.domain.user.UserRepository;
 import com.qmate.domain.auth.model.response.LoginResponse;
+import com.qmate.exception.custom.auth.InvalidCredentialsException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -19,10 +20,10 @@ public class AuthService {
 
   public LoginResponse login(String email, String rawPassword) {
     User user = userRepository.findByEmail(email)
-        .orElseThrow(() -> new BadCredentialsException("Invalid email or password"));
+        .orElseThrow(InvalidCredentialsException::new);
 
     if (!passwordEncoder.matches(rawPassword, user.getPasswordHash())) {
-      throw new BadCredentialsException("Invalid email or password");
+      throw new InvalidCredentialsException();
     }
 
     JwtService.TokenPair pair = jwtService.issue(user.getId(), user.getRole().name(), user.getEmail());

--- a/back/src/main/java/com/qmate/domain/auth/EmailVerificationService.java
+++ b/back/src/main/java/com/qmate/domain/auth/EmailVerificationService.java
@@ -1,6 +1,9 @@
 package com.qmate.domain.auth;
 
 import com.qmate.domain.mail.MailSender;
+import com.qmate.exception.custom.auth.AttemptsLimitExceededException;
+import com.qmate.exception.custom.auth.ResendCooldownException;
+import com.qmate.exception.custom.auth.VerificationInvalidOrExpiredException;
 import java.security.SecureRandom;
 import java.time.Duration;
 import java.util.UUID;
@@ -37,7 +40,7 @@ public class EmailVerificationService {
 
   public void sendCode(String email, String purpose) {
     if (Boolean.TRUE.equals(redis.hasKey(resendKey(purpose, email)))) {
-      throw new IllegalStateException("RESEND_COOLDOWN");
+      throw new ResendCooldownException();
     }
     String code = String.format("%06d", RND.nextInt(1_000_000));//0~999,999 범위 난수 생성 후 6자리 0패딩 문자열로 포맷
     redis.opsForValue().set(codeKey(purpose, email), code, CODE_TTL);
@@ -50,15 +53,15 @@ public class EmailVerificationService {
 
   public String verifyAndIssueToken(String email, String purpose, String inputCode) {
     String stored = redis.opsForValue().get(codeKey(purpose, email));
-    if (!StringUtils.hasText(stored)) throw new IllegalArgumentException("만료 또는 유효하지 않음");
+    if (!StringUtils.hasText(stored)) throw new VerificationInvalidOrExpiredException();
 
     long attempts = increment(attemptKey(purpose, email), CODE_TTL);
     if (attempts > MAX_ATTEMPTS) {
       deleteAll(purpose, email);
-      throw new IllegalArgumentException("시도 한도 초과");
+      throw new AttemptsLimitExceededException();
     }
 
-    if (!stored.equals(inputCode)) throw new IllegalArgumentException("만료 또는 유효하지 않음");
+    if (!stored.equals(inputCode)) throw new VerificationInvalidOrExpiredException();
 
     //성공-----------------
     deleteAll(purpose, email);

--- a/back/src/main/java/com/qmate/domain/user/ProfileService.java
+++ b/back/src/main/java/com/qmate/domain/user/ProfileService.java
@@ -1,5 +1,7 @@
 package com.qmate.domain.user;
 
+import com.qmate.exception.custom.user.BirthDateInFutureException;
+import com.qmate.exception.custom.user.NicknameTooLongException;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,7 +18,7 @@ public class ProfileService {
     boolean changed = false;
 
     if (nickname != null) {
-      if (nickname.length() > 50) throw new IllegalArgumentException("닉네임은 50자 이내");
+      if (nickname.length() > 50) throw new NicknameTooLongException();
       if (!nickname.equals(u.getNickname())) {
         u.setNickname(nickname);
         changed = true;
@@ -24,7 +26,7 @@ public class ProfileService {
     }
 
     if (birthDate != null) {
-      if (birthDate.isAfter(LocalDate.now())) throw new IllegalArgumentException("미래 날짜 불가");
+      if (birthDate.isAfter(LocalDate.now())) throw new BirthDateInFutureException();
       if (!birthDate.equals(u.getBirthDate())) {
         u.setBirthDate(birthDate);
         changed = true;

--- a/back/src/main/java/com/qmate/domain/user/UserService.java
+++ b/back/src/main/java/com/qmate/domain/user/UserService.java
@@ -1,6 +1,7 @@
 package com.qmate.domain.user;
 
 import com.qmate.domain.user.model.request.RegisterRequest;
+import com.qmate.exception.custom.user.EmailAlreadyInUseException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -13,7 +14,7 @@ public class UserService {
 
   public Long register(RegisterRequest req) {
     if(userRepository.existsByEmail(req.getEmail())){
-      throw new IllegalArgumentException("이미 사용중인 이메일");
+      throw new EmailAlreadyInUseException();
     }
     User user = User.builder()
         .email(req.getEmail())

--- a/back/src/main/java/com/qmate/exception/custom/auth/AttemptsLimitExceededException.java
+++ b/back/src/main/java/com/qmate/exception/custom/auth/AttemptsLimitExceededException.java
@@ -1,0 +1,10 @@
+package com.qmate.exception.custom.auth;
+
+import com.qmate.exception.BusinessGlobalException;
+import com.qmate.exception.errorcode.EmailVerificationErrorCode;
+
+public class AttemptsLimitExceededException extends BusinessGlobalException {
+  public AttemptsLimitExceededException() {
+    super(EmailVerificationErrorCode.attemptsExceeded());
+  }
+}

--- a/back/src/main/java/com/qmate/exception/custom/auth/InvalidCredentialsException.java
+++ b/back/src/main/java/com/qmate/exception/custom/auth/InvalidCredentialsException.java
@@ -1,0 +1,11 @@
+package com.qmate.exception.custom.auth;
+
+import com.qmate.exception.BusinessGlobalException;
+import com.qmate.exception.errorcode.AuthErrorCode;
+
+public class InvalidCredentialsException extends BusinessGlobalException {
+
+  public InvalidCredentialsException() {
+    super(AuthErrorCode.invalidCredential());
+  }
+}

--- a/back/src/main/java/com/qmate/exception/custom/auth/OAuthResponseMissingIdException.java
+++ b/back/src/main/java/com/qmate/exception/custom/auth/OAuthResponseMissingIdException.java
@@ -1,0 +1,10 @@
+package com.qmate.exception.custom.auth;
+
+import com.qmate.exception.BusinessGlobalException;
+import com.qmate.exception.errorcode.AuthErrorCode;
+
+public class OAuthResponseMissingIdException extends BusinessGlobalException {
+  public OAuthResponseMissingIdException() {
+    super(AuthErrorCode.oauthResponseMissingId());
+  }
+}

--- a/back/src/main/java/com/qmate/exception/custom/auth/OAuthResponseParseException.java
+++ b/back/src/main/java/com/qmate/exception/custom/auth/OAuthResponseParseException.java
@@ -1,0 +1,10 @@
+package com.qmate.exception.custom.auth;
+
+import com.qmate.exception.BusinessGlobalException;
+import com.qmate.exception.errorcode.AuthErrorCode;
+
+public class OAuthResponseParseException extends BusinessGlobalException {
+  public OAuthResponseParseException() {
+    super(AuthErrorCode.oauthResponseParseFailed());
+  }
+}

--- a/back/src/main/java/com/qmate/exception/custom/auth/OkTokenInvalidException.java
+++ b/back/src/main/java/com/qmate/exception/custom/auth/OkTokenInvalidException.java
@@ -1,0 +1,10 @@
+package com.qmate.exception.custom.auth;
+
+import com.qmate.exception.BusinessGlobalException;
+import com.qmate.exception.errorcode.EmailVerificationErrorCode;
+
+public class OkTokenInvalidException extends BusinessGlobalException {
+  public OkTokenInvalidException() {
+    super(EmailVerificationErrorCode.okTokenInvalid());
+  }
+}

--- a/back/src/main/java/com/qmate/exception/custom/auth/ResendCooldownException.java
+++ b/back/src/main/java/com/qmate/exception/custom/auth/ResendCooldownException.java
@@ -1,0 +1,10 @@
+package com.qmate.exception.custom.auth;
+
+import com.qmate.exception.BusinessGlobalException;
+import com.qmate.exception.errorcode.EmailVerificationErrorCode;
+
+public class ResendCooldownException extends BusinessGlobalException {
+  public ResendCooldownException() {
+    super(EmailVerificationErrorCode.resendCooldown());
+  }
+}

--- a/back/src/main/java/com/qmate/exception/custom/auth/UnsupportedPrincipalTypeException.java
+++ b/back/src/main/java/com/qmate/exception/custom/auth/UnsupportedPrincipalTypeException.java
@@ -1,0 +1,10 @@
+package com.qmate.exception.custom.auth;
+
+import com.qmate.exception.BusinessGlobalException;
+import com.qmate.exception.errorcode.AuthErrorCode;
+
+public class UnsupportedPrincipalTypeException extends BusinessGlobalException {
+  public UnsupportedPrincipalTypeException() {
+    super(AuthErrorCode.unsupportedPrincipalType());
+  }
+}

--- a/back/src/main/java/com/qmate/exception/custom/auth/VerificationInvalidOrExpiredException.java
+++ b/back/src/main/java/com/qmate/exception/custom/auth/VerificationInvalidOrExpiredException.java
@@ -1,0 +1,10 @@
+package com.qmate.exception.custom.auth;
+
+import com.qmate.exception.BusinessGlobalException;
+import com.qmate.exception.errorcode.EmailVerificationErrorCode;
+
+public class VerificationInvalidOrExpiredException extends BusinessGlobalException {
+  public VerificationInvalidOrExpiredException() {
+    super(EmailVerificationErrorCode.codeInvalidOrExpired());
+  }
+}

--- a/back/src/main/java/com/qmate/exception/custom/user/BirthDateInFutureException.java
+++ b/back/src/main/java/com/qmate/exception/custom/user/BirthDateInFutureException.java
@@ -1,0 +1,10 @@
+package com.qmate.exception.custom.user;
+
+import com.qmate.exception.BusinessGlobalException;
+import com.qmate.exception.errorcode.UserErrorCode;
+
+public class BirthDateInFutureException extends BusinessGlobalException {
+  public BirthDateInFutureException() {
+    super(UserErrorCode.birthDateInFuture());
+  }
+}

--- a/back/src/main/java/com/qmate/exception/custom/user/EmailAlreadyInUseException.java
+++ b/back/src/main/java/com/qmate/exception/custom/user/EmailAlreadyInUseException.java
@@ -1,0 +1,10 @@
+package com.qmate.exception.custom.user;
+
+import com.qmate.exception.BusinessGlobalException;
+import com.qmate.exception.errorcode.UserErrorCode;
+
+public class EmailAlreadyInUseException extends BusinessGlobalException {
+  public EmailAlreadyInUseException() {
+    super(UserErrorCode.emailAlreadyInUse());
+  }
+}

--- a/back/src/main/java/com/qmate/exception/custom/user/NicknameTooLongException.java
+++ b/back/src/main/java/com/qmate/exception/custom/user/NicknameTooLongException.java
@@ -1,0 +1,10 @@
+package com.qmate.exception.custom.user;
+
+import com.qmate.exception.BusinessGlobalException;
+import com.qmate.exception.errorcode.UserErrorCode;
+
+public class NicknameTooLongException extends BusinessGlobalException {
+  public NicknameTooLongException() {
+    super(UserErrorCode.nicknameTooLong());
+  }
+}

--- a/back/src/main/java/com/qmate/exception/errorcode/AuthErrorCode.java
+++ b/back/src/main/java/com/qmate/exception/errorcode/AuthErrorCode.java
@@ -1,0 +1,39 @@
+package com.qmate.exception.errorcode;
+
+import com.qmate.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class AuthErrorCode extends ErrorCode {
+
+  public static final String INVALID_CREDENTIALS_CODE = "AU_001";
+  private static final String INVALID_CREDENTIALS_MESSAGE = "이메일 또는 비밀번호가 올바르지 않습니다.";
+
+  public static final String UNSUPPORTED_PRINCIPAL_TYPE_CODE = "AU_002";
+  public static final String UNSUPPORTED_PRINCIPAL_TYPE_MESSAGE = "지원되지 않는 인증 Principal 타입입니다.";
+
+  public static final String OAUTH_RESPONSE_PARSE_FAILED_CODE = "AU_003";
+  public static final String OAUTH_RESPONSE_PARSE_FAILED_MESSAGE = "외부 인증 응답 파싱에 실패했습니다.";
+
+  public static final String OAUTH_RESPONSE_MISSING_ID_CODE = "AU_004";
+  public static final String OAUTH_RESPONSE_MISSING_ID_MESSAGE = "네이버 사용자 ID가 응답에 없습니다.";
+
+  public static ErrorCode invalidCredential() {
+    return new AuthErrorCode(HttpStatus.UNAUTHORIZED, INVALID_CREDENTIALS_CODE, INVALID_CREDENTIALS_MESSAGE );
+  }
+
+  public static ErrorCode unsupportedPrincipalType() {
+    return new AuthErrorCode(HttpStatus.INTERNAL_SERVER_ERROR, UNSUPPORTED_PRINCIPAL_TYPE_CODE, UNSUPPORTED_PRINCIPAL_TYPE_MESSAGE);
+  }
+
+  public static ErrorCode oauthResponseParseFailed() {
+    return new AuthErrorCode(HttpStatus.BAD_GATEWAY, OAUTH_RESPONSE_PARSE_FAILED_CODE, OAUTH_RESPONSE_PARSE_FAILED_MESSAGE);
+  }
+
+  public static ErrorCode oauthResponseMissingId() {
+    return new AuthErrorCode(HttpStatus.BAD_GATEWAY, OAUTH_RESPONSE_MISSING_ID_CODE, OAUTH_RESPONSE_MISSING_ID_MESSAGE);
+  }
+
+  private AuthErrorCode(HttpStatus httpStatus, String code, String message){
+    super(httpStatus, code, message);
+  }
+}

--- a/back/src/main/java/com/qmate/exception/errorcode/EmailVerificationErrorCode.java
+++ b/back/src/main/java/com/qmate/exception/errorcode/EmailVerificationErrorCode.java
@@ -1,0 +1,39 @@
+package com.qmate.exception.errorcode;
+
+import com.qmate.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class EmailVerificationErrorCode extends ErrorCode {
+
+  public static final String RESEND_COOLDOWN_CODE = "EV_001";
+  public static final String RESEND_COOLDOWN_MSG  = "인증코드 재전송 대기 시간입니다.";
+
+  public static final String CODE_INVALID_OR_EXPIRED_CODE = "EV_002";
+  public static final String CODE_INVALID_OR_EXPIRED_MSG  = "인증코드가 만료되었거나 유효하지 않습니다.";
+
+  public static final String ATTEMPTS_EXCEEDED_CODE = "EV_003";
+  public static final String ATTEMPTS_EXCEEDED_MSG  = "인증 시도 한도를 초과했습니다.";
+
+  public static final String OK_TOKEN_INVALID_CODE = "EV_004";
+  public static final String OK_TOKEN_INVALID_MSG  = "이메일 인증 확인 토큰이 유효하지 않거나 만료되었습니다.";
+
+  public static ErrorCode resendCooldown() {
+    return new EmailVerificationErrorCode(HttpStatus.TOO_MANY_REQUESTS, RESEND_COOLDOWN_CODE, RESEND_COOLDOWN_MSG);
+  }
+
+  public static ErrorCode codeInvalidOrExpired() {
+    return new EmailVerificationErrorCode(HttpStatus.BAD_REQUEST, CODE_INVALID_OR_EXPIRED_CODE, CODE_INVALID_OR_EXPIRED_MSG);
+  }
+
+  public static ErrorCode attemptsExceeded() {
+    return new EmailVerificationErrorCode(HttpStatus.TOO_MANY_REQUESTS, ATTEMPTS_EXCEEDED_CODE, ATTEMPTS_EXCEEDED_MSG);
+  }
+
+  public static ErrorCode okTokenInvalid() {
+    return new EmailVerificationErrorCode(HttpStatus.BAD_REQUEST, OK_TOKEN_INVALID_CODE, OK_TOKEN_INVALID_MSG);
+  }
+
+  private EmailVerificationErrorCode(HttpStatus status, String code, String message) {
+    super(status, code, message);
+  }
+}

--- a/back/src/main/java/com/qmate/exception/errorcode/UserErrorCode.java
+++ b/back/src/main/java/com/qmate/exception/errorcode/UserErrorCode.java
@@ -1,0 +1,32 @@
+package com.qmate.exception.errorcode;
+
+import com.qmate.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class UserErrorCode extends ErrorCode {
+
+  public static final String NICKNAME_TOO_LONG_CODE = "US_001";
+  public static final String NICKNAME_TOO_LONG_MSG  = "닉네임은 50자 이내여야 합니다.";
+
+  public static final String BIRTHDATE_IN_FUTURE_CODE = "US_002";
+  public static final String BIRTHDATE_IN_FUTURE_MSG  = "생년월일은 미래 날짜일 수 없습니다.";
+
+  public static final String EMAIL_ALREADY_IN_USE_CODE = "US_003";
+  public static final String EMAIL_ALREADY_IN_USE_MSG  = "이미 사용 중인 이메일입니다.";
+
+  public static ErrorCode nicknameTooLong() {
+    return new UserErrorCode(HttpStatus.BAD_REQUEST, NICKNAME_TOO_LONG_CODE, NICKNAME_TOO_LONG_MSG);
+  }
+
+  public static ErrorCode birthDateInFuture() {
+    return new UserErrorCode(HttpStatus.BAD_REQUEST, BIRTHDATE_IN_FUTURE_CODE, BIRTHDATE_IN_FUTURE_MSG);
+  }
+
+  public static ErrorCode emailAlreadyInUse() {
+    return new UserErrorCode(HttpStatus.CONFLICT, EMAIL_ALREADY_IN_USE_CODE, EMAIL_ALREADY_IN_USE_MSG);
+  }
+
+  private UserErrorCode(HttpStatus status, String code, String message) {
+    super(status, code, message);
+  }
+}

--- a/back/src/main/java/com/qmate/security/oauth/CustomOAuth2UserService.java
+++ b/back/src/main/java/com/qmate/security/oauth/CustomOAuth2UserService.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.qmate.domain.auth.SocialAccountService;
 import com.qmate.domain.user.User;
 import com.qmate.domain.user.UserSocialAccount.SocialProvider;
+import com.qmate.exception.custom.auth.OAuthResponseMissingIdException;
+import com.qmate.exception.custom.auth.OAuthResponseParseException;
 import java.time.LocalDate;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -36,7 +38,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
       try {
         log.debug("NAVER attrs = {}", new ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(resp));
       } catch (JsonProcessingException e) {
-        throw new RuntimeException(e);
+        throw new OAuthResponseParseException();
       }
 
       String providerUserId = String.valueOf(resp.get("id"));
@@ -45,7 +47,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
       LocalDate birthDate = parseNaverBirth(resp);
 
       if (providerUserId == null) {
-        throw new IllegalStateException("Naver response missing 'id'");
+        throw new OAuthResponseMissingIdException();
       }
 
       User user = socialAccountService.upsertSocialUser(

--- a/back/src/main/java/com/qmate/security/oauth/OAuth2FailureHandler.java
+++ b/back/src/main/java/com/qmate/security/oauth/OAuth2FailureHandler.java
@@ -1,22 +1,37 @@
 package com.qmate.security.oauth;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.qmate.exception.CommonErrorCode;
+import com.qmate.exception.ErrorCode;
+import com.qmate.exception.ErrorResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
+@RequiredArgsConstructor
 public class OAuth2FailureHandler implements AuthenticationFailureHandler {
+  private final ObjectMapper objectMapper;
+
   @Override
   public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
       AuthenticationException exception) throws IOException {
-    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    log.warn("OAuth2 로그인 실패: {}", exception.getMessage());
+
+    ErrorCode ec = CommonErrorCode.unauthorized(); // 401 / C_401 같은 공통 코드 사용
+    ErrorResponse body = new ErrorResponse(ec.getCode(), ec.getMessage());
+
+    response.setStatus(ec.getHttpStatus().value());
     response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-    response.getWriter().write("{\"error\":\"oauth2_login_failed\",\"message\":\"" +
-        exception.getMessage().replace("\"","'") + "\"}");
+    response.setCharacterEncoding("UTF-8");
+    objectMapper.writeValue(response.getWriter(), body);
     response.getWriter().flush();
   }
 }

--- a/back/src/main/java/com/qmate/security/oauth/OAuth2SuccessHandler.java
+++ b/back/src/main/java/com/qmate/security/oauth/OAuth2SuccessHandler.java
@@ -7,6 +7,7 @@ import com.qmate.domain.auth.model.response.LoginResponse;
 import com.qmate.domain.user.User;
 import com.qmate.domain.user.UserRepository;
 import com.qmate.domain.user.UserSocialAccount.SocialProvider;
+import com.qmate.exception.custom.auth.UnsupportedPrincipalTypeException;
 import com.qmate.security.UserPrincipal;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -51,7 +52,7 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
       String birthdate = (String) oidc.getClaims().get("birthdate");
       log.debug("GOOGLE birthdate claim = {}", birthdate);
     } else {
-      throw new IllegalStateException("Unsupported principal type: " + p.getClass());
+      throw new UnsupportedPrincipalTypeException();
     }
 
     var principal = new UserPrincipal(user.getId(), user.getEmail(), user.getRole().name());


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

- 서비스/컨트롤러 전반에서 IllegalArgumentException, IllegalStateException, RuntimeException, BadCredentialsException 등 일반예외 사용 → 글로벌 핸들러 응답 포맷/에러코드 불일치
- OAuth2 실패 응답이 {error, message} 형태로 별도 처리됨

**TO-BE**

- 도메인 전용 예외(BusinessGlobalException 상속)로 통일 및 글로벌 핸들러 매핑

> Auth: InvalidCredentialsException(AU_001, 401), UnsupportedPrincipalTypeException(AU_002, 500), OAuthResponseParseException(AU_003, 502), OAuthResponseMissingIdException(AU_004, 502)
> User: NicknameTooLongException(US_001, 400), BirthDateInFutureException(US_002, 400), EmailAlreadyInUseException(US_003, 409)
> EmailVerification: ResendCooldownException(EV_001, 429), VerificationInvalidOrExpiredException(EV_002, 400), AttemptsLimitExceededException(EV_003, 429), OkTokenInvalidException(EV_004, 400)

- OAuth2FailureHandler 응답을 ErrorResponse{errorCode, message, errors}로 통일 (COMMON_002/401)
- 성공 플로우 및 비즈니스 로직에는 변경 없음(에러 응답만 표준화)

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- API 테스트 