### PR TITLE
Feature/get detached match

### DIFF
--- a/back/src/main/java/com/qmate/api/MatchController.java
+++ b/back/src/main/java/com/qmate/api/MatchController.java
@@ -4,6 +4,7 @@ import com.qmate.common.constants.match.MatchConstants;
 import com.qmate.domain.match.model.request.MatchCreationRequest;
 import com.qmate.domain.match.model.request.MatchJoinRequest;
 import com.qmate.domain.match.model.request.MatchUpdateRequest;
+import com.qmate.domain.match.model.response.DetachedMatchStatusResponse;
 import com.qmate.domain.match.model.response.LockStatusResponse;
 import com.qmate.domain.match.model.response.MatchActionResponse;
 import com.qmate.domain.match.model.response.MatchCreationResponse;
@@ -174,6 +175,18 @@ public class MatchController {
       @AuthenticationPrincipal UserPrincipal principal
   ){
     LockStatusResponse response = matchService.getLockStatus(principal.userId());
+    return ResponseEntity.ok(response);
+  }
+  //현재 로그인한 사용자가 복구 가능한 '연결 끊김' 상태의 매칭을 가지고 있는지 조회
+  @GetMapping("/detached-status")
+  @Operation(
+      summary = "복구 가능한 '연결 끊김' 상태의 매칭 조회",
+      description = "현재 로그인한 사용자가 복구 가능한 '연결 끊김' 상태의 매칭을 가지고 있는지 조회합니다."
+  )
+  public ResponseEntity<DetachedMatchStatusResponse> getDetachedMatchStatus(
+      @AuthenticationPrincipal UserPrincipal principal
+  ){
+    DetachedMatchStatusResponse response = matchService.getDetachedMatchStatus(principal.userId());
     return ResponseEntity.ok(response);
   }
 }

--- a/back/src/main/java/com/qmate/domain/match/model/response/DetachedMatchStatusResponse.java
+++ b/back/src/main/java/com/qmate/domain/match/model/response/DetachedMatchStatusResponse.java
@@ -1,0 +1,15 @@
+package com.qmate.domain.match.model.response;
+
+import lombok.Getter;
+
+@Getter
+public class DetachedMatchStatusResponse {
+  private final boolean hasDetachedMatch;
+  private final Long matchId; // 복구 가능한 매칭이 있을 경우 그 ID
+
+  public DetachedMatchStatusResponse(boolean hasDetachedMatch, Long matchId){
+    this.hasDetachedMatch = hasDetachedMatch;
+    this.matchId = matchId;
+  }
+
+}

