### PR TITLE
Feature/auto disconnect inactive matches

### DIFF
--- a/back/src/main/java/com/qmate/QMateApplication.java
+++ b/back/src/main/java/com/qmate/QMateApplication.java
@@ -2,8 +2,10 @@ package com.qmate;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class QMateApplication {
 
   public static void main(String[] args) {

--- a/back/src/main/java/com/qmate/api/MatchController.java
+++ b/back/src/main/java/com/qmate/api/MatchController.java
@@ -189,4 +189,12 @@ public class MatchController {
     DetachedMatchStatusResponse response = matchService.getDetachedMatchStatus(principal.userId());
     return ResponseEntity.ok(response);
   }
+
+// 14일 이상 연결 끊기 테스트 컨트롤러
+//  @PostMapping("/run-inactive-check")
+//  public ResponseEntity<String> runInactiveCheck() {
+//    matchService.disconnectInactiveMatches();
+//    return ResponseEntity.ok("비활성 매칭 체크 스케줄러를 수동으로 실행했습니다.");
+//  }
+
 }

--- a/back/src/main/java/com/qmate/common/scheduler/match/MatchScheduler.java
+++ b/back/src/main/java/com/qmate/common/scheduler/match/MatchScheduler.java
@@ -1,0 +1,28 @@
+package com.qmate.common.scheduler.match;
+
+import com.qmate.domain.match.service.MatchService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MatchScheduler {
+
+  private final MatchService matchService;
+
+  //매일 자정 0시 0분 0초에 이 메서드를 실행
+  @Scheduled(cron = "0 0 0 * * *")
+  public void runDisconnectInactiveMatches(){
+    log.info("비활성 매칭 자동 연결 끊기 작업을 시작합니다...");
+    try {
+      matchService.disconnectInactiveMatches();
+      log.info("비할성 매칭 자동 연결 끊기 작업을 성공적으로 완료했습니다.");
+    } catch (Exception e){
+      log.error("비활성 매칭 자동 연결 끊기 작업 중 오류가 발생했습니다.", e);
+    }
+  }
+
+}

--- a/back/src/main/java/com/qmate/domain/match/repository/MatchRepository.java
+++ b/back/src/main/java/com/qmate/domain/match/repository/MatchRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-public interface MatchRepository extends JpaRepository<Match, Long> {
+public interface MatchRepository extends JpaRepository<Match, Long>, MatchRepositoryCustom {
 
 
   @EntityGraph(attributePaths = {"members", "members.user"})

--- a/back/src/main/java/com/qmate/domain/match/repository/MatchRepositoryCustom.java
+++ b/back/src/main/java/com/qmate/domain/match/repository/MatchRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.qmate.domain.match.repository;
+
+import com.qmate.domain.match.Match;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface MatchRepositoryCustom {
+
+  List<Match> findInactiveMatches(LocalDateTime cutoffDate);
+
+}

--- a/back/src/main/java/com/qmate/domain/match/repository/MatchRepositoryImpl.java
+++ b/back/src/main/java/com/qmate/domain/match/repository/MatchRepositoryImpl.java
@@ -1,0 +1,32 @@
+package com.qmate.domain.match.repository;
+
+import com.qmate.domain.match.Match;
+import com.qmate.domain.match.MatchStatus;
+import com.qmate.domain.match.QMatch;
+import com.qmate.domain.match.QMatchMember;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class MatchRepositoryImpl implements MatchRepositoryCustom{
+
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public List<Match> findInactiveMatches(LocalDateTime cutoffDate){
+    QMatch match = QMatch.match;
+    QMatchMember matchMember = QMatchMember.matchMember;
+
+  return queryFactory
+      .select(match)
+      .from(match)
+      .join(match.members, matchMember)
+      .where(match.status.eq(MatchStatus.ACTIVE))
+      .groupBy(match.id)
+      .having(matchMember.lastAnsweredAt.max().before(cutoffDate))
+      .fetch();
+  }
+
+}

--- a/back/src/main/java/com/qmate/domain/match/repository/MatchRepositoryImpl.java
+++ b/back/src/main/java/com/qmate/domain/match/repository/MatchRepositoryImpl.java
@@ -19,13 +19,15 @@ public class MatchRepositoryImpl implements MatchRepositoryCustom{
     QMatch match = QMatch.match;
     QMatchMember matchMember = QMatchMember.matchMember;
 
+    //기존 두명 다 14일 이상에서, 한명이라도 14일 이상으로 변경.
   return queryFactory
-      .select(match)
+      .select(match).distinct()
       .from(match)
       .join(match.members, matchMember)
-      .where(match.status.eq(MatchStatus.ACTIVE))
-      .groupBy(match.id)
-      .having(matchMember.lastAnsweredAt.max().before(cutoffDate))
+      .where(match.status.eq(MatchStatus.ACTIVE),
+          matchMember.lastAnsweredAt.before(cutoffDate))
+//      .groupBy(match.id)
+//      .having(matchMember.lastAnsweredAt.max().before(cutoffDate))
       .fetch();
   }
 

--- a/back/src/main/java/com/qmate/domain/match/service/MatchService.java
+++ b/back/src/main/java/com/qmate/domain/match/service/MatchService.java
@@ -38,9 +38,11 @@ import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class MatchService {
@@ -322,5 +324,17 @@ public class MatchService {
         .filter(member -> !member.getUser().getId().equals(joinerId))
         .findFirst()
         .orElseThrow(PartnerNotFoundException::new);
+  }
+  //자동 연결 끊기 서비스 로직 구현
+  @Transactional
+  public void disconnectInactiveMatches(){
+    LocalDateTime toWeeksAgo = LocalDateTime.now().minusWeeks(2);
+    List<Match> inactiveMatches = matchRepository.findInactiveMatches(toWeeksAgo);
+
+    for (Match match : inactiveMatches){
+      match.getMembers().forEach(matchMember -> matchMember.getUser().leaveMatch());
+      match.disconnect();
+    }
+  log.info("{}개의 비활성 매칭을 연결 끊기 상태로 전환했습니다.", inactiveMatches.size());
   }
 }

--- a/back/src/test/java/com/qmate/domain/match/service/disconnectInactiveMatches_success.java
+++ b/back/src/test/java/com/qmate/domain/match/service/disconnectInactiveMatches_success.java
@@ -1,0 +1,58 @@
+package com.qmate.domain.match.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.qmate.domain.match.Match;
+import com.qmate.domain.match.MatchMember;
+import com.qmate.domain.match.MatchStatus;
+import com.qmate.domain.match.repository.MatchRepository;
+import com.qmate.domain.user.User;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MatchServiceSchedulerTest {
+
+  @InjectMocks
+  private MatchService sut;
+
+  @Mock
+  private MatchRepository matchRepository;
+
+  @Test
+  @DisplayName("자동 연결 끊기: 비활성 매칭 목록을 받아 상태를 올바르게 변경한다")
+  void disconnectInactiveMatches_success() {
+    // given: 1번(비활성) 매칭이 있는 상황
+    Match inactiveMatch = spy(Match.builder().id(1L).status(MatchStatus.ACTIVE).build());
+
+    // ▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼ 이 부분을 수정합니다 ▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼
+    // User 객체도 spy()로 감싸서 행동을 추적할 수 있도록 만듭니다.
+    User user1 = spy(User.builder().id(1L).build());
+    // ▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲
+
+    inactiveMatch.addMember(MatchMember.create(user1, inactiveMatch));
+
+    given(matchRepository.findInactiveMatches(any(LocalDateTime.class)))
+        .willReturn(List.of(inactiveMatch));
+
+    // when: 서비스 메서드를 실행하면
+    sut.disconnectInactiveMatches();
+
+    // then:
+    // 1. 비활성 매칭(inactiveMatch)의 disconnect() 메서드가 1번 호출되었는지 검증
+    verify(inactiveMatch, times(1)).disconnect();
+    // 2. 비활성 매칭의 멤버(user1)의 leaveMatch() 메서드가 1번 호출되었는지 검증
+    verify(user1, times(1)).leaveMatch(); // ◀◀◀ 이제 이 검증이 성공합니다!
+  }
+}


### PR DESCRIPTION
### 개요
기획서의 요구사항에 따라, **14일 이상 활동(답변)이 없는 `ACTIVE` 상태의 매칭을 자동으로 '연결 끊기 대기(`DETACHED_PENDING_DELETE`)' 상태로 전환**하는  작업을 구현했습니다.

이를 통해 비활성 상태의 매칭을 주기적으로 정리하여, 서비스의 데이터 정합성을 유지하고 사용자에게 더 나은 경험을 제공합니다.

### 변경 사항

#### Scheduler
- **`MatchScheduler.java` (신규)**
    - Spring Scheduler(`@Scheduled`)를 사용하여 **매일 자정(00)시에** 비활성 매칭을 확인하는 스케줄러를 추가했습니다.
    - `@EnableScheduling`을 메인 애플리케이션 클래스에 추가하여 스케줄링 기능을 활성화했습니다.

#### Service
- **`MatchService#disconnectInactiveMatches()` (신규)**
    - 스케줄러가 호출할, 실제 '연결 끊기' 작업을 수행하는 비즈니스 로직을 구현했습니다.
    - 14일 전을 기준으로 비활성 매칭 목록을 조회한 뒤, 각 매칭에 대해 기존의 `disconnect()` 및 `leaveMatch()` 메서드를 호출하여 상태를 변경합니다.

#### Repository
- **`MatchRepository` (수정)**
    - **"두 멤버 중 한 명이라도 14일 이상 답변이 없는"** `ACTIVE` 상태의 매칭을 조회하는 `findInactiveMatches` 커스텀 메서드를 추가했습니다.
    - 해당 쿼리는 복잡한 조건을 안전하고 명확하게 처리하기 위해 **QueryDSL**을 사용하여 `MatchRepositoryImpl`에 구현했습니다.

### 테스트

- **[X] 서비스 단위 테스트**
    - `MatchServiceSchedulerTest.java`를 통해 `disconnectInactiveMatches` 메서드의 핵심 로직을 검증했습니다.
    - `findInactiveMatches`가 비활성 매칭 목록을 반환했을 때, 해당 매칭의 `disconnect()`와 멤버들의 `leaveMatch()` 메서드가 정확히 호출되는지 `spy`와 `verify`를 사용하여 확인했습니다.

- **[X] API 테스트 (Postman + DB 조작)**
    - 로컬 환경에서만 동작하는 테스트용 API(`POST /api/test/run-inactive-check`)를 임시로 추가하여 스케줄러를 수동으로 트리거했습니다.
    - DBeaver를 통해 특정 `match_member`의 `last_answered_at` 값을 수동 조작했습니다.
    - 테스트 API를 호출한 결과, 해당 `match`의 `status`가 `DETACHED_PENDING_DELETE`로, 관련 `user`들의 `current_match_id`가 `NULL`로 정상 변경되는 것을 DB에서 최종 확인했습니다.