### PR TITLE
docs: Swagger API 문서의 에러 응답 형식을 통일안에 맞춰 적용

### DIFF
--- a/back/src/main/java/com/qmate/api/MatchController.java
+++ b/back/src/main/java/com/qmate/api/MatchController.java
@@ -42,7 +42,7 @@ public class MatchController {
   @PostMapping
   @Operation(
       summary = "매칭 초대코드 발급",
-      description = "로그인한 매칭 요청자가 초대코드 발급합니다."
+      description = MatchConstants.CREATE_MATCH_MD
   )
   public ResponseEntity<MatchCreationResponse> createMatch(
       @RequestBody @Valid MatchCreationRequest request,
@@ -60,7 +60,7 @@ public class MatchController {
   @PostMapping("/join")
   @Operation(
       summary = "매칭 참여 초대코드 입력",
-      description = "로그인한 초대코드 전달받은 자가 초대코드 입력합니다. "
+      description = MatchConstants.JOIN_MATCH_MD
   )
   public ResponseEntity<MatchJoinResponse> joinMatch(
       @RequestBody @Valid MatchJoinRequest request,
@@ -82,7 +82,7 @@ public class MatchController {
   @GetMapping("{matchId}")
   @Operation(
       summary = "매칭 정보 조회",
-      description = "특정 매칭의 상세 정보(관계 유형, 구성원, 시작일 등)를 조회합니다."
+      description = MatchConstants.GET_MATCH_INFO_MD
   )
   public ResponseEntity<MatchInfoResponse> getMatchInfo(
       @PathVariable Long matchId,
@@ -97,7 +97,7 @@ public class MatchController {
   @GetMapping("/{matchId}/members")
   @Operation(
       summary = "특정 매칭의 구성원 목록 조회",
-      description = "매칭 구성원 목록을 조회하는 API. 두 사람의 닉네임, 생일, 요청자 본인 유무, 복구동의 유무 등 멤버 정보를 불러올 때 사용합니다."
+      description = MatchConstants.GET_MATCH_MEMBERS_MD
   )
   public ResponseEntity<MatchMembersResponse> getMatchMembers(
       @PathVariable Long matchId,
@@ -118,7 +118,7 @@ public class MatchController {
   @PatchMapping("/{matchId}/info")
   @Operation(
       summary = "특정 매칭의 정보를 업데이트 합니다.",
-      description = "특정 매칭 정보를 업데이트하는 API. 매칭이 성립된 후, 질문 받는 시간 등 설정을 변경할 때 사용합니다. "
+      description = MatchConstants.UPDATE_MATCH_INFO_MD
   )
   public ResponseEntity<Void> updateMatchInfo(
       @PathVariable Long matchId,
@@ -134,7 +134,7 @@ public class MatchController {
   @PostMapping("/{matchId}/disconnect")
   @Operation(
       summary = "매칭 연결을 끊습니다.",
-      description = "매칭을 종료하는 API. 사용자가 의도적으로 연결을 끊을 때 사용하며, 즉시 데이터가 삭제되는 것이 아니라 유예기간이 시작됩니다."
+      description = MatchConstants.DISCONNECT_MATCH_MD
   )
   public ResponseEntity<MatchActionResponse> disconnectMatch(
       @PathVariable Long matchId,
@@ -149,7 +149,7 @@ public class MatchController {
   @PostMapping("/{matchId}/restore")
   @Operation(
       summary = "매칭 연결 복구",
-      description = "2주 유예 기간 내에 매칭을 복구합니다."
+      description = MatchConstants.RESTORE_MATCH_MD
   )
   public ResponseEntity<MatchActionResponse> restoreMatch(
       @PathVariable Long matchId,
@@ -181,7 +181,7 @@ public class MatchController {
   @GetMapping("/detached-status")
   @Operation(
       summary = "복구 가능한 '연결 끊김' 상태의 매칭 조회",
-      description = "현재 로그인한 사용자가 복구 가능한 '연결 끊김' 상태의 매칭을 가지고 있는지 조회합니다."
+      description = MatchConstants.GET_DETACHED_STATUS_MD
   )
   public ResponseEntity<DetachedMatchStatusResponse> getDetachedMatchStatus(
       @AuthenticationPrincipal UserPrincipal principal

--- a/back/src/main/java/com/qmate/common/constants/match/MatchConstants.java
+++ b/back/src/main/java/com/qmate/common/constants/match/MatchConstants.java
@@ -1,5 +1,9 @@
 package com.qmate.common.constants.match;
 
+import com.qmate.common.constants.HttpStatusCode;
+import com.qmate.exception.CommonErrorCode;
+import com.qmate.exception.MatchErrorCode;
+
 public class MatchConstants {
 
   // MatchUpdateRequest
@@ -18,4 +22,62 @@ public class MatchConstants {
   public static final String DISCONNECT_SUCCESS_MESSAGE = "매칭 연결 끊기 요청이 처리되었습니다. 2주 후에 데이터가 삭제됩니다.";
   public static final String RESTORE_SUCCESS_MESSAGE = "매칭이 성공적으로 복구되었습니다.";
   public static final String RESTORE_AGREED_AWAITING_PARTNER_MESSAGE = "복구에 동의했습니다. 상대방의 동의를 기다려주세요.";
+  private static final String ERROR_RESPONSE_HEADER =
+
+      "\n\n### 에러 응답\n\n"
+          + "| HTTP | errorCode | message |\n"
+          + "|-----:|-----------|---------|\n";
+
+  // --- API Descriptions for Swagger ---
+
+  public static final String CREATE_MATCH_MD =
+      "사용자가 관계 유형(친구/연인)을 선택하여 새로운 매칭을 생성하고, 12시간 동안 유효한 초대 코드를 발급받습니다."
+          + ERROR_RESPONSE_HEADER
+          + "| " + HttpStatusCode.BAD_REQUEST + " | " + MatchErrorCode.INVALID_START_DATE_FOR_COUPLE_ERROR_CODE + " | " + MatchErrorCode.INVALID_START_DATE_FOR_COUPLE_MESSAGE + " |\n"
+          + "| " + HttpStatusCode.CONFLICT + " | " + MatchErrorCode.ALREADY_IN_MATCH_ERROR_CODE + " | " + MatchErrorCode.ALREADY_IN_MATCH_MESSAGE + " |\n";
+
+  public static final String JOIN_MATCH_MD =
+      "초대 코드를 사용하여 기존 매칭에 참여합니다. 매칭이 성사되면 `User`의 `current_match_id`가 업데이트되고, Redis의 초대 코드는 삭제됩니다."
+          + ERROR_RESPONSE_HEADER
+          + "| " + HttpStatusCode.BAD_REQUEST + " | " + MatchErrorCode.INVITE_CODE_EXPIRED_ERROR_CODE + " | " + MatchErrorCode.INVITE_CODE_EXPIRED_MESSAGE + " |\n"
+          + "| " + HttpStatusCode.FORBIDDEN + " | " + MatchErrorCode.INVITE_ATTEMPT_LOCKED_ERROR_CODE + " | " + MatchErrorCode.INVITE_ATTEMPT_LOCKED_MESSAGE + " |\n"
+          + "| " + HttpStatusCode.CONFLICT + " | " + MatchErrorCode.ALREADY_IN_MATCH_ERROR_CODE + " | " + MatchErrorCode.ALREADY_IN_MATCH_MESSAGE + " |\n";
+
+  public static final String GET_MATCH_INFO_MD =
+      "특정 매칭의 상세 정보(관계 유형, 시작일, 상태, 멤버 정보 등)를 조회합니다."
+          + ERROR_RESPONSE_HEADER
+          + "| " + HttpStatusCode.NOT_FOUND + " | " + MatchErrorCode.MATCH_NOT_FOUND_ERROR_CODE + " | " + MatchErrorCode.MATCH_NOT_FOUND_MESSAGE + " |\n"
+          + "| " + HttpStatusCode.FORBIDDEN + " | " + MatchErrorCode.MATCH_FORBIDDEN_ERROR_CODE + " | " + MatchErrorCode.MATCH_FORBIDDEN_MESSAGE + " |\n";
+
+  public static final String GET_MATCH_MEMBERS_MD =
+      "특정 매칭의 구성원 목록(상세 정보: 생년월일 포함)을 조회합니다."
+          + ERROR_RESPONSE_HEADER
+          + "| " + HttpStatusCode.NOT_FOUND + " | " + MatchErrorCode.MATCH_NOT_FOUND_ERROR_CODE + " | " + MatchErrorCode.MATCH_NOT_FOUND_MESSAGE + " |\n"
+          + "| " + HttpStatusCode.FORBIDDEN + " | " + MatchErrorCode.MATCH_FORBIDDEN_ERROR_CODE + " | " + MatchErrorCode.MATCH_FORBIDDEN_MESSAGE + " |\n";
+
+  public static final String UPDATE_MATCH_INFO_MD =
+      "매칭의 속성(기념일, 질문 받는 시간)을 선택적으로 수정합니다."
+          + ERROR_RESPONSE_HEADER
+          + "| " + HttpStatusCode.NOT_FOUND + " | " + MatchErrorCode.MATCH_NOT_FOUND_ERROR_CODE + " | " + MatchErrorCode.MATCH_NOT_FOUND_MESSAGE + " |\n"
+          + "| " + HttpStatusCode.FORBIDDEN + " | " + MatchErrorCode.MATCH_FORBIDDEN_ERROR_CODE + " | " + MatchErrorCode.MATCH_FORBIDDEN_MESSAGE + " |\n";
+
+  public static final String DISCONNECT_MATCH_MD =
+      "매칭 연결을 끊고, 2주간의 복구 유예 기간을 시작합니다."
+          + ERROR_RESPONSE_HEADER
+          + "| " + HttpStatusCode.NOT_FOUND + " | " + MatchErrorCode.MATCH_NOT_FOUND_ERROR_CODE + " | " + MatchErrorCode.MATCH_NOT_FOUND_MESSAGE + " |\n"
+          + "| " + HttpStatusCode.FORBIDDEN + " | " + MatchErrorCode.MATCH_FORBIDDEN_ERROR_CODE + " | " + MatchErrorCode.MATCH_FORBIDDEN_MESSAGE + " |\n"
+          + "| " + HttpStatusCode.CONFLICT + " | " + MatchErrorCode.MATCH_STATE_CONFLICT_ERROR_CODE + " | " + MatchErrorCode.MATCH_STATE_CONFLICT_MESSAGE + " |\n";
+
+  public static final String RESTORE_MATCH_MD =
+      "2주 유예 기간 내에 매칭을 복구합니다. 상호 동의가 필요합니다."
+          + ERROR_RESPONSE_HEADER
+          + "| " + HttpStatusCode.NOT_FOUND + " | " + MatchErrorCode.MATCH_NOT_FOUND_ERROR_CODE + " | " + MatchErrorCode.MATCH_NOT_FOUND_MESSAGE + " |\n"
+          + "| " + HttpStatusCode.FORBIDDEN + " | " + MatchErrorCode.MATCH_FORBIDDEN_ERROR_CODE + " | " + MatchErrorCode.MATCH_FORBIDDEN_MESSAGE + " |\n"
+          + "| " + HttpStatusCode.CONFLICT + " | " + MatchErrorCode.MATCH_STATE_CONFLICT_ERROR_CODE + " | " + MatchErrorCode.MATCH_STATE_CONFLICT_MESSAGE + " |\n"
+          + "| " + HttpStatusCode.CONFLICT + " | " + MatchErrorCode.MATCH_RECOVERY_EXPIRED_ERROR_CODE + " | " + MatchErrorCode.MATCH_RECOVERY_EXPIRED_MESSAGE + " |\n";
+
+  public static final String GET_DETACHED_STATUS_MD =
+      "로그인한 사용자가 복구 가능한 '연결 끊김' 상태의 매칭이 있는지 조회합니다."
+          + ERROR_RESPONSE_HEADER
+          + "| " + HttpStatusCode.UNAUTHORIZED + " | " + CommonErrorCode.UNAUTHORIZED_ERROR_CODE + " | " + CommonErrorCode.UNAUTHORIZED_MESSAGE + " |\n";
 }

--- a/back/src/main/java/com/qmate/exception/MatchErrorCode.java
+++ b/back/src/main/java/com/qmate/exception/MatchErrorCode.java
@@ -7,56 +7,68 @@ import org.springframework.http.HttpStatus;
 public class MatchErrorCode extends ErrorCode {
 
   //에러 메시지 상수화
-  private static final String ALREADY_IN_MATCH_MESSAGE = "이미 다른 매칭에 참여 중이거나, 해당 매칭에 참여할 수 없습니다.";
-  private static final String MATCH_NOT_FOUND_MESSAGE = "해당 매칭을 찾을 수 없습니다.";
-  private static final String PARTNER_NOT_FOUND_MESSAGE = "파트너 정보를 찾을 수 없습니다.";
-  private static final String INVITE_CODE_EXPIRED_MESSAGE = "초대 코드가 만료되었거나 유효하지 않습니다.";
-  private static final String INVALID_START_DATE_FOR_COUPLE_MESSAGE = "연인 관계는 기념일(YYYY-MM-DD)을 필수로 입력해야 합니다.";
-  private static final String INVITE_ATTEMPT_LOCKED_MESSAGE = "초대 코드 입력 5회 실패하여 24시간 동안 시도할 수 없습니다.";
-  private static final String CANNOT_MATCH_WITH_SELF_MESSAGE = "자기 자신과 매칭할 수 없습니다.";
-  private static final String MATCH_FORBIDDEN_MESSAGE = "해당 매칭에 대한 접근 권한이 없습니다.";
-  private static final String MATCH_STATE_CONFLICT_MESSAGE = "요청을 처리할 수 없는 매칭 상태입니다.";
-  private static final String MATCH_RECOVERY_EXPIRED_MESSAGE = "복구 가능 기간(2주)이 지나 매칭을 복구할 수 없습니다.";
+  public static final String ALREADY_IN_MATCH_MESSAGE = "이미 다른 매칭에 참여 중이거나, 해당 매칭에 참여할 수 없습니다.";
+  public static final String MATCH_NOT_FOUND_MESSAGE = "해당 매칭을 찾을 수 없습니다.";
+  public static final String PARTNER_NOT_FOUND_MESSAGE = "파트너 정보를 찾을 수 없습니다.";
+  public static final String INVITE_CODE_EXPIRED_MESSAGE = "초대 코드가 만료되었거나 유효하지 않습니다.";
+  public static final String INVALID_START_DATE_FOR_COUPLE_MESSAGE = "연인 관계는 기념일(YYYY-MM-DD)을 필수로 입력해야 합니다.";
+  public static final String INVITE_ATTEMPT_LOCKED_MESSAGE = "초대 코드 입력 5회 실패하여 24시간 동안 시도할 수 없습니다.";
+  public static final String CANNOT_MATCH_WITH_SELF_MESSAGE = "자기 자신과 매칭할 수 없습니다.";
+  public static final String MATCH_FORBIDDEN_MESSAGE = "해당 매칭에 대한 접근 권한이 없습니다.";
+  public static final String MATCH_STATE_CONFLICT_MESSAGE = "요청을 처리할 수 없는 매칭 상태입니다.";
+  public static final String MATCH_RECOVERY_EXPIRED_MESSAGE = "복구 가능 기간(2주)이 지나 매칭을 복구할 수 없습니다.";
 
+  //에러 코드 상수
+  public static final String ALREADY_IN_MATCH_ERROR_CODE = "MATCH_001";
+  public static final String MATCH_NOT_FOUND_ERROR_CODE = "MATCH_002";
+  public static final String PARTNER_NOT_FOUND_ERROR_CODE = "MATCH_003";
+  public static final String INVITE_CODE_EXPIRED_ERROR_CODE = "MATCH_004";
+  public static final String INVALID_START_DATE_FOR_COUPLE_ERROR_CODE = "MATCH_005";
+  public static final String CANNOT_MATCH_WITH_SELF_ERROR_CODE = "MATCH_006";
+  public static final String INVITE_ATTEMPT_LOCKED_ERROR_CODE = "MATCH_007";
+  public static final String MATCH_FORBIDDEN_ERROR_CODE = "MATCH_008";
+  public static final String MATCH_STATE_CONFLICT_ERROR_CODE = "MATCH_009";
+  public static final String MATCH_RECOVERY_EXPIRED_ERROR_CODE = "MATCH_010";
   // 에러 코드 객체 반환 메서드
   public static ErrorCode alreadyInMatch() {
-    return new MatchErrorCode(HttpStatus.CONFLICT, "MATCH_001", ALREADY_IN_MATCH_MESSAGE);
+    return new MatchErrorCode(HttpStatus.CONFLICT, ALREADY_IN_MATCH_ERROR_CODE, ALREADY_IN_MATCH_MESSAGE);
   }
 
   public static ErrorCode matchNotFound() {
-    return new MatchErrorCode(HttpStatus.NOT_FOUND, "MATCH_002", MATCH_NOT_FOUND_MESSAGE);
+    return new MatchErrorCode(HttpStatus.NOT_FOUND, MATCH_NOT_FOUND_ERROR_CODE, MATCH_NOT_FOUND_MESSAGE);
   }
 
   public static ErrorCode partnerNotFound() {
-    return new MatchErrorCode(HttpStatus.NOT_FOUND, "MATCH_003", PARTNER_NOT_FOUND_MESSAGE);
+    return new MatchErrorCode(HttpStatus.NOT_FOUND, PARTNER_NOT_FOUND_ERROR_CODE, PARTNER_NOT_FOUND_MESSAGE);
   }
 
   public static ErrorCode inviteCodeExpired() {
-    return new MatchErrorCode(HttpStatus.BAD_REQUEST, "MATCH_004", INVITE_CODE_EXPIRED_MESSAGE);
+    return new MatchErrorCode(HttpStatus.BAD_REQUEST, INVITE_CODE_EXPIRED_ERROR_CODE, INVITE_CODE_EXPIRED_MESSAGE);
   }
 
   public static ErrorCode invalidStartDateForCouple() {
-    return new MatchErrorCode(HttpStatus.BAD_REQUEST, "MATCH_005",
+    return new MatchErrorCode(HttpStatus.BAD_REQUEST, INVALID_START_DATE_FOR_COUPLE_ERROR_CODE,
         INVALID_START_DATE_FOR_COUPLE_MESSAGE);
-  }
-  public static ErrorCode inviteAttemptLocked(){
-    return new MatchErrorCode(HttpStatus.FORBIDDEN, "MATCH_007",INVITE_ATTEMPT_LOCKED_MESSAGE);
   }
 
   public static ErrorCode cannotMatchWithSelf() {
-    return new MatchErrorCode(HttpStatus.BAD_REQUEST, "MATCH_006", CANNOT_MATCH_WITH_SELF_MESSAGE);
+    return new MatchErrorCode(HttpStatus.BAD_REQUEST, CANNOT_MATCH_WITH_SELF_ERROR_CODE, CANNOT_MATCH_WITH_SELF_MESSAGE);
+  }
+  public static ErrorCode inviteAttemptLocked(){
+    return new MatchErrorCode(HttpStatus.FORBIDDEN, INVITE_ATTEMPT_LOCKED_ERROR_CODE,INVITE_ATTEMPT_LOCKED_MESSAGE);
   }
 
+
   public static ErrorCode matchForbidden(){
-    return new MatchErrorCode(HttpStatus.FORBIDDEN, "MATCH_008", MATCH_FORBIDDEN_MESSAGE);
+    return new MatchErrorCode(HttpStatus.FORBIDDEN, MATCH_FORBIDDEN_ERROR_CODE, MATCH_FORBIDDEN_MESSAGE);
   }
 
   public static ErrorCode matchStateConflict(){
-    return new MatchErrorCode(HttpStatus.CONFLICT, "MATCH_009",MATCH_STATE_CONFLICT_MESSAGE);
+    return new MatchErrorCode(HttpStatus.CONFLICT, MATCH_STATE_CONFLICT_ERROR_CODE,MATCH_STATE_CONFLICT_MESSAGE);
   }
 
   public static ErrorCode matchRecoveryExpired() {
-    return new MatchErrorCode(HttpStatus.CONFLICT, "MATCH_010", MATCH_RECOVERY_EXPIRED_MESSAGE);
+    return new MatchErrorCode(HttpStatus.CONFLICT, MATCH_RECOVERY_EXPIRED_ERROR_CODE, MATCH_RECOVERY_EXPIRED_MESSAGE);
   }
 
   private MatchErrorCode(HttpStatus httpStatus, String code, String message) {

--- a/back/src/test/java/com/qmate/api/match/InviteControllerValidateTest.java
+++ b/back/src/test/java/com/qmate/api/match/InviteControllerValidateTest.java
@@ -1,4 +1,4 @@
-package com.qmate.api;
+package com.qmate.api.match;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -10,6 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.qmate.AuthTestUtils;
 import com.qmate.SecuritySliceTestConfig;
+import com.qmate.api.InviteController;
 import com.qmate.domain.match.model.request.InviteCodeValidationRequest;
 import com.qmate.domain.match.model.response.InviteCodeValidationResponse;
 import com.qmate.domain.match.service.MatchService;

--- a/back/src/test/java/com/qmate/api/match/MatchControllerDetachedStatusTest.java
+++ b/back/src/test/java/com/qmate/api/match/MatchControllerDetachedStatusTest.java
@@ -1,4 +1,4 @@
-package com.qmate.api;
+package com.qmate.api.match;
 
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
@@ -8,6 +8,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.qmate.AuthTestUtils;
 import com.qmate.SecuritySliceTestConfig;
+import com.qmate.api.MatchController;
 import com.qmate.domain.match.model.response.DetachedMatchStatusResponse;
 import com.qmate.domain.match.service.MatchService;
 import org.junit.jupiter.api.DisplayName;

--- a/back/src/test/java/com/qmate/api/match/MatchControllerDisconnectTest.java
+++ b/back/src/test/java/com/qmate/api/match/MatchControllerDisconnectTest.java
@@ -1,4 +1,4 @@
-package com.qmate.api;
+package com.qmate.api.match;
 
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.willDoNothing;
@@ -9,6 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.qmate.AuthTestUtils; // ◀◀◀ 1. AuthTestUtils import
 import com.qmate.SecuritySliceTestConfig; // ◀◀◀ 2. SecuritySliceTestConfig import
+import com.qmate.api.MatchController;
 import com.qmate.domain.match.service.MatchService;
 import com.qmate.exception.custom.matchinstance.MatchForbiddenException;
 import com.qmate.exception.custom.matchinstance.MatchNotFoundException;

--- a/back/src/test/java/com/qmate/api/match/MatchControllerInvitedCodeLockUserTest.java
+++ b/back/src/test/java/com/qmate/api/match/MatchControllerInvitedCodeLockUserTest.java
@@ -1,4 +1,4 @@
-package com.qmate.api;
+package com.qmate.api.match;
 
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
@@ -8,6 +8,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.qmate.AuthTestUtils;
 import com.qmate.SecuritySliceTestConfig;
+import com.qmate.api.MatchController;
 import com.qmate.domain.match.model.response.LockStatusResponse;
 import com.qmate.domain.match.service.MatchService;
 import org.junit.jupiter.api.DisplayName;

--- a/back/src/test/java/com/qmate/api/match/MatchControllerRestoreTest.java
+++ b/back/src/test/java/com/qmate/api/match/MatchControllerRestoreTest.java
@@ -1,8 +1,7 @@
-package com.qmate.api;
+package com.qmate.api.match;
 
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.BDDMockito.willThrow;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -10,12 +9,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.qmate.AuthTestUtils;
 import com.qmate.SecuritySliceTestConfig;
+import com.qmate.api.MatchController;
 import com.qmate.common.constants.match.MatchConstants;
 import com.qmate.domain.match.service.MatchService;
-import com.qmate.exception.custom.matchinstance.MatchForbiddenException;
-import com.qmate.exception.custom.matchinstance.MatchNotFoundException;
 import com.qmate.exception.custom.matchinstance.MatchRecoveryExpiredException;
-import com.qmate.exception.custom.matchinstance.MatchStateConflictException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/back/src/test/java/com/qmate/api/match/MatchControllerTest.java
+++ b/back/src/test/java/com/qmate/api/match/MatchControllerTest.java
@@ -1,4 +1,4 @@
-package com.qmate.api;
+package com.qmate.api.match;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -14,6 +14,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.qmate.AuthTestUtils;
 import com.qmate.SecuritySliceTestConfig;
+import com.qmate.api.MatchController;
 import com.qmate.domain.match.Match;
 import com.qmate.domain.match.RelationType;
 import com.qmate.domain.match.model.request.MatchJoinRequest;

--- a/back/src/test/java/com/qmate/api/match/MatchControllerUpdateTest.java
+++ b/back/src/test/java/com/qmate/api/match/MatchControllerUpdateTest.java
@@ -1,4 +1,4 @@
-package com.qmate.api;
+package com.qmate.api.match;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -8,8 +8,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.qmate.config.SecurityConfig;
-import com.qmate.domain.auth.JwtService;
+import com.qmate.api.MatchController;
 import com.qmate.domain.match.model.request.MatchUpdateRequest;
 import com.qmate.domain.match.service.MatchService;
 import com.qmate.exception.custom.matchinstance.MatchForbiddenException;
@@ -19,7 +18,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;


### PR DESCRIPTION
### 개요
팀의 API 문서 표준을 준수하기 위해, 기존에 구현된 모든 API의 **Swagger/OpenAPI 문서를 통일된 형식으로 리팩토링**했습니다.

이를 통해 API 명세서의 가독성을 높이고, 특히 에러 응답 형식을 마크다운 테이블로 명확하게 표현하여 프론트엔드 개발자와의 협업 효율성을 개선하고자 합니다.

### 변경 사항

#### 1. API 문서(OpenAPI / Swagger)
- **`@Operation` 어노테이션 보강:**
    - `MatchController`, `InviteController` 등 컨트롤러의 각 엔드포인트에 `@Operation` 어노테이션을 추가하거나 수정했습니다.
    - `summary`에는 API의 핵심 기능을, `description`에는 상세 설명과 함께 **표 형식의 에러 응답 목록**을 명시하여 가독성을 높였습니다.
- **`@Tag` 어노테이션 추가:**
    - 각 컨트롤러 클래스 상단에 `@Tag`를 추가하여, Swagger UI에서 API들이 도메인별로 그룹화되어 보이도록 개선했습니다.

#### 2. Constants (상수 관리)
- **`MatchConstants.java` 생성:**
    - 각 API의 `description`에 들어갈 마크다운 형식의 긴 문자열들을 `public static final String` 상수로 분리했습니다.
    - 이를 통해 컨트롤러 코드는 순수한 로직에만 집중하고, 문서 내용은 `Constants` 클래스에서 중앙 관리할 수 있도록 구조를 개선했습니다.

#### 3. ErrorCode 수정
- `MatchConstants`에서 에러 코드와 메시지를 쉽게 참조할 수 있도록, `MatchErrorCode`와 `CommonErrorCode`에 각 에러의 코드(`MATCH_001`)와 메시지(`"..."`)를 `public static final String` 상수로 노출하도록 수정했습니다.

### 테스트
- [X] 애플리케이션을 재실행하여, Swagger UI (`/swagger-ui.html`) 페이지가 오류 없이 정상적으로 렌더링되고, 모든 API 설명이 의도한 대로 표 형식으로 잘 보이는지 확인했습니다.
- [ ] (문서 관련 리팩토링이므로, 별도의 기능 테스트 코드는 추가되지 않았습니다.)