### PR TITLE
feat: 일정 리스트 조회 API 구현(반복 전개 포함)

### DIFF
--- a/back/src/main/java/com/qmate/api/event/EventController.java
+++ b/back/src/main/java/com/qmate/api/event/EventController.java
@@ -1,6 +1,7 @@
 package com.qmate.api.event;
 
 import com.qmate.common.constants.event.EventConstants;
+import com.qmate.domain.event.entity.EventRepeatType;
 import com.qmate.domain.event.model.request.EventCreateRequest;
 import com.qmate.domain.event.model.request.EventUpdateRequest;
 import com.qmate.domain.event.model.response.EventResponse;
@@ -11,8 +12,17 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import java.net.URI;
+import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.format.annotation.DateTimeFormat.ISO;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -23,6 +33,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -129,5 +140,38 @@ public class EventController {
     Long userId = principal.userId();
     eventService.deleteEvent(matchId, userId, eventId);
     return ResponseEntity.noContent().build();
+  }
+
+  /**
+   * 일정 리스트 조회
+   */
+  @Operation(
+      summary = "일정 리스트 조회(반복 전개 포함)",
+      description = EventConstants.LIST_MD,
+      parameters = {
+          @Parameter(name = "matchId", description = "매치 ID"),
+          @Parameter(name = "from", description = "조회 시작 날짜(yyyy-MM-dd)", required = true),
+          @Parameter(name = "to", description = "조회 종료 날짜(yyyy-MM-dd)", required = true),
+          @Parameter(name = "repeatType", description = "반복 유형 필터"),
+          @Parameter(name = "anniversary", description = "기념일 여부 필터"),
+          @Parameter(name = "size", description = "페이지 크기 (최대 100)"),
+          @Parameter(name = "sort", description = "사용하지 않음")
+      }
+  )
+  @GetMapping("/matches/{matchId}/events")
+  public ResponseEntity<Page<EventResponse>> listEvents(
+      @PathVariable Long matchId,
+      @AuthenticationPrincipal UserPrincipal principal,
+      @RequestParam @DateTimeFormat(iso = ISO.DATE) LocalDate from,
+      @RequestParam @DateTimeFormat(iso = ISO.DATE) LocalDate to,
+      @RequestParam(required = false) EventRepeatType repeatType,
+      @RequestParam(required = false) Boolean anniversary,
+      @PageableDefault(page = 0, size = 20)
+      @ParameterObject Pageable pageable
+  ) {
+    // size 상한 100
+    int size = Math.min(pageable.getPageSize(), 100);
+    Pageable capped = PageRequest.of(pageable.getPageNumber(), size, pageable.getSort());
+    return ResponseEntity.ok(eventService.listEvents(matchId, principal.userId(), from, to, repeatType, anniversary, capped));
   }
 }

--- a/back/src/main/java/com/qmate/common/constants/event/EventConstants.java
+++ b/back/src/main/java/com/qmate/common/constants/event/EventConstants.java
@@ -1,6 +1,7 @@
 package com.qmate.common.constants.event;
 
 import com.qmate.common.constants.HttpStatusCode;
+import com.qmate.exception.CommonErrorCode;
 import com.qmate.exception.MatchErrorCode;
 import com.qmate.exception.errorcode.CustomQuestionErrorCode;
 import com.qmate.exception.errorcode.EventErrorCode;
@@ -12,6 +13,8 @@ public class EventConstants {
   // 상수
   public static final int EVENT_TITLE_MAX_LENGTH = 120;
   public static final int EVENT_DESCRIPTION_MAX_LENGTH = 1000;
+  // 이벤트 리스트 조회 기간 최대 범위
+  public static final int EVENT_LIST_MAX_RANGE_YEARS = 3;
 
   // validation message
   // 제목 공백 불가
@@ -62,4 +65,23 @@ public class EventConstants {
           + EventErrorCode.EVENT_NOT_FOUND_MESSAGE + " |\n"
           + "| " + HttpStatusCode.CONFLICT + " | " + EventErrorCode.EVENT_DELETION_NOT_ALLOWED_ERROR_CODE + " | "
           + EventErrorCode.EVENT_DELETION_NOT_ALLOWED_MESSAGE + " |\n";
+
+  public static final String LIST_MD =
+      "지정한 기간[from, to]에 대해 매치의 일정들을 조회합니다.\n\n"
+          + "#### 규칙\n"
+          + "- from, to **모두 포함**입니다. (예: from==발생일, to==발생일도 결과에 포함)\n"
+          + "- 페이징: `page`(0-based), `size`(기본 20, **최대 100**; 초과 시 100으로 캡).\n"
+          + "- 필터: `repeatType`(NONE|WEEKLY|MONTHLY|YEARLY), `anniversary`(true/false). 미지정 시 전체 대상.\n"
+          + "- 정렬: **발생일 오름차순**, 동일일자는 **eventId 오름차순**.\n"
+          + "- 권한: `user.currentMatchId == {matchId}` 인 경우에만 조회되며, 미충족 시 **빈 페이지**가 반환됩니다.\n"
+          + "- 날짜 형식: `YYYY-MM-DD`.\n\n"
+          + "#### 반복 전개\n"
+          + "- WEEKLY: seed 요일 기준 주 단위 전개.\n"
+          + "- MONTHLY: seed의 일(day) 기준 전개, 말일 초과 시 해당 월의 **말일로 보정**.\n"
+          + "- YEARLY: seed의 월/일 그대로 전개, **2/29는 평년에는 2/28로 보정**.\n\n"
+          + "### 에러 응답\n\n"
+          + "| HTTP | errorCode | message |\n"
+          + "|-----:|-----------|---------|\n"
+          + "| " + HttpStatusCode.BAD_REQUEST + " | " + EventErrorCode.EVENT_LIST_DATE_RANGE_EXCEEDED_ERROR_CODE + " | "
+          + EventErrorCode.EVENT_LIST_DATE_RANGE_EXCEEDED_MESSAGE + " |\n";
 }

--- a/back/src/main/java/com/qmate/domain/event/mapper/EventMapper.java
+++ b/back/src/main/java/com/qmate/domain/event/mapper/EventMapper.java
@@ -4,6 +4,7 @@ import com.qmate.domain.event.entity.Event;
 import com.qmate.domain.event.model.request.EventCreateRequest;
 import com.qmate.domain.event.model.response.EventResponse;
 import com.qmate.domain.match.Match;
+import java.time.LocalDate;
 import java.util.Objects;
 import lombok.NoArgsConstructor;
 
@@ -42,6 +43,20 @@ public class EventMapper {
         .eventAt(req.getEventAt())
         .repeatType(req.getRepeatType())
         .alarmOption(req.getAlarmOption())
+        .build();
+  }
+
+  public static EventResponse toResponse(Event e, LocalDate occurrenceDate) {
+    return EventResponse.builder()
+        .eventId(e.getId())
+        .title(e.getTitle())
+        .description(e.getDescription())
+        .eventAt(occurrenceDate)
+        .repeatType(e.getRepeatType())
+        .alarmOption(e.getAlarmOption())
+        .anniversary(e.isAnniversary())
+        .createdAt(e.getCreatedAt())
+        .updatedAt(e.getUpdatedAt())
         .build();
   }
 }

