### PR TITLE
feat: Notifications – 푸시 구독 업서트/해지 + VAPID 공개키 API 및 테스트 추가

### DIFF
--- a/back/src/main/java/com/qmate/api/notification/NotificationSettingController.java
+++ b/back/src/main/java/com/qmate/api/notification/NotificationSettingController.java
@@ -19,11 +19,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/push-settings")
+@RequestMapping("/api/notifications/settings")
 @RequiredArgsConstructor
 @SecurityRequirement(name = "bearerAuth")
-@Tag(name = "Push Setting", description = "알림 설정 관련 API")
-public class PushSettingController {
+@Tag(name = "Notification Setting", description = "알림 설정 관련 API")
+public class NotificationSettingController {
 
   private final PushSettingService pushSettingService;
 

--- a/back/src/main/java/com/qmate/api/notification/NotificationSubscriptionController.java
+++ b/back/src/main/java/com/qmate/api/notification/NotificationSubscriptionController.java
@@ -1,0 +1,86 @@
+package com.qmate.api.notification;
+
+import com.qmate.domain.notification.model.request.PushSubscriptionRegisterRequest;
+import com.qmate.domain.notification.model.response.PushSubscriptionRegisterResponse;
+import com.qmate.domain.notification.service.PushSubscriptionService;
+import com.qmate.security.UserPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/notifications/subscriptions")
+@RequiredArgsConstructor
+@SecurityRequirement(name = "bearerAuth")
+@Tag(name = "Notification Subscription", description = "푸시 알림 구독 관련 API")
+public class NotificationSubscriptionController {
+
+  private final PushSubscriptionService pushSubscriptionService;
+
+  @Operation(
+      summary = "푸시 알림 구독/갱신",
+      description = """
+        브라우저의 PushSubscription 객체를 **그대로 본문에 담아** 보내면 서버가 `endpoint`와 `keys.p256dh/auth`를 추출해
+        구독을 생성하거나 갱신합니다. 클라이언트에서 별도 가공이나 해시 계산은 필요 없습니다.
+
+        - 호출 시점: 로그인 직후 또는 알림 설정을 켤 때
+        - 동작: 기존 구독이 있으면 소유권을 현재 사용자로 이전하고 키를 최신화, 없으면 새로 생성
+        """
+  )
+  @PostMapping
+  public ResponseEntity<PushSubscriptionRegisterResponse> upsert(
+      @AuthenticationPrincipal UserPrincipal me,
+      @Valid @RequestBody PushSubscriptionRegisterRequest req) {
+
+    PushSubscriptionRegisterResponse resp = pushSubscriptionService.upsert(me.userId(), req);
+    return ResponseEntity.ok(resp);
+  }
+
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  @Operation(
+      summary = "푸시 알림 구독 해지 (엔드포인트 기준)",
+      description = """
+        브라우저에서 `getSubscription()`으로 얻은 **`subscription.endpoint` 값을 그대로** `endpoint` 쿼리로 보내면,
+        서버가 해시를 계산해 현재 사용자 소유의 구독만 안전하게 삭제합니다.
+        별도의 `subscriptionId` 보관은 필요 없습니다.
+
+        - 호출 시점: 로그아웃 직전/직후 훅에서 호출 권장
+        """
+  )
+  @DeleteMapping("/by-endpoint")
+  public ResponseEntity<Void> unsubscribeByEndpoint(
+      @AuthenticationPrincipal UserPrincipal me,
+      @RequestParam("endpoint") String endpoint) {
+
+    pushSubscriptionService.unsubscribe(me.userId(), endpoint);
+    return ResponseEntity.noContent().build();
+  }
+
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  @Operation(
+      summary = "푸시 알림 구독 해지 (구독 ID 기준)",
+      description = """
+        이미 발급받은 `subscriptionId`를 보관하고 있다면 경로 변수로 전달해 삭제할 수 있습니다.
+        """
+  )
+  @DeleteMapping("/{subscriptionId}")
+  public ResponseEntity<Void> unsubscribeById(
+      @AuthenticationPrincipal UserPrincipal me,
+      @PathVariable Long subscriptionId) {
+    pushSubscriptionService.unsubscribe(me.userId(), subscriptionId);
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/back/src/main/java/com/qmate/api/notification/NotificationSubscriptionController.java
+++ b/back/src/main/java/com/qmate/api/notification/NotificationSubscriptionController.java
@@ -2,6 +2,7 @@ package com.qmate.api.notification;
 
 import com.qmate.domain.notification.model.request.PushSubscriptionRegisterRequest;
 import com.qmate.domain.notification.model.response.PushSubscriptionRegisterResponse;
+import com.qmate.domain.notification.model.response.VapidPublicKeyResponse;
 import com.qmate.domain.notification.service.PushSubscriptionService;
 import com.qmate.security.UserPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
@@ -9,10 +10,12 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -30,15 +33,18 @@ public class NotificationSubscriptionController {
 
   private final PushSubscriptionService pushSubscriptionService;
 
+  @Value("${webpush.vapid.public-key}")
+  private String vapidPublicKey;
+
   @Operation(
       summary = "푸시 알림 구독/갱신",
       description = """
-        브라우저의 PushSubscription 객체를 **그대로 본문에 담아** 보내면 서버가 `endpoint`와 `keys.p256dh/auth`를 추출해
-        구독을 생성하거나 갱신합니다. 클라이언트에서 별도 가공이나 해시 계산은 필요 없습니다.
-
-        - 호출 시점: 로그인 직후 또는 알림 설정을 켤 때
-        - 동작: 기존 구독이 있으면 소유권을 현재 사용자로 이전하고 키를 최신화, 없으면 새로 생성
-        """
+          브라우저의 PushSubscription 객체를 **그대로 본문에 담아** 보내면 서버가 `endpoint`와 `keys.p256dh/auth`를 추출해
+          구독을 생성하거나 갱신합니다. 클라이언트에서 별도 가공이나 해시 계산은 필요 없습니다.
+          
+          - 호출 시점: 로그인 직후 또는 알림 설정을 켤 때
+          - 동작: 기존 구독이 있으면 소유권을 현재 사용자로 이전하고 키를 최신화, 없으면 새로 생성
+          """
   )
   @PostMapping
   public ResponseEntity<PushSubscriptionRegisterResponse> upsert(
@@ -53,12 +59,12 @@ public class NotificationSubscriptionController {
   @Operation(
       summary = "푸시 알림 구독 해지 (엔드포인트 기준)",
       description = """
-        브라우저에서 `getSubscription()`으로 얻은 **`subscription.endpoint` 값을 그대로** `endpoint` 쿼리로 보내면,
-        서버가 해시를 계산해 현재 사용자 소유의 구독만 안전하게 삭제합니다.
-        별도의 `subscriptionId` 보관은 필요 없습니다.
-
-        - 호출 시점: 로그아웃 직전/직후 훅에서 호출 권장
-        """
+          브라우저에서 `getSubscription()`으로 얻은 **`subscription.endpoint` 값을 그대로** `endpoint` 쿼리로 보내면,
+          서버가 해시를 계산해 현재 사용자 소유의 구독만 안전하게 삭제합니다.
+          별도의 `subscriptionId` 보관은 필요 없습니다.
+          
+          - 호출 시점: 로그아웃 직전/직후 훅에서 호출 권장
+          """
   )
   @DeleteMapping("/by-endpoint")
   public ResponseEntity<Void> unsubscribeByEndpoint(
@@ -73,8 +79,8 @@ public class NotificationSubscriptionController {
   @Operation(
       summary = "푸시 알림 구독 해지 (구독 ID 기준)",
       description = """
-        이미 발급받은 `subscriptionId`를 보관하고 있다면 경로 변수로 전달해 삭제할 수 있습니다.
-        """
+          이미 발급받은 `subscriptionId`를 보관하고 있다면 경로 변수로 전달해 삭제할 수 있습니다.
+          """
   )
   @DeleteMapping("/{subscriptionId}")
   public ResponseEntity<Void> unsubscribeById(
@@ -82,5 +88,14 @@ public class NotificationSubscriptionController {
       @PathVariable Long subscriptionId) {
     pushSubscriptionService.unsubscribe(me.userId(), subscriptionId);
     return ResponseEntity.noContent().build();
+  }
+
+  @Operation(summary = "VAPID 공개키 조회",
+      description = "브라우저 Push API 구독에 사용할 VAPID 공개키를 반환합니다. 클라이언트에서 그대로 쓰면 됩니다.")
+  @GetMapping("/vapid-public-key")
+  public ResponseEntity<VapidPublicKeyResponse> getVapidPublicKey() {
+    return ResponseEntity.ok(VapidPublicKeyResponse.builder()
+        .vapidPublicKey(vapidPublicKey)
+        .build());
   }
 }

--- a/back/src/main/java/com/qmate/domain/notification/entity/PushSubscription.java
+++ b/back/src/main/java/com/qmate/domain/notification/entity/PushSubscription.java
@@ -1,0 +1,89 @@
+package com.qmate.domain.notification.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.LocalDateTime;
+import java.util.Objects;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Table(name = "push_subscription")
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@Setter
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class PushSubscription {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "push_subscription_id", nullable = false)
+  private Long id;
+
+  @Column(name = "user_id", nullable = false)
+  private Long userId;
+
+  @Column(name = "endpoint", nullable = false)
+  private String endpoint;
+
+  @Column(name = "endpoint_hash", nullable = false)
+  private byte[] endpointHash;
+
+  @Column(name = "key_p256dh", nullable = false)
+  private String keyP256dh;
+
+  @Column(name = "key_auth", nullable = false)
+  private String keyAuth;
+
+  @CreatedDate
+  @Column(name = "created_at", nullable = false)
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate
+  @Column(name = "updated_at", nullable = false)
+  private LocalDateTime updatedAt;
+
+  /**
+   * 한 endpoint = 한 user 정책 하에서,
+   * - 동일 endpoint의 소유권을 현재 사용자로 이전하거나(계정 전환)
+   * - 키(p256dh/auth)를 최신화한다.
+   */
+  public void claimOrRefresh(Long newUserId, String newEndpoint, String newP256dh, String newAuth) {
+    // endpoint가 바뀌면 해시 재계산
+    if (!Objects.equals(this.endpoint, newEndpoint)) {
+      this.endpoint = newEndpoint;
+      this.endpointHash = sha256(newEndpoint);
+    }
+    // 소유권 이전 허용 (한 endpoint = 한 user 정책 하에서 전환)
+    this.userId = newUserId;
+
+    // 키는 매번 최신화
+    this.keyP256dh = newP256dh;
+    this.keyAuth = newAuth;
+  }
+
+  public static byte[] sha256(String value) {
+    try {
+      MessageDigest md = MessageDigest.getInstance("SHA-256");
+      return md.digest(value.getBytes(StandardCharsets.UTF_8));
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException("SHA-256 not supported", e);
+    }
+  }
+}

--- a/back/src/main/java/com/qmate/domain/notification/model/request/PushSubscriptionRegisterRequest.java
+++ b/back/src/main/java/com/qmate/domain/notification/model/request/PushSubscriptionRegisterRequest.java
@@ -1,0 +1,48 @@
+package com.qmate.domain.notification.model.request;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PushSubscriptionRegisterRequest {
+
+  @NotBlank
+  private String endpoint;
+
+  @Valid
+  @JsonProperty("keys")
+  private Keys keys;
+
+  @Getter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Builder
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public static class Keys {
+
+    @NotBlank
+    private String p256dh;
+
+    @NotBlank
+    private String auth;
+  }
+
+  // 편의 접근자: 서비스에서 바로 쓰기 좋게
+  public String getKeyP256dh() {
+    return keys != null ? keys.p256dh : null;
+  }
+
+  public String getKeyAuth() {
+    return keys != null ? keys.auth : null;
+  }
+}

--- a/back/src/main/java/com/qmate/domain/notification/model/response/PushSubscriptionRegisterResponse.java
+++ b/back/src/main/java/com/qmate/domain/notification/model/response/PushSubscriptionRegisterResponse.java
@@ -1,0 +1,26 @@
+package com.qmate.domain.notification.model.response;
+
+import com.qmate.domain.notification.entity.PushSubscription;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PushSubscriptionRegisterResponse {
+  private Long subscriptionId;
+  private LocalDateTime createdAt;
+  private LocalDateTime updatedAt;
+
+  public static PushSubscriptionRegisterResponse from(PushSubscription entity) {
+    return new PushSubscriptionRegisterResponse(
+        entity.getId(),
+        entity.getCreatedAt(),
+        entity.getUpdatedAt()
+    );
+  }
+}

--- a/back/src/main/java/com/qmate/domain/notification/model/response/VapidPublicKeyResponse.java
+++ b/back/src/main/java/com/qmate/domain/notification/model/response/VapidPublicKeyResponse.java
@@ -1,0 +1,14 @@
+package com.qmate.domain.notification.model.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class VapidPublicKeyResponse {
+  private String vapidPublicKey;
+}

--- a/back/src/main/java/com/qmate/domain/notification/repository/PushSubscriptionRepository.java
+++ b/back/src/main/java/com/qmate/domain/notification/repository/PushSubscriptionRepository.java
@@ -1,0 +1,9 @@
+package com.qmate.domain.notification.repository;
+
+import com.qmate.domain.notification.entity.PushSubscription;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PushSubscriptionRepository extends JpaRepository<PushSubscription, Long> {
+  Optional<PushSubscription> findByEndpointHash(byte[] endpointHash);
+}

--- a/back/src/main/java/com/qmate/domain/notification/service/PushSubscriptionService.java
+++ b/back/src/main/java/com/qmate/domain/notification/service/PushSubscriptionService.java
@@ -1,0 +1,70 @@
+package com.qmate.domain.notification.service;
+
+import com.qmate.domain.notification.entity.PushSubscription;
+import com.qmate.domain.notification.model.request.PushSubscriptionRegisterRequest;
+import com.qmate.domain.notification.model.response.PushSubscriptionRegisterResponse;
+import com.qmate.domain.notification.repository.PushSubscriptionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PushSubscriptionService {
+
+  private final PushSubscriptionRepository pushSubscriptionRepository;
+
+  /**
+   * 구독 업서트(로그인/알림설정 ON 시 호출):
+   * - endpoint 해시 기준으로 기존 레코드 조회
+   * - 있으면 소유권 이전(+키 최신화), 없으면 신규 생성
+   * - 저장 후 subscriptionId/createdAt/updatedAt 반환
+   */
+  public PushSubscriptionRegisterResponse upsert(Long userId, PushSubscriptionRegisterRequest req) {
+    final String endpoint = req.getEndpoint();
+    final String p256dh = req.getKeyP256dh();
+    final String auth = req.getKeyAuth();
+
+    byte[] hash = PushSubscription.sha256(endpoint);
+
+    PushSubscription entity = pushSubscriptionRepository.findByEndpointHash(hash)
+        .map(exist -> {
+          exist.claimOrRefresh(userId, endpoint, p256dh, auth);
+          return exist;
+        })
+        .orElseGet(() -> PushSubscription.builder()
+            .userId(userId)
+            .endpoint(endpoint)
+            .endpointHash(hash)
+            .keyP256dh(p256dh)
+            .keyAuth(auth)
+            .build()
+        );
+
+    return PushSubscriptionRegisterResponse.from(pushSubscriptionRepository.save(entity));
+  }
+
+  /**
+   * 구독 해지(로그아웃/알림설정 OFF 시 호출):
+   * - endpoint 해시 기준으로 기존 레코드 조회
+   * - 있으면 소유권 확인 후 삭제, 없으면 무시
+   */
+  public void unsubscribe(Long userId, String endpoint) {
+    byte[] hash = PushSubscription.sha256(endpoint);
+
+    // 동일 endpoint가 현재 사용자 소유일 때만 삭제)
+    pushSubscriptionRepository.findByEndpointHash(hash)
+        .filter(sub -> userId.equals(sub.getUserId()))
+        .ifPresent(pushSubscriptionRepository::delete);
+  }
+
+  /**
+   * 구독 해지(subscriptionId로 직접 해지 시 호출):
+   * - subscriptionId 기준으로 기존 레코드 조회
+   * - 있으면 소유권 확인 후 삭제, 없으면 무시
+   */
+  public void unsubscribe(Long userId, Long subscriptionId) {
+    pushSubscriptionRepository.findById(subscriptionId)
+        .filter(sub -> userId.equals(sub.getUserId()))
+        .ifPresent(pushSubscriptionRepository::delete);
+  }
+}

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -5,3 +5,7 @@ spring:
     import: "optional:classpath:application-local.yml"
   profiles:
     active: local
+
+webpush:
+  vapid:
+    public-key: BAyiTTiiEObOVfRK-VgIztsE5tgtNs-J84ZsIqxb1AHyC2ubQhidiJijmGi48PKL-AYiMRIfhM3U-JqWZHSlJ0I

--- a/back/src/test/java/com/qmate/api/notification/NotificationSubscriptionControllerTest.java
+++ b/back/src/test/java/com/qmate/api/notification/NotificationSubscriptionControllerTest.java
@@ -1,0 +1,97 @@
+package com.qmate.api.notification;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.qmate.AuthTestUtils;
+import com.qmate.SecuritySliceTestConfig;
+import com.qmate.domain.notification.model.request.PushSubscriptionRegisterRequest;
+import com.qmate.domain.notification.model.request.PushSubscriptionRegisterRequest.Keys;
+import com.qmate.domain.notification.model.response.PushSubscriptionRegisterResponse;
+import com.qmate.domain.notification.service.PushSubscriptionService;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = NotificationSubscriptionController.class)
+@Import(SecuritySliceTestConfig.class)
+class NotificationSubscriptionControllerTest {
+
+  @Autowired
+  MockMvc mvc;
+  @Autowired
+  ObjectMapper om;
+
+  @MockitoBean
+  PushSubscriptionService pushSubscriptionService;
+
+  private PushSubscriptionRegisterRequest req() {
+    return PushSubscriptionRegisterRequest.builder()
+        .endpoint("https://fcm.googleapis.com/fcm/send/ABC")
+        .keys(Keys.builder()
+            .p256dh("B" + "x".repeat(87))
+            .auth("A" + "y".repeat(23))
+            .build())
+        .build();
+  }
+
+  @Test
+  @DisplayName("POST /api/notifications/subscriptions - 구독 업서트 성공")
+  void upsert_ok() throws Exception {
+    var request = req();
+    var now = LocalDateTime.now();
+    var resp = PushSubscriptionRegisterResponse.builder()
+        .subscriptionId(123L).createdAt(now).updatedAt(now).build();
+
+    given(pushSubscriptionService.upsert(eq(1L), any())).willReturn(resp);
+
+    mvc.perform(post("/api/notifications/subscriptions")
+            .with(AuthTestUtils.userPrincipal(1L))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(om.writeValueAsString(request)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.subscriptionId").value(123))
+        .andExpect(jsonPath("$.createdAt").exists())
+        .andExpect(jsonPath("$.updatedAt").exists());
+
+    then(pushSubscriptionService).should().upsert(eq(1L), any(PushSubscriptionRegisterRequest.class));
+  }
+
+  @Test
+  @DisplayName("DELETE /api/notifications/subscriptions/by-endpoint - 엔드포인트 기반 해지")
+  void unsubscribe_by_endpoint() throws Exception {
+    String endpoint = "https://fcm.googleapis.com/fcm/send/DELME";
+
+    willDoNothing().given(pushSubscriptionService).unsubscribe(1L, endpoint);
+
+    mvc.perform(delete("/api/notifications/subscriptions/by-endpoint")
+            .with(AuthTestUtils.userPrincipal(1L))
+            .param("endpoint", endpoint))
+        .andExpect(status().isNoContent());
+
+    then(pushSubscriptionService).should().unsubscribe(1L, endpoint);
+  }
+
+  @Test
+  @DisplayName("DELETE /api/notifications/subscriptions/{id} - ID 기반 해지")
+  void unsubscribe_by_id() throws Exception {
+    long id = 999L;
+    willDoNothing().given(pushSubscriptionService).unsubscribe(1L, id);
+
+    mvc.perform(delete("/api/notifications/subscriptions/{id}", id)
+            .with(AuthTestUtils.userPrincipal(1L)))
+        .andExpect(status().isNoContent());
+
+    then(pushSubscriptionService).should().unsubscribe(1L, id);
+  }
+}

--- a/back/src/test/java/com/qmate/api/notification/PushSettingControllerTest.java
+++ b/back/src/test/java/com/qmate/api/notification/PushSettingControllerTest.java
@@ -6,15 +6,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.qmate.domain.notification.model.response.PushSettingResponse;
 import com.qmate.domain.notification.service.PushSettingService;
-import com.qmate.security.UserPrincipal;
 import com.qmate.SecuritySliceTestConfig;
 import com.qmate.AuthTestUtils;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -22,7 +19,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 
-@WebMvcTest(PushSettingController.class)
+@WebMvcTest(NotificationSettingController.class)
 @Import(SecuritySliceTestConfig.class)
 class PushSettingControllerTest {
 

--- a/back/src/test/java/com/qmate/domain/notification/service/PushSubscriptionServiceTest.java
+++ b/back/src/test/java/com/qmate/domain/notification/service/PushSubscriptionServiceTest.java
@@ -1,0 +1,150 @@
+package com.qmate.domain.notification.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.*;
+
+import com.qmate.domain.notification.entity.PushSubscription;
+import com.qmate.domain.notification.model.request.PushSubscriptionRegisterRequest;
+import com.qmate.domain.notification.model.request.PushSubscriptionRegisterRequest.Keys;
+import com.qmate.domain.notification.model.response.PushSubscriptionRegisterResponse;
+import com.qmate.domain.notification.repository.PushSubscriptionRepository;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PushSubscriptionServiceTest {
+  @Mock
+  PushSubscriptionRepository repository;
+
+  @InjectMocks
+  PushSubscriptionService service;
+
+  private static PushSubscriptionRegisterRequest request(String endpoint) {
+    return PushSubscriptionRegisterRequest.builder()
+        .endpoint(endpoint)
+        .keys(Keys.builder()
+            .p256dh("B" + "x".repeat(87)) // 더미 88자
+            .auth("A" + "y".repeat(23))   // 더미 24자
+            .build())
+        .build();
+  }
+
+  @Test
+  @DisplayName("새 엔드포인트면 새 구독을 생성한다")
+  void upsert_creates_new_subscription_when_not_exists() {
+    // given
+    long userId = 1L;
+    String endpoint = "https://fcm.googleapis.com/fcm/send/NEW";
+    var req = request(endpoint);
+    byte[] hash = PushSubscription.sha256(endpoint);
+
+    given(repository.findByEndpointHash(hash)).willReturn(Optional.empty());
+
+    var saved = PushSubscription.builder()
+        .id(10L).userId(userId).endpoint(endpoint).endpointHash(hash)
+        .keyP256dh(req.getKeyP256dh()).keyAuth(req.getKeyAuth())
+        .build();
+    var now = LocalDateTime.now();
+    saved.setCreatedAt(now);
+    saved.setUpdatedAt(now);
+
+    given(repository.save(Mockito.argThat(ps ->
+        ps.getUserId().equals(userId) && ps.getEndpoint().equals(endpoint)))).willReturn(saved);
+
+    // when
+    PushSubscriptionRegisterResponse resp = service.upsert(userId, req);
+
+    // then
+    assertThat(resp.getSubscriptionId()).isEqualTo(10L);
+    assertThat(resp.getCreatedAt()).isNotNull();
+    assertThat(resp.getUpdatedAt()).isNotNull();
+    then(repository).should().findByEndpointHash(hash);
+    then(repository).should().save(Mockito.any(PushSubscription.class));
+  }
+
+  @Test
+  @DisplayName("기존 엔드포인트면 소유권을 새 사용자로 이전하고 키를 최신화한다")
+  void upsert_transfers_ownership_and_refreshes_keys_when_exists() {
+    // given
+    long oldUser = 111L;
+    long newUser = 222L;
+    String endpoint = "https://fcm.googleapis.com/fcm/send/SAME";
+    var req = request(endpoint);
+    byte[] hash = PushSubscription.sha256(endpoint);
+
+    var exist = PushSubscription.builder()
+        .id(55L).userId(oldUser).endpoint(endpoint).endpointHash(hash)
+        .keyP256dh("OLD_P").keyAuth("OLD_A")
+        .build();
+
+    given(repository.findByEndpointHash(hash)).willReturn(Optional.of(exist));
+
+    var saved = PushSubscription.builder()
+        .id(55L).userId(newUser).endpoint(endpoint).endpointHash(hash)
+        .keyP256dh(req.getKeyP256dh()).keyAuth(req.getKeyAuth())
+        .build();
+    saved.setCreatedAt(LocalDateTime.now().minusDays(1));
+    saved.setUpdatedAt(LocalDateTime.now());
+    given(repository.save(exist)).willReturn(saved);
+
+    // when
+    PushSubscriptionRegisterResponse resp = service.upsert(newUser, req);
+
+    // then
+    assertThat(resp.getSubscriptionId()).isEqualTo(55L);
+    assertThat(exist.getUserId()).isEqualTo(newUser);
+    assertThat(exist.getKeyP256dh()).isEqualTo(req.getKeyP256dh());
+    assertThat(exist.getKeyAuth()).isEqualTo(req.getKeyAuth());
+    then(repository).should().save(exist);
+  }
+
+  @Test
+  @DisplayName("엔드포인트 기반 해지: 현재 사용자 소유일 때만 삭제된다")
+  void unsubscribe_deletes_only_when_owned_by_request_user() {
+    // given
+    long userId = 1L;
+    String endpoint = "https://fcm.googleapis.com/fcm/send/DEL";
+    byte[] hash = PushSubscription.sha256(endpoint);
+
+    var owned = PushSubscription.builder()
+        .id(9L).userId(userId).endpoint(endpoint).endpointHash(hash)
+        .keyP256dh("P").keyAuth("A").build();
+
+    given(repository.findByEndpointHash(hash)).willReturn(Optional.of(owned));
+
+    // when
+    service.unsubscribe(userId, endpoint);
+
+    // then
+    then(repository).should().delete(owned);
+  }
+
+  @Test
+  @DisplayName("엔드포인트 기반 해지: 다른 사용자 소유면 삭제하지 않는다")
+  void unsubscribe_does_nothing_when_owned_by_other_user() {
+    // given
+    long me = 1L;
+    long other = 2L;
+    String endpoint = "https://fcm.googleapis.com/fcm/send/KEEP";
+    byte[] hash = PushSubscription.sha256(endpoint);
+
+    var notOwned = PushSubscription.builder()
+        .id(10L).userId(other).endpoint(endpoint).endpointHash(hash)
+        .keyP256dh("P").keyAuth("A").build();
+
+    given(repository.findByEndpointHash(hash)).willReturn(Optional.of(notOwned));
+
+    // when
+    service.unsubscribe(me, endpoint);
+
+    // then
+    then(repository).should(never()).delete(any());
+  }
+}


### PR DESCRIPTION
## 요약
- 브라우저 `PushSubscription` 원본을 받아 **구독 업서트**(등록/소유권 이전/키 최신화) 구현
- **엔드포인트 기반 해지** 및  **ID 기반 해지** 구현
- **VAPID 공개키 조회 API** 제공
- 서비스/컨트롤러 **유닛 & 슬라이스 테스트** 추가

## 변경 사항
### API
- `POST /api/notifications/subscriptions`  
  - 브라우저 `PushSubscription` **원본(JSON)** 수신 → 서버가 `endpoint`/`keys.p256dh`/`keys.auth` 추출
  - 동일 `endpoint`가 존재하면 **소유권을 현재 사용자로 이전**하고 **키 최신화**, 없으면 신규 생성
  - 응답: `{ subscriptionId, createdAt, updatedAt }`
- `DELETE /api/notifications/subscriptions/by-endpoint?endpoint=...`  
  - **엔드포인트 기반 해지**(권장). 서버에서 해시 계산 후 **현재 사용자 소유일 때만** 삭제
  - 응답: `204 No Content`
- `DELETE /api/notifications/subscriptions/{subscriptionId}`
  - **ID 기반 해지**(클라가 id를 보관 중일 때 사용)
  - 응답: `204 No Content`
- `GET /api/notifications/subscriptions/vapid-public-key`  
  - `application.yml`에 설정된 **VAPID 공개키** 반환
  - 응답: `{ vapidPublicKey }`

### 도메인/모델
- `PushSubscription` 엔티티
  - `claimOrRefresh(newUserId, endpoint, p256dh, auth)` 메서드 추가  
    → 한 endpoint=한 user 정책 하에서 **소유권 이전 + 키 갱신** 일괄 처리
- DTO
  - **Request**: `PushSubscriptionRegisterRequest` (브라우저 `PushSubscription` 원본 매핑: `endpoint`, `keys.p256dh`, `keys.auth`)
  - **Response**: `PushSubscriptionRegisterResponse` (`subscriptionId`, `createdAt`, `updatedAt`)
  - **VAPID**: `VapidPublicKeyResponse` (`vapidPublicKey`)
- 서비스
  - `upsert(userId, request)`
  - `unsubscribe(userId, endpoint)` 및 *(선택)* `unsubscribe(userId, subscriptionId)`

### 테스트
- **Service**: `PushSubscriptionServiceTest`
  - `upsert_creates_new_subscription_when_not_exists`
  - `upsert_transfers_ownership_and_refreshes_keys_when_exists`
  - `unsubscribe_deletes_only_when_owned_by_request_user`
  - `unsubscribe_does_nothing_when_owned_by_other_user`
- **Controller**: `NotificationSubscriptionControllerTest` (WebMvcTest 슬라이스)
  - `POST /api/notifications/subscriptions`
  - `DELETE /api/notifications/subscriptions/by-endpoint`
  - `DELETE /api/notifications/subscriptions/{id}`