--- a/back/src/main/java/com/qmate/domain/match/repository/MatchMemberRepository.java
+++ b/back/src/main/java/com/qmate/domain/match/repository/MatchMemberRepository.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MatchMemberRepository extends JpaRepository<MatchMember, Long> {
+public interface MatchMemberRepository extends JpaRepository<MatchMember, Long>,MatchMemberRepositoryCustom {
 
   Optional<MatchMember> findByMatch_IdAndUser_Id(Long matchId, Long id);
 

--- a/back/src/main/java/com/qmate/domain/match/repository/MatchMemberRepositoryCustom.java
+++ b/back/src/main/java/com/qmate/domain/match/repository/MatchMemberRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.qmate.domain.match.repository;
+
+import com.qmate.domain.match.MatchMember;
+import com.qmate.domain.match.MatchStatus;
+import java.util.Optional;
+
+public interface MatchMemberRepositoryCustom {
+
+  Optional<MatchMember> findDetachedMatchForUser(Long userId, MatchStatus status);
+
+}

--- a/back/src/main/java/com/qmate/domain/match/repository/MatchMemberRepositoryImpl.java
+++ b/back/src/main/java/com/qmate/domain/match/repository/MatchMemberRepositoryImpl.java
@@ -1,0 +1,32 @@
+package com.qmate.domain.match.repository;
+
+import com.qmate.domain.match.MatchMember;
+import com.qmate.domain.match.MatchStatus;
+import com.qmate.domain.match.QMatchMember;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class MatchMemberRepositoryImpl implements MatchMemberRepositoryCustom{
+
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public Optional<MatchMember> findDetachedMatchForUser(Long userId, MatchStatus status){
+    QMatchMember matchMember = QMatchMember.matchMember;
+
+    MatchMember result = queryFactory
+        .selectFrom(matchMember)
+        .where(
+            matchMember.user.id.eq(userId),
+            matchMember.match.status.eq(status)
+        )
+        .orderBy(matchMember.match.detachedAt.desc())
+        .fetchFirst(); // LIMIT 1과 동일
+
+    return Optional.ofNullable(result);
+  }
+
+
+}

--- a/back/src/main/java/com/qmate/domain/match/service/MatchService.java
+++ b/back/src/main/java/com/qmate/domain/match/service/MatchService.java
@@ -9,6 +9,7 @@ import com.qmate.domain.match.RelationType;
 import com.qmate.domain.match.model.request.MatchCreationRequest;
 import com.qmate.domain.match.model.request.MatchJoinRequest;
 import com.qmate.domain.match.model.request.MatchUpdateRequest;
+import com.qmate.domain.match.model.response.DetachedMatchStatusResponse;
 import com.qmate.domain.match.model.response.InviteCodeValidationResponse;
 import com.qmate.domain.match.model.response.LockStatusResponse;
 import com.qmate.domain.match.model.response.MatchCreationResponse;
@@ -250,6 +251,23 @@ public class MatchService {
     return redisHelper.getLockTimeRemaining(userId)
         .map(remainingSeconds -> new LockStatusResponse(true, remainingSeconds)) // 잠겨있다면 (시간이 남아있다면)
         .orElse(new LockStatusResponse(false, 0L)); // 잠겨있지 않다면
+  }
+
+  //복구 가능 매칭 조회
+  @Transactional(readOnly = true)
+  public DetachedMatchStatusResponse getDetachedMatchStatus(Long userId){
+    //QueryDSL로 구현된 커스텀 리포지토리 메서드를 호출
+    Optional<MatchMember> detachedMemberOpt = matchMemberRepository.findDetachedMatchForUser(userId, MatchStatus.DETACHED_PENDING_DELETE);
+
+    if (detachedMemberOpt.isPresent()){
+      // 복구 가능한 매칭이 있다면, 해당 MatchMember에서 Match 객체를 꺼내고,
+      // 그 Match의 ID를 가져와 DTO에 담아 반환합니다.
+      Long matchId = detachedMemberOpt.get().getMatch().getId();
+      return new DetachedMatchStatusResponse(true, matchId);
+    }else {
+      //복구 가능한 매칭 없으면 , false와 null 반환.
+      return new DetachedMatchStatusResponse(false, null);
+    }
   }
 
 

--- a/back/src/test/java/com/qmate/api/MatchControllerDetachedStatusTest.java
+++ b/back/src/test/java/com/qmate/api/MatchControllerDetachedStatusTest.java
@@ -1,0 +1,64 @@
+package com.qmate.api;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.qmate.AuthTestUtils;
+import com.qmate.SecuritySliceTestConfig;
+import com.qmate.domain.match.model.response.DetachedMatchStatusResponse;
+import com.qmate.domain.match.service.MatchService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = MatchController.class)
+@AutoConfigureMockMvc
+@Import(SecuritySliceTestConfig.class)
+class MatchControllerDetachedStatusTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockitoBean
+  private MatchService matchService;
+
+  @Test
+  @DisplayName("복구 가능 매칭 조회 성공: 매칭이 있을 때 true와 matchId를 응답한다")
+  void getDetachedMatchStatus_success_whenMatchExists() throws Exception {
+    // given: 서비스가 '매칭 있음' DTO를 반환하는 상황
+    Long requesterId = 1L;
+    var fakeResponse = new DetachedMatchStatusResponse(true, 123L);
+    given(matchService.getDetachedMatchStatus(anyLong())).willReturn(fakeResponse);
+
+    // expect: API를 호출하면, 200 OK 응답과 DTO 내용이 정확히 와야 함
+    mockMvc.perform(get("/api/matches/detached-status")
+            .with(AuthTestUtils.userPrincipal(requesterId)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.hasDetachedMatch").value(true))
+        .andExpect(jsonPath("$.matchId").value(123L));
+  }
+
+  @Test
+  @DisplayName("복구 가능 매칭 조회 성공: 매칭이 없을 때 false와 null을 응답한다")
+  void getDetachedMatchStatus_success_whenMatchDoesNotExist() throws Exception {
+    // given: 서비스가 '매칭 없음' DTO를 반환하는 상황
+    Long requesterId = 2L;
+    var fakeResponse = new DetachedMatchStatusResponse(false, null);
+    given(matchService.getDetachedMatchStatus(anyLong())).willReturn(fakeResponse);
+
+    // expect
+    mockMvc.perform(get("/api/matches/detached-status")
+            .with(AuthTestUtils.userPrincipal(requesterId)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.hasDetachedMatch").value(false))
+        .andExpect(jsonPath("$.matchId").isEmpty());
+  }
+}

--- a/back/src/test/java/com/qmate/domain/match/service/MatchServiceDetachedStatusTest.java
+++ b/back/src/test/java/com/qmate/domain/match/service/MatchServiceDetachedStatusTest.java
@@ -1,0 +1,65 @@
+package com.qmate.domain.match.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import com.qmate.domain.match.MatchStatus;
+import com.qmate.domain.match.model.response.DetachedMatchStatusResponse;
+import com.qmate.domain.match.Match;
+import com.qmate.domain.match.MatchMember;
+import com.qmate.domain.match.repository.MatchMemberRepository;
+import com.qmate.domain.user.User;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MatchServiceDetachedStatusTest {
+
+  @InjectMocks
+  private MatchService sut;
+
+  @Mock
+  private MatchMemberRepository matchMemberRepository;
+
+  @Test
+  @DisplayName("복구 가능 매칭 조회: 복구할 매칭이 있는 경우")
+  void getDetachedMatchStatus_whenMatchExists() {
+    // given: 1번 유저에게 복구 가능한 100번 매칭이 있는 상황
+    Long userId = 1L;
+    Long matchId = 100L;
+    User user = User.builder().id(userId).build();
+    Match match = Match.builder().id(matchId).build();
+    MatchMember detachedMember = MatchMember.create(user, match);
+
+    given(matchMemberRepository.findDetachedMatchForUser(userId, MatchStatus.DETACHED_PENDING_DELETE))
+        .willReturn(Optional.of(detachedMember));
+
+    // when: 서비스 메서드를 실행하면
+    DetachedMatchStatusResponse response = sut.getDetachedMatchStatus(userId);
+
+    // then: hasDetachedMatch는 true이고, matchId가 정확히 반환되어야 한다
+    assertThat(response.isHasDetachedMatch()).isTrue();
+    assertThat(response.getMatchId()).isEqualTo(matchId);
+  }
+
+  @Test
+  @DisplayName("복구 가능 매칭 조회: 복구할 매칭이 없는 경우")
+  void getDetachedMatchStatus_whenMatchDoesNotExist() {
+    // given: 2번 유저에게는 복구 가능한 매칭이 없는 상황
+    Long userId = 2L;
+    given(matchMemberRepository.findDetachedMatchForUser(userId, MatchStatus.DETACHED_PENDING_DELETE))
+        .willReturn(Optional.empty());
+
+    // when: 서비스 메서드를 실행하면
+    DetachedMatchStatusResponse response = sut.getDetachedMatchStatus(userId);
+
+    // then: hasDetachedMatch는 false이고, matchId는 null이어야 한다
+    assertThat(response.isHasDetachedMatch()).isFalse();
+    assertThat(response.getMatchId()).isNull();
+  }
+}


### PR DESCRIPTION
### 개요
'연결 끊기' 상태의 사용자가 앱에 다시 접속했을 때, 자신이 복구할 수 있는 매칭이 있는지 알 수 없는 UX 문제를 해결합니다.

로그인한 사용자가 **복구 가능한 매칭 정보(ID)를 조회**할 수 있는 **`GET /api/matches/detached-status`** API를 신규 구현했습니다. 프론트엔드는 이 API를 로그인 직후 호출하여, 결과에 따라 사용자에게 '복구하기' 버튼을 동적으로 노출할 수 있습니다.

### 변경 사항

#### API
- **`GET /api/matches/detached-status` (신규)**
    - 로그인한 사용자를 기준으로, `DETACHED_PENDING_DELETE` 상태인 매칭이 있는지 조회합니다.

#### 제약/상태코드
- **성공:** `200 OK`
- **실패:** `401 Unauthorized` (로그인하지 않은 경우)

#### DTO
- `DetachedMatchStatusResponse.java`: API의 응답을 위한 DTO를 추가했습니다. 복구 가능한 매칭 존재 여부(`hasDetachedMatch`)와 해당 `matchId`를 포함합니다.

#### Repository
- **`MatchMemberRepository`**
    - `findDetachedMatchForUser`: 특정 사용자의 '복구 대기' 상태인 매칭을 조회하는 커스텀 메서드를 추가했습니다.
    - **(개선)** 기존 JPA 메서드 이름 방식이 너무 길어지는 문제를 해결하기 위해, **QueryDSL**을 도입하여 해당 쿼리를 구현했습니다.

#### Service
- **`MatchService#getDetachedMatchStatus(userId)`**
    - QueryDSL로 구현된 Repository 메서드를 호출하여 비즈니스 로직을 수행하고, 결과를 `DetachedMatchStatusResponse` DTO로 변환하여 반환합니다.

#### Controller
- `MatchController`에 `GET /detached-status` 엔드포인트를 추가했습니다. `@AuthenticationPrincipal`을 사용하여 로그인한 사용자의 ID를 안전하게 가져와 서비스에 전달합니다.

### 테스트
- **[X] 서비스 단위 테스트**
    - `MatchServiceDetachedStatusTest.java`를 통해 '복구할 매칭이 있는 경우'와 '없는 경우' 두 가지 시나리오를 모두 검증했습니다.
- **[X] 컨트롤러 단위 테스트**
    - `MatchControllerDetachedStatusTest.java`를 통해 서비스의 각 결과에 따라 컨트롤러가 올바른 HTTP 상태 코드와 JSON 본문을 응답하는지 검증했습니다.
- **[X] API 테스트 (Postman)**
    - 실제 '연결 끊기' 상태의 데이터를 준비하고 API를 호출하여, 두 가지 시나리오 모두에서 정상 동작하는 것을 최종 확인했습니다.