--- a/back/src/main/java/com/qmate/domain/event/repository/EventQueryRepository.java
+++ b/back/src/main/java/com/qmate/domain/event/repository/EventQueryRepository.java
@@ -1,0 +1,19 @@
+package com.qmate.domain.event.repository;
+
+import com.qmate.domain.event.entity.Event;
+import com.qmate.domain.event.entity.EventRepeatType;
+import jakarta.annotation.Nullable;
+import java.time.LocalDate;
+import java.util.List;
+
+public interface EventQueryRepository {
+
+  List<Event> findCandidates(
+      Long matchId,
+      Long userId,
+      LocalDate from,
+      LocalDate to,
+      @Nullable EventRepeatType repeatTypeFilter,
+      @Nullable Boolean anniversaryFilter
+  );
+}

--- a/back/src/main/java/com/qmate/domain/event/repository/EventQueryRepositoryImpl.java
+++ b/back/src/main/java/com/qmate/domain/event/repository/EventQueryRepositoryImpl.java
@@ -1,0 +1,81 @@
+package com.qmate.domain.event.repository;
+
+import com.qmate.domain.user.QUser;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.qmate.domain.event.entity.Event;
+import com.qmate.domain.event.entity.EventRepeatType;
+import com.qmate.domain.event.entity.QEvent;
+import com.qmate.domain.match.QMatchMember;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class EventQueryRepositoryImpl implements EventQueryRepository {
+
+  private final JPAQueryFactory qf;
+
+  @Override
+  public List<Event> findCandidates(
+      Long matchId,
+      Long userId,
+      LocalDate from,
+      LocalDate to,
+      EventRepeatType repeatTypeFilter,
+      Boolean anniversaryFilter
+  ) {
+    QEvent e = QEvent.event;
+    QMatchMember mm = QMatchMember.matchMember;
+    QUser u = QUser.user;
+
+    BooleanBuilder where = new BooleanBuilder();
+
+    where.and(e.match.id.eq(matchId));
+    // 권한 1) 사용자가 매치의 멤버
+    where.and(
+        JPAExpressions.selectOne()
+            .from(mm)
+            .where(
+                mm.match.id.eq(matchId),
+                mm.user.id.eq(userId)
+            )
+            .exists()
+    );
+
+    // 권한 2) 사용자의 currentMatchId == match.id
+    where.and(
+        JPAExpressions.selectOne()
+            .from(u)
+            .where(
+                u.id.eq(userId),
+                u.currentMatchId.eq(matchId)
+            )
+            .exists()
+    );
+
+    // 날짜 후보 조건
+    BooleanExpression noneHit = e.repeatType.eq(EventRepeatType.NONE)
+        .and(e.eventAt.between(from, to));
+    BooleanExpression repeatHit = e.repeatType.ne(EventRepeatType.NONE)
+        .and(e.eventAt.loe(to));
+    where.and(noneHit.or(repeatHit));
+
+    // 선택 필터
+    if (repeatTypeFilter != null) {
+      where.and(e.repeatType.eq(repeatTypeFilter));
+    }
+    if (anniversaryFilter != null) {
+      where.and(e.anniversary.eq(anniversaryFilter));
+    }
+
+    return qf.selectFrom(e)
+        .where(where)
+        .orderBy(e.id.asc())
+        .fetch();
+  }
+}

--- a/back/src/main/java/com/qmate/domain/event/repository/EventRepository.java
+++ b/back/src/main/java/com/qmate/domain/event/repository/EventRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface EventRepository extends JpaRepository<Event, Long> {
+public interface EventRepository extends JpaRepository<Event, Long>, EventQueryRepository {
 
   @Query("""
       select e

--- a/back/src/main/java/com/qmate/domain/event/service/EventService.java
+++ b/back/src/main/java/com/qmate/domain/event/service/EventService.java
@@ -1,6 +1,8 @@
 package com.qmate.domain.event.service;
 
+import com.qmate.common.constants.event.EventConstants;
 import com.qmate.domain.event.entity.Event;
+import com.qmate.domain.event.entity.EventRepeatType;
 import com.qmate.domain.event.mapper.EventMapper;
 import com.qmate.domain.event.model.request.EventCreateRequest;
 import com.qmate.domain.event.model.request.EventUpdateRequest;
@@ -9,10 +11,23 @@ import com.qmate.domain.event.repository.EventRepository;
 import com.qmate.domain.match.Match;
 import com.qmate.domain.match.repository.MatchRepository;
 import com.qmate.exception.custom.event.EventDeletionNotAllowedException;
+import com.qmate.exception.custom.event.EventListDateRangeExceededException;
 import com.qmate.exception.custom.event.EventNotFoundException;
 import com.qmate.exception.custom.event.EventRepeatModificationNotAllowedException;
 import com.qmate.exception.custom.matchinstance.MatchNotFoundException;
+import jakarta.annotation.Nullable;
+import java.time.LocalDate;
+import java.time.Year;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cglib.core.Local;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -79,6 +94,9 @@ public class EventService {
     return EventMapper.toResponse(eventRepository.saveAndFlush(event));
   }
 
+  /**
+   * 일정 삭제
+   */
   public void deleteEvent(Long matchId, Long userId, Long eventId) {
     Event event = eventRepository.findAuthorizedById(matchId, userId, eventId)
         .orElseThrow(EventNotFoundException::new);
@@ -88,5 +106,176 @@ public class EventService {
     }
 
     eventRepository.delete(event);
+  }
+
+  /**
+   * 일정 목록 조회 (반복 전개 포함)
+   */
+  @Transactional(readOnly = true)
+  public Page<EventResponse> listEvents(
+      Long matchId, Long userId,
+      LocalDate from, LocalDate to,
+      @Nullable EventRepeatType repeatTypeFilter,
+      @Nullable Boolean anniversaryFilter,
+      Pageable pageable
+  ) {
+    // 역전 가드
+    if (to.isBefore(from)) {
+      return Page.empty(pageable);
+    }
+
+    // 최대 N년 범위 제한
+    if (to.isAfter(from.plusYears(EventConstants.EVENT_LIST_MAX_RANGE_YEARS))) {
+      throw new EventListDateRangeExceededException();
+    }
+
+    // 후보 이벤트(권한 포함) 조회
+    List<Event> candidates = eventRepository.findCandidates(
+        matchId, userId, from, to, repeatTypeFilter, anniversaryFilter
+    );
+
+    // 반복 전개
+    List<Occurrence> occurrences = new ArrayList<>();
+    for (Event e : candidates) {
+      for (LocalDate d : expandOccurrences(e, from, to)) {
+        occurrences.add(new Occurrence(d, e));
+      }
+    }
+
+    // 정렬: 발생일 ASC, eventId ASC
+    occurrences.sort(
+        Comparator.comparing(Occurrence::date)
+            .thenComparing(o -> o.event().getId())
+    );
+
+    // 페이징
+    int total = occurrences.size();
+    int fromIdx = (int) pageable.getOffset();
+    int toIdx = Math.min(fromIdx + pageable.getPageSize(), total);
+
+    List<EventResponse> content = Collections.emptyList();
+    if (fromIdx < toIdx) {
+      content = occurrences.subList(fromIdx, toIdx).stream()
+          .map(o -> EventMapper.toResponse(o.event(), o.date()))
+          .toList();
+    }
+
+    return new PageImpl<>(content, pageable, total);
+  }
+
+  /* ===== 반복 전개 ===== */
+
+  private List<LocalDate> expandOccurrences(Event e, LocalDate from, LocalDate to) {
+    LocalDate seed = e.getEventAt();
+    return switch (e.getRepeatType()) {
+      case NONE -> (seed.isBefore(from) || seed.isAfter(to)) ? List.of() : List.of(seed);
+      case WEEKLY -> expandWeekly(seed, from, to);
+      case MONTHLY -> expandMonthly(seed, from, to);
+      case YEARLY -> expandYearly(seed, from, to);
+    };
+  }
+
+  private List<LocalDate> expandWeekly(LocalDate seed, LocalDate from, LocalDate to) {
+
+    // seed의 요일에 맞춘 첫 발생일 계산
+    int shift = (seed.getDayOfWeek().getValue() - from.getDayOfWeek().getValue() + 7) % 7;
+    LocalDate start = from.plusDays(shift);
+    // ex) seed 목(4), from: 10-06 월(1) -> shift 3 -> start 10-09 목
+    // ex) seed 월(1), from: 10-09 목(4) -> shift 4 -> start 10-13 월
+
+    // start가 seed 이전이면 seed로 조정
+    if (start.isBefore(seed)) {
+      start = seed;
+    }
+
+    if (start.isAfter(to)) {
+      return List.of();
+    }
+    List<LocalDate> out = new ArrayList<>();
+    // start부터 to까지 1주 단위로 증가시키며 추가
+    for (LocalDate d = start; !d.isAfter(to); d = d.plusWeeks(1)) {
+      out.add(d);
+    }
+    return out;
+  }
+
+  private List<LocalDate> expandMonthly(LocalDate seed, LocalDate from, LocalDate to) {
+
+    if (seed.isAfter(to)) {
+      return List.of();
+    }
+
+    List<LocalDate> out = new ArrayList<>();
+
+    // 둘 중 더 큰 달을 선택
+    YearMonth ym = YearMonth.from(from.isBefore(seed) ? seed : from);
+
+    // seed의 날짜가 ym의 말일을 초과하는 경우 ym의 말일로 조정
+    LocalDate first = clampDay(ym, seed.getDayOfMonth());
+
+    // ex) seed 8월 31일, from 9월 15일 -> ym 9월, first 9월 30일
+    // ex) seed 8월 31일, from 7월 30일 -> ym 8월, first 8월 31일
+    // ex) seed 25년 12월 31일, from 26년 1월 30일 -> 시작 26년 1월 31일
+
+    // first가 from 이전이면 다음 달부터 시작
+    if (first.isBefore(from)) {
+      ym = ym.plusMonths(1);
+      first = clampDay(ym, seed.getDayOfMonth());
+    }
+
+    // to 까지 월 단위로 증가시키며 추가
+    for (LocalDate d = first; !d.isAfter(to); ym = ym.plusMonths(1), d = clampDay(ym, seed.getDayOfMonth())) {
+      if (!d.isBefore(from)) {
+        out.add(d);
+      }
+    }
+    return out;
+  }
+
+  private List<LocalDate> expandYearly(LocalDate seed, LocalDate from, LocalDate to) {
+
+    if (seed.isAfter(to)) {
+      return List.of();
+    }
+
+    List<LocalDate> out = new ArrayList<>();
+
+    // 시작 연도 계산: from 기준으로 seed의 '월일'을 맞춘 첫 해
+    int year = Math.max(from.getYear(), seed.getYear());
+
+    LocalDate d = toYearlyDate(year, seed.getMonthValue(), seed.getDayOfMonth());
+
+    // from 이전이면 다음 해부터 시작
+    if (d.isBefore(from)) {
+      year++;
+      d = toYearlyDate(year, seed.getMonthValue(), seed.getDayOfMonth());
+    }
+
+    // to 까지 연 단위로 증가시키며 추가
+    while (!d.isAfter(to)) {
+      out.add(d);
+      year++;
+      d = toYearlyDate(year, seed.getMonthValue(), seed.getDayOfMonth());
+    }
+    return out;
+  }
+
+  // 기준 날짜가 해당 월의 말일을 초과하는 경우면 해당 월의 말일로 조정
+  // ex) 해당 월이 9월, 기준 날짜가 31일이면 9월 30일로 조정
+  private LocalDate clampDay(YearMonth ym, int dayOfMonth) {
+    int dom = Math.min(dayOfMonth, ym.lengthOfMonth());
+    return LocalDate.of(ym.getYear(), ym.getMonth(), dom);
+  }
+
+  // 윤년 고려: 2월 29일인 경우, 평년에는 2월 28일로 조정
+  private LocalDate toYearlyDate(int year, int month, int day) {
+    if (month == 2 && day == 29 && !Year.isLeap(year)) {
+      return LocalDate.of(year, 2, 28);
+    }
+    return LocalDate.of(year, month, day); // 그 외는 그대로
+  }
+
+  private record Occurrence(LocalDate date, Event event) {
+
   }
 }

--- a/back/src/main/java/com/qmate/exception/GlobalExceptionHandler.java
+++ b/back/src/main/java/com/qmate/exception/GlobalExceptionHandler.java
@@ -15,6 +15,7 @@ import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
@@ -56,6 +57,26 @@ public class GlobalExceptionHandler {
 
     );
 
+  }
+
+  @ExceptionHandler(MissingServletRequestParameterException.class)
+  public ResponseEntity<ErrorResponse> handleMissingParam(MissingServletRequestParameterException ex) {
+    log.warn("필수 파라미터 누락: {}", ex.getMessage());
+
+    ErrorCode errorCode = CommonErrorCode.invalidInput();
+    String field = ex.getParameterName();
+    String requiredType = ex.getParameterType();
+    List<ErrorResponse.FieldErrorDetail> errors = List.of(
+        new ErrorResponse.FieldErrorDetail(
+            field,
+            String.format("'%s' 파라미터가 필요합니다. (타입: %s)", field, requiredType)
+        )
+    );
+
+    return new ResponseEntity<>(
+        new ErrorResponse(errorCode.getCode(), errorCode.getMessage(), errors),
+        errorCode.getHttpStatus()
+    );
   }
 
   // 컨트롤러에서 타입 미스매치 예외를 처리하는 핸들러 (파라미터 전용)

--- a/back/src/main/java/com/qmate/exception/custom/event/EventListDateRangeExceededException.java
+++ b/back/src/main/java/com/qmate/exception/custom/event/EventListDateRangeExceededException.java
@@ -1,0 +1,12 @@
+package com.qmate.exception.custom.event;
+
+import com.qmate.exception.BusinessGlobalException;
+import com.qmate.exception.errorcode.EventErrorCode;
+
+public class EventListDateRangeExceededException extends BusinessGlobalException {
+
+  public EventListDateRangeExceededException() {
+    super(EventErrorCode.eventListDateRangeExceeded());
+  }
+
+}

--- a/back/src/main/java/com/qmate/exception/errorcode/EventErrorCode.java
+++ b/back/src/main/java/com/qmate/exception/errorcode/EventErrorCode.java
@@ -1,5 +1,6 @@
 package com.qmate.exception.errorcode;
 
+import com.qmate.common.constants.event.EventConstants;
 import com.qmate.exception.ErrorCode;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
@@ -11,11 +12,13 @@ public class EventErrorCode extends ErrorCode {
   public static final String EVENT_NOT_FOUND_MESSAGE = "일정을 찾을 수 없습니다.";
   public static final String EVENT_REPEAT_MODIFICATION_NOT_ALLOWED_MESSAGE = "기념일의 반복 설정은 변경할 수 없습니다.";
   public static final String EVENT_DELETION_NOT_ALLOWED_MESSAGE = "기념일은 삭제할 수 없습니다.";
+  public static final String EVENT_LIST_DATE_RANGE_EXCEEDED_MESSAGE = "조회 기간은 최대 " + EventConstants.EVENT_LIST_MAX_RANGE_YEARS + "년까지 가능합니다.";
 
   // error code
   public static final String EVENT_NOT_FOUND_ERROR_CODE = "EVENT_001";
   public static final String EVENT_REPEAT_MODIFICATION_NOT_ALLOWED_ERROR_CODE = "EVENT_002";
   public static final String EVENT_DELETION_NOT_ALLOWED_ERROR_CODE = "EVENT_003";
+  public static final String EVENT_LIST_DATE_RANGE_EXCEEDED_ERROR_CODE = "EVENT_004";
 
   // factory method
   public static ErrorCode eventNotFound() {
@@ -30,6 +33,11 @@ public class EventErrorCode extends ErrorCode {
   public static ErrorCode eventDeletionNotAllowed() {
     return new EventErrorCode(HttpStatus.CONFLICT, EVENT_DELETION_NOT_ALLOWED_ERROR_CODE,
         EVENT_DELETION_NOT_ALLOWED_MESSAGE);
+  }
+
+  public static ErrorCode eventListDateRangeExceeded() {
+    return new EventErrorCode(HttpStatus.BAD_REQUEST, EVENT_LIST_DATE_RANGE_EXCEEDED_ERROR_CODE,
+        EVENT_LIST_DATE_RANGE_EXCEEDED_MESSAGE);
   }
 
   protected EventErrorCode(HttpStatus httpStatus, String code, String message) {

--- a/back/src/test/java/com/qmate/api/event/EventControllerTest.java
+++ b/back/src/test/java/com/qmate/api/event/EventControllerTest.java
@@ -1,10 +1,14 @@
 package com.qmate.api.event;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.verify;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -25,16 +29,23 @@ import com.qmate.domain.event.model.request.EventUpdateRequest;
 import com.qmate.domain.event.model.response.EventResponse;
 import com.qmate.domain.event.service.EventService;
 import com.qmate.exception.custom.event.EventDeletionNotAllowedException;
+import com.qmate.exception.custom.event.EventListDateRangeExceededException;
 import com.qmate.exception.custom.event.EventNotFoundException;
 import com.qmate.exception.custom.event.EventRepeatModificationNotAllowedException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -240,5 +251,133 @@ class EventControllerTest {
         .andExpect(status().isConflict())
         .andExpect(jsonPath("$.errorCode").exists())
         .andExpect(jsonPath("$.message").exists());
+  }
+
+  private Page<EventResponse> samplePage() {
+    EventResponse r1 = EventResponse.builder()
+        .eventId(101L).title("t1").description("d1")
+        .eventAt(LocalDate.of(2025, 10, 10))
+        .repeatType(EventRepeatType.NONE)
+        .alarmOption(null)
+        .anniversary(false)
+        .createdAt(LocalDateTime.now()).updatedAt(LocalDateTime.now())
+        .build();
+    EventResponse r2 = EventResponse.builder()
+        .eventId(102L).title("t2").description("d2")
+        .eventAt(LocalDate.of(2025, 10, 17))
+        .repeatType(EventRepeatType.WEEKLY)
+        .alarmOption(null)
+        .anniversary(true)
+        .createdAt(LocalDateTime.now()).updatedAt(LocalDateTime.now())
+        .build();
+    return new PageImpl<>(List.of(r1, r2));
+  }
+
+  @Test
+  @DisplayName("일정 리스트 API - 기본 조회 200")
+  void listEvents_ok_200() throws Exception {
+    long matchId = 1L, userId = 99L;
+    LocalDate from = LocalDate.of(2025,10,1);
+    LocalDate to   = LocalDate.of(2025,10,31);
+
+    given(eventService.listEvents(eq(matchId), eq(userId), eq(from), eq(to),
+        isNull(), isNull(), any(Pageable.class)))
+        .willReturn(samplePage());
+
+    mockMvc.perform(get("/api/matches/{matchId}/events", matchId)
+            .param("from", "2025-10-01")
+            .param("to", "2025-10-31")
+            .with(AuthTestUtils.userPrincipal(userId))
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content", hasSize(2)))
+        .andExpect(jsonPath("$.content[0].eventId").value(101))
+        .andExpect(jsonPath("$.content[1].repeatType").value("WEEKLY"));
+  }
+
+  @Test
+  @DisplayName("일정 리스트 API - 필터 전달(repeatType, anniversary)")
+  void listEvents_filters_pass_200() throws Exception {
+    long matchId = 2L, userId = 42L;
+
+    given(eventService.listEvents(eq(matchId), eq(userId),
+        any(LocalDate.class), any(LocalDate.class),
+        eq(EventRepeatType.WEEKLY), eq(Boolean.TRUE), any(Pageable.class)))
+        .willReturn(samplePage());
+
+    mockMvc.perform(get("/api/matches/{matchId}/events", matchId)
+            .param("from", "2025-10-01")
+            .param("to", "2025-10-31")
+            .param("repeatType", "WEEKLY")
+            .param("anniversary", "true")
+            .with(AuthTestUtils.userPrincipal(userId)))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @DisplayName("일정 리스트 API - 필수 파라미터 누락 시 400")
+  void listEvents_missing_params_400() throws Exception {
+    long matchId = 3L, userId = 7L;
+
+    // to 누락
+    mockMvc.perform(get("/api/matches/{matchId}/events", matchId)
+            .param("from", "2025-10-01")
+            .with(AuthTestUtils.userPrincipal(userId)))
+        .andExpect(status().isBadRequest());
+
+    // from 누락
+    mockMvc.perform(get("/api/matches/{matchId}/events", matchId)
+            .param("to", "2025-10-31")
+            .with(AuthTestUtils.userPrincipal(userId)))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName("일정 리스트 API - 기간 3년 초과 시 400")
+  void listEvents_range_exceeded_400() throws Exception {
+    long matchId = 10L, userId = 10L;
+
+    given(eventService.listEvents(eq(matchId), eq(userId),
+        any(LocalDate.class), any(LocalDate.class),
+        any(), any(), any(Pageable.class)))
+        .willThrow(new EventListDateRangeExceededException());
+
+    mockMvc.perform(get("/api/matches/{matchId}/events", matchId)
+            .param("from", "2020-01-01")
+            .param("to", "2024-01-02") // 3년 초과
+            .with(AuthTestUtils.userPrincipal(userId)))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.errorCode").exists())
+        .andExpect(jsonPath("$.message").exists());
+  }
+
+  @Test
+  @DisplayName("컨트롤러: size=1000 요청 → 서비스에 전달되는 Pageable.size=100으로 캡")
+  void size_is_capped_to_100_in_controller() throws Exception {
+    long matchId = 5L, userId = 55L;
+
+    given(eventService.listEvents(eq(matchId), eq(userId),
+        any(LocalDate.class), any(LocalDate.class),
+        any(), any(), any(Pageable.class)))
+        .willReturn(samplePage());
+
+    ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+
+    mockMvc.perform(get("/api/matches/{matchId}/events", matchId)
+            .param("from", "2025-10-01")
+            .param("to", "2025-12-31")
+            .param("page", "2")
+            .param("size", "1000") // 과도한 요청
+            .with(AuthTestUtils.userPrincipal(userId)))
+        .andExpect(status().isOk());
+
+    // 서비스 호출 시 전달된 Pageable 캡처
+    verify(eventService).listEvents(eq(matchId), eq(userId),
+        any(LocalDate.class), any(LocalDate.class),
+        any(), any(), pageableCaptor.capture());
+
+    Pageable used = pageableCaptor.getValue();
+    assertThat(used.getPageSize()).isEqualTo(100);  // ← 캡핑 확인
+    assertThat(used.getPageNumber()).isEqualTo(2);  // page 값은 그대로 유지되는지 확인(옵션)
   }
 }

--- a/back/src/test/java/com/qmate/domain/event/EventServiceTest.java
+++ b/back/src/test/java/com/qmate/domain/event/EventServiceTest.java
@@ -2,6 +2,9 @@ package com.qmate.domain.event;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
@@ -17,11 +20,13 @@ import com.qmate.domain.event.service.EventService;
 import com.qmate.domain.match.Match;
 import com.qmate.domain.match.repository.MatchRepository;
 import com.qmate.exception.custom.event.EventDeletionNotAllowedException;
+import com.qmate.exception.custom.event.EventListDateRangeExceededException;
 import com.qmate.exception.custom.event.EventNotFoundException;
 import com.qmate.exception.custom.event.EventRepeatModificationNotAllowedException;
 import com.qmate.exception.custom.matchinstance.MatchNotFoundException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -29,6 +34,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 
 @ExtendWith(MockitoExtension.class)
 class EventServiceTest {
@@ -277,5 +284,238 @@ class EventServiceTest {
 
     then(eventRepository).should().findAuthorizedById(matchId, userId, eventId);
     then(eventRepository).should(never()).delete(any(Event.class));
+  }
+
+  @Test
+  @DisplayName("listEvents - WEEKLY 전개: from << seed, to 포함까지 전개")
+  void listEvents_weekly_expand_from_before_seed() {
+    // given
+    long matchId = 1L, userId = 99L;
+    LocalDate seed = LocalDate.of(2025, 10, 1); // 수요일
+    Event weekly = Event.builder()
+        .id(100L)
+        .match(Match.builder().id(matchId).build())
+        .title("weekly")
+        .eventAt(seed)
+        .repeatType(EventRepeatType.WEEKLY)
+        .anniversary(false)
+        .createdAt(LocalDateTime.now())
+        .updatedAt(LocalDateTime.now())
+        .build();
+
+    LocalDate from = LocalDate.of(2025, 7, 29); // 화
+    LocalDate to   = LocalDate.of(2025, 10, 15); // 수
+
+    given(eventRepository.findCandidates(eq(matchId), eq(userId), eq(from), eq(to), isNull(), isNull()))
+        .willReturn(List.of(weekly));
+
+    // when
+    Page<EventResponse> page = eventService.listEvents(
+        matchId, userId, from, to, null, null, PageRequest.of(0, 10)
+    );
+
+    // then: 10/01, 10/08, 10/15
+    assertThat(page.getContent()).extracting(EventResponse::getEventAt)
+        .containsExactly(
+            LocalDate.of(2025, 10, 1),
+            LocalDate.of(2025, 10, 8),
+            LocalDate.of(2025, 10, 15)
+        );
+  }
+
+  @Test
+  @DisplayName("listEvents - MONTHLY 전개: 8/31 → 9/30, 10/31, 11/30 (말일 클램프)")
+  void listEvents_monthly_end_of_month_clamp() {
+    // given
+    long matchId = 1L, userId = 99L;
+    Event monthly = Event.builder()
+        .id(101L)
+        .match(Match.builder().id(matchId).build())
+        .title("monthly-31")
+        .eventAt(LocalDate.of(2025, 8, 31))
+        .repeatType(EventRepeatType.MONTHLY)
+        .anniversary(false)
+        .createdAt(LocalDateTime.now())
+        .updatedAt(LocalDateTime.now())
+        .build();
+
+    LocalDate from = LocalDate.of(2025, 9, 15);
+    LocalDate to   = LocalDate.of(2025, 11, 30);
+
+    given(eventRepository.findCandidates(eq(matchId), eq(userId), eq(from), eq(to), isNull(), isNull()))
+        .willReturn(List.of(monthly));
+
+    // when
+    Page<EventResponse> page = eventService.listEvents(
+        matchId, userId, from, to, null, null, PageRequest.of(0, 10)
+    );
+
+    // then
+    assertThat(page.getContent()).extracting(EventResponse::getEventAt)
+        .containsExactly(
+            LocalDate.of(2025, 9, 30),
+            LocalDate.of(2025, 10, 31),
+            LocalDate.of(2025, 11, 30)
+        );
+  }
+
+  @Test
+  @DisplayName("listEvents - YEARLY 전개: 2/29는 평년 2/28로 보정")
+  void listEvents_yearly_feb29_to_feb28_in_common_years() {
+    // given
+    long matchId = 1L, userId = 99L;
+    Event yearly = Event.builder()
+        .id(102L)
+        .match(Match.builder().id(matchId).build())
+        .title("yearly-229")
+        .eventAt(LocalDate.of(2020, 2, 29))
+        .repeatType(EventRepeatType.YEARLY)
+        .anniversary(true)
+        .createdAt(LocalDateTime.now())
+        .updatedAt(LocalDateTime.now())
+        .build();
+
+    LocalDate from = LocalDate.of(2025, 1, 1);
+    LocalDate to   = LocalDate.of(2027, 12, 31);
+
+    given(eventRepository.findCandidates(eq(matchId), eq(userId), eq(from), eq(to), isNull(), isNull()))
+        .willReturn(List.of(yearly));
+
+    // when
+    Page<EventResponse> page = eventService.listEvents(
+        matchId, userId, from, to, null, null, PageRequest.of(0, 10)
+    );
+
+    // then: 2025/02/28, 2026/02/28, 2027/02/28
+    assertThat(page.getContent()).extracting(EventResponse::getEventAt)
+        .containsExactly(
+            LocalDate.of(2025, 2, 28),
+            LocalDate.of(2026, 2, 28),
+            LocalDate.of(2027, 2, 28)
+        );
+  }
+
+  @Test
+  @DisplayName("listEvents - NONE: from/to 경계 포함")
+  void listEvents_none_inclusive_bounds() {
+    // given
+    long matchId = 1L, userId = 99L;
+    LocalDate from = LocalDate.of(2025, 10, 10);
+    LocalDate to   = LocalDate.of(2025, 10, 31);
+
+    Event atFrom = Event.builder()
+        .id(201L).match(Match.builder().id(matchId).build())
+        .title("at-from").eventAt(from)
+        .repeatType(EventRepeatType.NONE).anniversary(false)
+        .createdAt(LocalDateTime.now()).updatedAt(LocalDateTime.now())
+        .build();
+
+    Event atTo = Event.builder()
+        .id(202L).match(Match.builder().id(matchId).build())
+        .title("at-to").eventAt(to)
+        .repeatType(EventRepeatType.NONE).anniversary(false)
+        .createdAt(LocalDateTime.now()).updatedAt(LocalDateTime.now())
+        .build();
+
+    given(eventRepository.findCandidates(eq(matchId), eq(userId), eq(from), eq(to), isNull(), isNull()))
+        .willReturn(List.of(atFrom, atTo));
+
+    // when
+    Page<EventResponse> page = eventService.listEvents(
+        matchId, userId, from, to, null, null, PageRequest.of(0, 10)
+    );
+
+    // then
+    assertThat(page.getContent()).extracting(EventResponse::getEventAt)
+        .containsExactlyInAnyOrder(from, to);
+  }
+
+  @Test
+  @DisplayName("listEvents - 정렬 타이브레이커: 동일 발생일이면 eventId 오름차순")
+  void listEvents_sort_tie_breaker_by_eventId() {
+    // given (동일 발생일 2025-10-10)
+    long matchId = 1L, userId = 99L;
+    LocalDate from = LocalDate.of(2025, 10, 1);
+    LocalDate to   = LocalDate.of(2025, 10, 31);
+
+    Event e1 = Event.builder()
+        .id(1L).match(Match.builder().id(matchId).build())
+        .title("A").eventAt(LocalDate.of(2025, 10, 10))
+        .repeatType(EventRepeatType.NONE).anniversary(false)
+        .createdAt(LocalDateTime.now()).updatedAt(LocalDateTime.now())
+        .build();
+
+    Event e2 = Event.builder()
+        .id(2L).match(Match.builder().id(matchId).build())
+        .title("B").eventAt(LocalDate.of(2025, 10, 10))
+        .repeatType(EventRepeatType.NONE).anniversary(false)
+        .createdAt(LocalDateTime.now()).updatedAt(LocalDateTime.now())
+        .build();
+
+    given(eventRepository.findCandidates(eq(matchId), eq(userId), eq(from), eq(to), isNull(), isNull()))
+        .willReturn(List.of(e2, e1)); // 섞어서 주입
+
+    // when
+    Page<EventResponse> page = eventService.listEvents(
+        matchId, userId, from, to, null, null, PageRequest.of(0, 10)
+    );
+
+    // then: eventId 1 → 2 순으로 정렬되어야 함
+    assertThat(page.getContent()).extracting(EventResponse::getEventId)
+        .containsExactly(1L, 2L);
+  }
+
+  @Test
+  @DisplayName("listEvents - 페이징: page=1,size=2 슬라이싱")
+  void listEvents_paging_slice() {
+    // given: 주 1회, to를 10/29까지(총 5회: 1,8,15,22,29)
+    long matchId = 1L, userId = 99L;
+    Event weekly = Event.builder()
+        .id(300L)
+        .match(Match.builder().id(matchId).build())
+        .title("weekly")
+        .eventAt(LocalDate.of(2025, 10, 1))
+        .repeatType(EventRepeatType.WEEKLY)
+        .anniversary(false)
+        .createdAt(LocalDateTime.now())
+        .updatedAt(LocalDateTime.now())
+        .build();
+
+    LocalDate from = LocalDate.of(2025, 7, 1);
+    LocalDate to   = LocalDate.of(2025, 10, 29);
+
+    given(eventRepository.findCandidates(eq(matchId), eq(userId), eq(from), eq(to), isNull(), isNull()))
+        .willReturn(List.of(weekly));
+
+    // when: page=1,size=2 → [10/15, 10/22] 기대
+    Page<EventResponse> page = eventService.listEvents(
+        matchId, userId, from, to, null, null, PageRequest.of(1, 2)
+    );
+
+    // then
+    assertThat(page.getTotalElements()).isEqualTo(5);
+    assertThat(page.getContent()).extracting(EventResponse::getEventAt)
+        .containsExactly(
+            LocalDate.of(2025, 10, 15),
+            LocalDate.of(2025, 10, 22)
+        );
+  }
+
+  @Test
+  @DisplayName("listEvents - 조회 기간 3년 초과 시 예외")
+  void listEvents_range_exceeded_throws() {
+    // given
+    long matchId = 1L, userId = 99L;
+    LocalDate from = LocalDate.of(2020, 1, 1);
+    LocalDate to   = LocalDate.of(2024, 1, 2); // from.plusYears(3) 초과
+
+    // when & then
+    assertThatThrownBy(() ->
+        eventService.listEvents(matchId, userId, from, to, null, null, PageRequest.of(0, 20))
+    ).isInstanceOf(EventListDateRangeExceededException.class);
+
+    // findCandidates 호출되지 않아야 함
+    then(eventRepository).should(never())
+        .findCandidates(anyLong(), anyLong(), any(LocalDate.class), any(LocalDate.class), any(), any());
   }
 }

--- a/back/src/test/java/com/qmate/domain/event/repository/EventQueryRepositoryTest.java
+++ b/back/src/test/java/com/qmate/domain/event/repository/EventQueryRepositoryTest.java
@@ -16,6 +16,7 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -26,6 +27,7 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles("test")
 @DataJpaTest
 @Import({JpaConfig.class, QuerydslConfig.class})
+@Tag("local")
 class EventQueryRepositoryTest {
 
   @Autowired

--- a/back/src/test/java/com/qmate/domain/event/repository/EventQueryRepositoryTest.java
+++ b/back/src/test/java/com/qmate/domain/event/repository/EventQueryRepositoryTest.java
@@ -1,0 +1,247 @@
+package com.qmate.domain.event.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.qmate.config.JpaConfig;
+import com.qmate.config.QuerydslConfig;
+import com.qmate.domain.event.entity.Event;
+import com.qmate.domain.event.entity.EventAlarmOption;
+import com.qmate.domain.event.entity.EventRepeatType;
+import com.qmate.domain.match.Match;
+import com.qmate.domain.match.MatchMember;
+import com.qmate.domain.user.User;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@DataJpaTest
+@Import({JpaConfig.class, QuerydslConfig.class})
+class EventQueryRepositoryTest {
+
+  @Autowired
+  private TestEntityManager tem;
+  @Autowired
+  private EventRepository eventRepository;
+
+  private Long matchId, otherMatchId, userId;
+  private Long eNoneBefore, eNoneInside, eNoneAfter;
+  private Long eWeeklyPastSeed, eWeeklySeedAfterTo;
+  private Long eMonthly31, eYearlyFeb29, otherMatchEvent;
+
+  @BeforeEach
+  void setUp() {
+    // ===== seed: Match + User(currentMatchId=matchId) + MatchMember =====
+    Match match = Match.builder()
+        .startDate(LocalDateTime.now())
+        .createdAt(LocalDateTime.now())
+        .updatedAt(LocalDateTime.now())
+        .build();
+    tem.persist(match);
+
+    Match other = Match.builder()
+        .startDate(LocalDateTime.now())
+        .createdAt(LocalDateTime.now())
+        .updatedAt(LocalDateTime.now())
+        .build();
+    tem.persist(other);
+
+    User user = User.builder()
+        .email("user99@test.com")
+        .nickname("nick")
+        .currentMatchId(match.getId())
+        .build();
+    tem.persist(user);
+
+    MatchMember mm = MatchMember.builder()
+        .match(match)
+        .user(user)
+        .build();
+    tem.persist(mm);
+
+    // ===== 동일 매치의 이벤트들 =====
+    eNoneBefore = persistEvent(match, "NONE_BEFORE",
+        LocalDate.of(2025, 9, 30), EventRepeatType.NONE, false);
+
+    eNoneInside = persistEvent(match, "NONE_INSIDE",
+        LocalDate.of(2025, 10, 10), EventRepeatType.NONE, false);
+
+    eNoneAfter = persistEvent(match, "NONE_AFTER",
+        LocalDate.of(2025, 11, 1), EventRepeatType.NONE, false);
+
+    eWeeklyPastSeed = persistEvent(match, "WEEKLY_PAST_SEED",
+        LocalDate.of(2025, 9, 1), EventRepeatType.WEEKLY, false);
+
+    eWeeklySeedAfterTo = persistEvent(match, "WEEKLY_AFTER_TO",
+        LocalDate.of(2025, 12, 1), EventRepeatType.WEEKLY, false);
+
+    eMonthly31 = persistEvent(match, "MONTHLY_31",
+        LocalDate.of(2025, 8, 31), EventRepeatType.MONTHLY, false);
+
+    eYearlyFeb29 = persistEvent(match, "YEARLY_FEB29",
+        LocalDate.of(2020, 2, 29), EventRepeatType.YEARLY, true);
+
+    // ===== 다른 매치의 이벤트 (스코프 제외 확인용) =====
+    otherMatchEvent = persistEvent(other, "OTHER_MATCH_EVENT",
+        LocalDate.of(2025, 10, 10), EventRepeatType.NONE, false);
+
+    tem.flush();
+    tem.clear();
+
+    matchId = match.getId();
+    otherMatchId = other.getId();
+    userId = user.getId();
+  }
+
+  /* ---------------------------
+     권한/스코프 규칙
+     --------------------------- */
+  @Nested
+  @DisplayName("권한/스코프")
+  class AuthScope {
+
+    @Test
+    @DisplayName("currentMatchId == matchId & 매치 멤버 → 후보 조회 OK")
+    void authorized_user_sees_candidates() {
+      List<Event> found = eventRepository.findCandidates(
+          matchId, userId,
+          LocalDate.of(2025,10,1), LocalDate.of(2025,10,31),
+          null, null
+      );
+      assertThat(found).extracting(Event::getId)
+          .contains(eNoneInside, eWeeklyPastSeed, eMonthly31, eYearlyFeb29)
+          .doesNotContain(otherMatchEvent); // 스코프 외
+    }
+
+    @Test
+    @DisplayName("currentMatchId 불일치면 0건")
+    void current_match_mismatch_returns_empty() {
+      User u = tem.find(User.class, userId);
+      u.setCurrentMatchId(otherMatchId);
+      tem.flush();
+      tem.clear();
+
+      List<Event> found = eventRepository.findCandidates(
+          matchId, userId,
+          LocalDate.of(2025,10,1), LocalDate.of(2025,10,31),
+          null, null
+      );
+      assertThat(found).isEmpty();
+    }
+
+    @Test
+    @DisplayName("다른 매치의 이벤트는 제외")
+    void other_match_events_excluded() {
+      List<Event> found = eventRepository.findCandidates(
+          matchId, userId,
+          LocalDate.of(2025,10,1), LocalDate.of(2025,10,31),
+          null, null
+      );
+      assertThat(found).extracting(Event::getId)
+          .doesNotContain(otherMatchEvent);
+    }
+  }
+
+  /* ---------------------------
+     날짜 후보 규칙 (레포 단계)
+     --------------------------- */
+  @Nested
+  @DisplayName("날짜 후보 규칙")
+  class DateCandidate {
+
+    @Test
+    @DisplayName("NONE: eventAt ∈ [from, to]만 후보 (양끝 포함)")
+    void none_between_inclusive() {
+      LocalDate from = LocalDate.of(2025, 10, 10);
+      LocalDate to   = LocalDate.of(2025, 10, 10);
+      List<Event> found = eventRepository.findCandidates(
+          matchId, userId, from, to, EventRepeatType.NONE, null
+      );
+      assertThat(found).extracting(Event::getId)
+          .contains(eNoneInside)
+          .doesNotContain(eNoneBefore, eNoneAfter);
+    }
+
+    @Test
+    @DisplayName("반복(W/M/Y): seed(eventAt) ≤ to 인 것만 후보")
+    void repeats_seed_must_be_le_to() {
+      LocalDate from = LocalDate.of(2025, 10, 1);
+      LocalDate to   = LocalDate.of(2025, 10, 31);
+
+      List<Event> weekly = eventRepository.findCandidates(
+          matchId, userId, from, to, EventRepeatType.WEEKLY, null
+      );
+      assertThat(weekly).extracting(Event::getId)
+          .contains(eWeeklyPastSeed)
+          .doesNotContain(eWeeklySeedAfterTo);
+
+      List<Event> monthly = eventRepository.findCandidates(
+          matchId, userId, from, to, EventRepeatType.MONTHLY, null
+      );
+      assertThat(monthly).extracting(Event::getId)
+          .contains(eMonthly31);
+
+      List<Event> yearly = eventRepository.findCandidates(
+          matchId, userId, from, to, EventRepeatType.YEARLY, null
+      );
+      assertThat(yearly).extracting(Event::getId)
+          .contains(eYearlyFeb29);
+    }
+  }
+
+  /* ---------------------------
+     필터
+     --------------------------- */
+  @Nested
+  @DisplayName("필터")
+  class Filters {
+
+    @Test
+    @DisplayName("repeatType 필터 적용")
+    void repeatType_filter() {
+      List<Event> weekly = eventRepository.findCandidates(
+          matchId, userId,
+          LocalDate.of(2025,10,1), LocalDate.of(2025,10,31),
+          EventRepeatType.WEEKLY, null
+      );
+      assertThat(weekly).allMatch(e -> e.getRepeatType() == EventRepeatType.WEEKLY);
+    }
+
+    @Test
+    @DisplayName("anniversary=true 필터 적용")
+    void anniversary_true_filter() {
+      List<Event> onlyAnniv = eventRepository.findCandidates(
+          matchId, userId,
+          LocalDate.of(2025,1,1), LocalDate.of(2025,12,31),
+          null, true
+      );
+      assertThat(onlyAnniv).allMatch(Event::isAnniversary);
+    }
+  }
+
+  private Long persistEvent(Match match, String title, LocalDate seedDate,
+      EventRepeatType type, boolean anniversary) {
+    Event e = Event.builder()
+        .match(match)
+        .title(title)
+        .description(title)
+        .eventAt(seedDate)
+        .repeatType(type)
+        .alarmOption(EventAlarmOption.WEEK_BEFORE)
+        .anniversary(anniversary)
+        .createdAt(LocalDateTime.now())
+        .updatedAt(LocalDateTime.now())
+        .build();
+    tem.persist(e);
+    return e.getId();
+  }
+}


### PR DESCRIPTION
# feat(event): 일정 리스트 조회 API 구현(반복 전개 포함)

## 개요
매치 스코프에서 기간 내 발생하는 일정들을 조회하는 API를 추가했습니다.  
반복 일정(WEEKLY/MONTHLY/YEARLY)은 지정한 기간 `[from, to]` 내 **발생 건으로 전개**해 반환합니다.

## 변경사항
- Controller: `GET /api/matches/{matchId}/events`
  - `from`, `to`(포함), `repeatType`, `anniversary`, `page/size` 지원
  - `size` 상한 **100** 캡핑
- Service: 반복 전개 + 정렬 + 페이징
  - WEEKLY: seed 요일 기준 주 단위 전개 (from 이전이면 첫 발생을 seed로 보정)
  - MONTHLY: seed 일(day) 기준, **말일 클램프**
  - YEARLY: seed 월/일 유지, **2/29 → 평년 2/28** 보정
  - 정렬: 발생일 ASC, 동일일자는 **eventId ASC**
- Repository(QueryDSL):
  - 후보 최소화 + 권한 포함 조회
    - `matchId` 스코프 강제
    - **user.currentMatchId == matchId** 조건
    - NONE: `eventAt between [from, to]`
    - 반복(W/M/Y): `eventAt <= to`
  - `repeatType`, `anniversary` 필터 옵션
- 정책 가드: 조회 기간 최대 **3년**(상수화) 초과 시 예외
- 예외 처리: 파라미터 누락/타입 미스매치 등 400 스키마 통일
- OpenAPI: summary/description/parameters 반영 (`EventConstants.LIST_MD`)

## 테스트
- **Repository 테스트**
  - 권한/스코프: currentMatchId 불일치/비멤버 → 0건
  - 날짜 후보 규칙: NONE `between [from,to]`, 반복 seed `<= to`
  - 필터: repeatType, anniversary 적용
- **Controller 테스트 (@WebMvcTest)**
  - 200 정상 플로우, 필터 전달, 필수 파라미터 누락 400
  - 기간 3년 초과 400, **size=1000 요청 → Pageable.size=100** 캡핑 검증
- **Service 테스트 (Mockito)**
  - WEEKLY: `from << seed` → 첫 발생 seed 보정, to까지 전개
  - MONTHLY: 8/31 → 9/30, 10/31, 11/30 (말일 클램프)
  - YEARLY: 2/29 → 평년 2/28
  - NONE 경계 포함, 정렬 tie-breaker(eventId ASC), 페이징 슬라이스
  - 3년 초과 예외 + repository 미호출 보장