### PR TITLE
feat: 캘린더 조회 API 추가 (from~to 최대 60일, 날짜당 1개 집계)

### DIFF
--- a/back/src/main/java/com/qmate/api/event/EventController.java
+++ b/back/src/main/java/com/qmate/api/event/EventController.java
@@ -4,6 +4,7 @@ import com.qmate.common.constants.event.EventConstants;
 import com.qmate.domain.event.entity.EventRepeatType;
 import com.qmate.domain.event.model.request.EventCreateRequest;
 import com.qmate.domain.event.model.request.EventUpdateRequest;
+import com.qmate.domain.event.model.response.CalendarMonthResponse;
 import com.qmate.domain.event.model.response.EventResponse;
 import com.qmate.domain.event.service.EventService;
 import com.qmate.security.UserPrincipal;
@@ -173,5 +174,28 @@ public class EventController {
     int size = Math.min(pageable.getPageSize(), 100);
     Pageable capped = PageRequest.of(pageable.getPageNumber(), size, pageable.getSort());
     return ResponseEntity.ok(eventService.listEvents(matchId, principal.userId(), from, to, repeatType, anniversary, capped));
+  }
+
+  /**
+   * 캘린더 월 조회
+   */
+  @Operation(
+      summary = "캘린더 월 조회",
+      description = EventConstants.CALENDAR_MD,
+      parameters = {
+          @Parameter(name = "matchId", description = "매치 ID"),
+          @Parameter(name = "from", description = "조회 시작 날짜(yyyy-MM-dd)", required = true),
+          @Parameter(name = "to", description = "조회 종료 날짜(yyyy-MM-dd)", required = true)
+      }
+  )
+  @GetMapping("/matches/{matchId}/events/calendar")
+  public CalendarMonthResponse getCalendar(
+      @PathVariable Long matchId,
+      @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+      @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to,
+      @AuthenticationPrincipal UserPrincipal principal
+  ) {
+    Long userId = principal.userId();
+    return eventService.getCalendarMonth(matchId, userId, from, to);
   }
 }

--- a/back/src/main/java/com/qmate/common/constants/event/EventConstants.java
+++ b/back/src/main/java/com/qmate/common/constants/event/EventConstants.java
@@ -15,6 +15,8 @@ public class EventConstants {
   public static final int EVENT_DESCRIPTION_MAX_LENGTH = 1000;
   // 이벤트 리스트 조회 기간 최대 범위
   public static final int EVENT_LIST_MAX_RANGE_YEARS = 3;
+  // 일정 캘린더 조회 최대 범위
+  public static final int EVENT_CALENDAR_MAX_RANGE_DAYS = 60;
 
   // validation message
   // 제목 공백 불가
@@ -84,4 +86,26 @@ public class EventConstants {
           + "|-----:|-----------|---------|\n"
           + "| " + HttpStatusCode.BAD_REQUEST + " | " + EventErrorCode.EVENT_LIST_DATE_RANGE_EXCEEDED_ERROR_CODE + " | "
           + EventErrorCode.EVENT_LIST_DATE_RANGE_EXCEEDED_MESSAGE + " |\n";
+
+  public static final String CALENDAR_MD =
+      "지정한 기간[from, to]에 대해 매치의 캘린더 이벤트를 조회합니다.\n\n"
+          + "#### 규칙\n"
+          + "- from, to **모두 포함**입니다. (예: from==발생일, to==발생일도 결과에 포함)\n"
+          + "- 조회 기간은 **최대 60일**(포함 기준)까지만 허용합니다. **같은 달 제한은 없습니다.**\n"
+          + "- **페이징 없음**: 캘린더 특성상 날짜당 최대 1개만 반환됩니다.\n"
+          + "- 집계 규칙(같은 날짜에 여러 이벤트 존재 시):\n"
+          + "  - **대표 eventId = 최솟값**\n"
+          + "  - **isAnniversary = OR** (해당 날짜에 하나라도 기념일이 있으면 true)\n"
+          + "- 정렬: **날짜(eventAt) 오름차순**.\n"
+          + "- 권한: `user.currentMatchId == {matchId}` 인 경우에만 조회되며, 미충족 시 **빈 결과**가 반환됩니다.\n"
+          + "- 날짜 형식: `YYYY-MM-DD`.\n\n"
+          + "#### 반복 전개\n"
+          + "- WEEKLY: seed 요일 기준 주 단위 전개.\n"
+          + "- MONTHLY: seed의 일(day) 기준 전개, 말일 초과 시 해당 월의 **말일로 보정**.\n"
+          + "- YEARLY: seed의 월/일 그대로 전개, **2/29는 평년에는 2/28로 보정**.\n\n"
+          + "### 에러 응답\n\n"
+          + "| HTTP | errorCode | message |\n"
+          + "|-----:|-----------|---------|\n"
+          + "| " + HttpStatusCode.BAD_REQUEST + " | " + EventErrorCode.EVENT_CALENDAR_DATE_RANGE_EXCEEDED_ERROR_CODE + " | "
+          + EventErrorCode.EVENT_CALENDAR_DATE_RANGE_EXCEEDED_MESSAGE + " |\n";
 }

--- a/back/src/main/java/com/qmate/domain/event/model/response/CalendarMonthResponse.java
+++ b/back/src/main/java/com/qmate/domain/event/model/response/CalendarMonthResponse.java
@@ -1,0 +1,28 @@
+// CalendarMonthResponse.java
+package com.qmate.domain.event.model.response;
+
+import java.time.LocalDate;
+import java.util.List;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CalendarMonthResponse {
+
+  private int year;       // 1~9999
+  private int month;      // 1~12
+  private List<DayItem> days;
+
+  @Getter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Builder
+  public static class DayItem {
+
+    private Long eventId;         // 같은 날짜 여러 개면 대표 eventId(최솟값)
+    private LocalDate eventAt;    // yyyy-MM-dd
+    private boolean isAnniversary;// 하나라도 기념일이면 true
+  }
+}

--- a/back/src/main/java/com/qmate/domain/event/service/EventService.java
+++ b/back/src/main/java/com/qmate/domain/event/service/EventService.java
@@ -6,10 +6,12 @@ import com.qmate.domain.event.entity.EventRepeatType;
 import com.qmate.domain.event.mapper.EventMapper;
 import com.qmate.domain.event.model.request.EventCreateRequest;
 import com.qmate.domain.event.model.request.EventUpdateRequest;
+import com.qmate.domain.event.model.response.CalendarMonthResponse;
 import com.qmate.domain.event.model.response.EventResponse;
 import com.qmate.domain.event.repository.EventRepository;
 import com.qmate.domain.match.Match;
 import com.qmate.domain.match.repository.MatchRepository;
+import com.qmate.exception.custom.event.EventCalendarDateRangeExceededException;
 import com.qmate.exception.custom.event.EventDeletionNotAllowedException;
 import com.qmate.exception.custom.event.EventListDateRangeExceededException;
 import com.qmate.exception.custom.event.EventNotFoundException;
@@ -19,12 +21,14 @@ import jakarta.annotation.Nullable;
 import java.time.LocalDate;
 import java.time.Year;
 import java.time.YearMonth;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 import lombok.RequiredArgsConstructor;
-import org.springframework.cglib.core.Local;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -163,6 +167,78 @@ public class EventService {
     return new PageImpl<>(content, pageable, total);
   }
 
+  /**
+   * 캘린더용 일정 조회
+   * - from~to: 최대 60일(양끝 포함), 같은 달 제한 없음
+   * - 날짜당 1개로 압축: 대표 eventId=최솟값, isAnniversary=OR
+   * - 반복 전개(expandOccurrences) 사용
+   */
+  @Transactional(readOnly = true)
+  public CalendarMonthResponse getCalendarMonth(
+      Long matchId, Long userId,
+      LocalDate from, LocalDate to
+  ) {
+    if (to.isBefore(from)) {
+      YearMonth base = YearMonth.from(from);
+      return CalendarMonthResponse.builder()
+          .year(base.getYear())
+          .month(base.getMonthValue())
+          .days(List.of())
+          .build();
+    }
+
+    // 최대 60일 (양끝 포함): between은 양끝 제외라서 59 초과면 60일 초과
+    long gap = ChronoUnit.DAYS.between(from, to);
+    if (gap > EventConstants.EVENT_CALENDAR_MAX_RANGE_DAYS - 1) {
+      throw new EventCalendarDateRangeExceededException();
+    }
+
+    YearMonth base = YearMonth.from(from); // 응답 year/month 표기를 위한 기준
+
+    // 후보 조회 (권한 포함 가정)
+    List<Event> candidates = eventRepository.findCandidates(
+        matchId, userId, from, to, null, null
+    );
+
+    // 반복 전개
+    List<Occurrence> occurrences = new ArrayList<>();
+    for (Event e : candidates) {
+      for (LocalDate d : expandOccurrences(e, from, to)) {
+        occurrences.add(new Occurrence(d, e));
+      }
+    }
+
+    // 날짜별 압축: 대표 eventId=최솟값, isAnniversary=OR
+    Map<LocalDate, Aggregate> byDate = new TreeMap<>();
+    for (Occurrence o : occurrences) {
+      LocalDate date = o.date();
+      Event ev = o.event();
+      Aggregate agg = byDate.get(date);
+      if (agg == null) {
+        byDate.put(date, new Aggregate(ev.getId(), ev.isAnniversary()));
+      } else {
+        byDate.put(date, new Aggregate(
+            Math.min(agg.representativeEventId(), ev.getId()),
+            agg.isAnniversary() || ev.isAnniversary()
+        ));
+      }
+    }
+
+    List<CalendarMonthResponse.DayItem> days = byDate.entrySet().stream()
+        .map(e -> CalendarMonthResponse.DayItem.builder()
+            .eventId(e.getValue().representativeEventId())
+            .eventAt(e.getKey())
+            .isAnniversary(e.getValue().isAnniversary())
+            .build())
+        .toList();
+
+    return CalendarMonthResponse.builder()
+        .year(base.getYear())
+        .month(base.getMonthValue())
+        .days(days)
+        .build();
+  }
+
   /* ===== 반복 전개 ===== */
 
   private List<LocalDate> expandOccurrences(Event e, LocalDate from, LocalDate to) {
@@ -276,6 +352,10 @@ public class EventService {
   }
 
   private record Occurrence(LocalDate date, Event event) {
+
+  }
+
+  private record Aggregate(long representativeEventId, boolean isAnniversary) {
 
   }
 }

--- a/back/src/main/java/com/qmate/exception/custom/event/EventCalendarDateRangeExceededException.java
+++ b/back/src/main/java/com/qmate/exception/custom/event/EventCalendarDateRangeExceededException.java
@@ -1,0 +1,12 @@
+package com.qmate.exception.custom.event;
+
+import com.qmate.exception.BusinessGlobalException;
+import com.qmate.exception.errorcode.EventErrorCode;
+
+public class EventCalendarDateRangeExceededException extends BusinessGlobalException {
+
+  public EventCalendarDateRangeExceededException() {
+    super(EventErrorCode.eventCalendarDateRangeExceeded());
+  }
+
+}

--- a/back/src/main/java/com/qmate/exception/errorcode/EventErrorCode.java
+++ b/back/src/main/java/com/qmate/exception/errorcode/EventErrorCode.java
@@ -13,12 +13,14 @@ public class EventErrorCode extends ErrorCode {
   public static final String EVENT_REPEAT_MODIFICATION_NOT_ALLOWED_MESSAGE = "기념일의 반복 설정은 변경할 수 없습니다.";
   public static final String EVENT_DELETION_NOT_ALLOWED_MESSAGE = "기념일은 삭제할 수 없습니다.";
   public static final String EVENT_LIST_DATE_RANGE_EXCEEDED_MESSAGE = "조회 기간은 최대 " + EventConstants.EVENT_LIST_MAX_RANGE_YEARS + "년까지 가능합니다.";
+  public static final String EVENT_CALENDAR_DATE_RANGE_EXCEEDED_MESSAGE = "캘린더 조회 기간은 최대 " + EventConstants.EVENT_CALENDAR_MAX_RANGE_DAYS + "일 까지 가능합니다.";
 
   // error code
   public static final String EVENT_NOT_FOUND_ERROR_CODE = "EVENT_001";
   public static final String EVENT_REPEAT_MODIFICATION_NOT_ALLOWED_ERROR_CODE = "EVENT_002";
   public static final String EVENT_DELETION_NOT_ALLOWED_ERROR_CODE = "EVENT_003";
   public static final String EVENT_LIST_DATE_RANGE_EXCEEDED_ERROR_CODE = "EVENT_004";
+  public static final String EVENT_CALENDAR_DATE_RANGE_EXCEEDED_ERROR_CODE = "EVENT_005";
 
   // factory method
   public static ErrorCode eventNotFound() {
@@ -38,6 +40,11 @@ public class EventErrorCode extends ErrorCode {
   public static ErrorCode eventListDateRangeExceeded() {
     return new EventErrorCode(HttpStatus.BAD_REQUEST, EVENT_LIST_DATE_RANGE_EXCEEDED_ERROR_CODE,
         EVENT_LIST_DATE_RANGE_EXCEEDED_MESSAGE);
+  }
+
+  public static ErrorCode eventCalendarDateRangeExceeded() {
+    return new EventErrorCode(HttpStatus.BAD_REQUEST, EVENT_CALENDAR_DATE_RANGE_EXCEEDED_ERROR_CODE,
+        EVENT_CALENDAR_DATE_RANGE_EXCEEDED_MESSAGE);
   }
 
   protected EventErrorCode(HttpStatus httpStatus, String code, String message) {

--- a/back/src/test/java/com/qmate/domain/event/EventServiceTest.java
+++ b/back/src/test/java/com/qmate/domain/event/EventServiceTest.java
@@ -7,10 +7,12 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 
 import com.qmate.domain.event.model.request.EventCreateRequest;
 import com.qmate.domain.event.model.request.EventUpdateRequest;
+import com.qmate.domain.event.model.response.CalendarMonthResponse;
 import com.qmate.domain.event.model.response.EventResponse;
 import com.qmate.domain.event.entity.Event;
 import com.qmate.domain.event.entity.EventAlarmOption;
@@ -19,6 +21,7 @@ import com.qmate.domain.event.repository.EventRepository;
 import com.qmate.domain.event.service.EventService;
 import com.qmate.domain.match.Match;
 import com.qmate.domain.match.repository.MatchRepository;
+import com.qmate.exception.custom.event.EventCalendarDateRangeExceededException;
 import com.qmate.exception.custom.event.EventDeletionNotAllowedException;
 import com.qmate.exception.custom.event.EventListDateRangeExceededException;
 import com.qmate.exception.custom.event.EventNotFoundException;
@@ -26,9 +29,11 @@ import com.qmate.exception.custom.event.EventRepeatModificationNotAllowedExcepti
 import com.qmate.exception.custom.matchinstance.MatchNotFoundException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.YearMonth;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -517,5 +522,120 @@ class EventServiceTest {
     // findCandidates 호출되지 않아야 함
     then(eventRepository).should(never())
         .findCandidates(anyLong(), anyLong(), any(LocalDate.class), any(LocalDate.class), any(), any());
+  }
+
+  private static final Long MATCH_ID = 42L;
+  private static final Long USER_ID = 7L;
+
+  @Nested
+  @DisplayName("캘린더 조회(getCalendarMonth)")
+  class GetCalendarMonth {
+
+    @Test
+    @DisplayName("to < from 이면 빈 결과를 반환한다")
+    void returnsEmptyWhenReversedRange() {
+      // given
+      LocalDate from = LocalDate.of(2025, 9, 10);
+      LocalDate to = LocalDate.of(2025, 9, 9);
+
+      // when
+      CalendarMonthResponse res = eventService.getCalendarMonth(MATCH_ID, USER_ID, from, to);
+
+      // then
+      assertThat(res.getYear()).isEqualTo(YearMonth.from(from).getYear());
+      assertThat(res.getMonth()).isEqualTo(YearMonth.from(from).getMonthValue());
+      assertThat(res.getDays()).isEmpty();
+
+      then(eventRepository).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("조회 기간이 60일 초과면 예외를 던진다")
+    void throwsWhenOver60Days() {
+      // given
+      LocalDate from = LocalDate.of(2025, 9, 1);
+      LocalDate to = from.plusDays(60); // 포함 기준 61일 → 예외
+
+      // when / then
+      assertThatThrownBy(() ->
+          eventService.getCalendarMonth(MATCH_ID, USER_ID, from, to)
+      ).isInstanceOf(EventCalendarDateRangeExceededException.class);
+
+      then(eventRepository).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("같은 날짜에 여러 이벤트가 있으면 대표 eventId=최솟값, isAnniversary는 OR 집계")
+    void aggregatesSameDate() {
+      // given
+      LocalDate from = LocalDate.of(2025, 9, 1);
+      LocalDate to = LocalDate.of(2025, 9, 30);
+      LocalDate day = LocalDate.of(2025, 9, 27);
+
+      Event e1 = mock(Event.class);
+      given(e1.getId()).willReturn(10L);
+      given(e1.isAnniversary()).willReturn(false);
+      given(e1.getRepeatType()).willReturn(EventRepeatType.NONE);
+      given(e1.getEventAt()).willReturn(day);
+
+      Event e2 = mock(Event.class);
+      given(e2.getId()).willReturn(3L); // 더 작은 ID
+      given(e2.isAnniversary()).willReturn(true); // 기념일
+      given(e2.getRepeatType()).willReturn(EventRepeatType.NONE);
+      given(e2.getEventAt()).willReturn(day);
+
+      // findCandidates는 두 이벤트를 반환
+      given(eventRepository.findCandidates(MATCH_ID, USER_ID, from, to, null, null))
+          .willReturn(List.of(e1, e2));
+
+      // when
+      CalendarMonthResponse res = eventService.getCalendarMonth(MATCH_ID, USER_ID, from, to);
+
+      // then
+      assertThat(res.getDays()).hasSize(1);
+      var item = res.getDays().get(0);
+      assertThat(item.getEventAt()).isEqualTo(day);
+      assertThat(item.getEventId()).isEqualTo(3L); // 최솟값
+      assertThat(item.isAnniversary()).isTrue();   // OR → true
+
+      then(eventRepository).should().findCandidates(MATCH_ID, USER_ID, from, to, null, null);
+    }
+
+    @Test
+    @DisplayName("WEEKLY 반복 전개: 기간 내 해당 요일로 전개되어 날짜당 1개로 반환된다")
+    void expandsWeekly() {
+      // given
+      LocalDate from = LocalDate.of(2025, 9, 1);   // 월
+      LocalDate to = LocalDate.of(2025, 9, 21);    // 3주 범위
+
+      // seed: 2025-09-03(수) → 매주 수요일 전개 예상: 09-03, 09-10, 09-17
+      Event weekly = mock(Event.class);
+      given(weekly.getId()).willReturn(100L);
+      given(weekly.isAnniversary()).willReturn(false);
+      given(weekly.getRepeatType()).willReturn(EventRepeatType.WEEKLY);
+      given(weekly.getEventAt()).willReturn(LocalDate.of(2025, 9, 3));
+
+      // findCandidates는 1건 반환
+      given(eventRepository.findCandidates(MATCH_ID, USER_ID, from, to, null, null))
+          .willReturn(List.of(weekly));
+
+      // when
+      CalendarMonthResponse res = eventService.getCalendarMonth(MATCH_ID, USER_ID, from, to);
+
+      // then
+      assertThat(res.getDays())
+          .extracting(d -> d.getEventAt())
+          .containsExactly(
+              LocalDate.of(2025, 9, 3),
+              LocalDate.of(2025, 9, 10),
+              LocalDate.of(2025, 9, 17)
+          );
+
+      // 날짜당 1개 보장 & 동일 이벤트의 반복 전개이므로 eventId 동일
+      assertThat(res.getDays())
+          .allSatisfy(d -> assertThat(d.getEventId()).isEqualTo(100L));
+
+      then(eventRepository).should().findCandidates(MATCH_ID, USER_ID, from, to, null, null);
+    }
   }
 }


### PR DESCRIPTION
## 개요
- /api/matches/{matchId}/events/calendar 엔드포인트를 추가하여 캘린더 뷰용 일정을 조회합니다.
- 기간은 from~to(포함)로 받으며 최대 60일까지 허용합니다.
- 같은 날짜에 여러 이벤트가 있으면 대표 eventId = 최솟값, isAnniversary = OR로 날짜당 1개로 집계합니다.
- DTO는 최상위에 year, month, days 필드만 제공합니다.

## 주요 변경 사항
- Controller
  - GET /api/matches/{matchId}/events/calendar?from=YYYY-MM-DD&to=YYYY-MM-DD
- Service
  - EventService#getCalendarMonth(matchId, userId, from, to)
    - 60일 범위 검증(포함 기준)
    - 후보 이벤트 조회 → 반복 전개 재사용 → 날짜별 1건으로 압축
    - 정렬: eventAt 오름차순
- DTO
  - CalendarMonthResponse { year, month, days[] }
  - DayItem { eventId, eventAt, isAnniversary }
- 상수
  - EventConstants.EVENT_CALENDAR_MAX_RANGE_DAYS = 60

## API 스펙
- 권한: user.currentMatchId == {matchId} 인 경우만 데이터 반환(미충족 시 빈 결과)
- 파라미터: from, to는 ISO 날짜(YYYY-MM-DD), 모두 포함
- 정렬: eventAt 오름차순
- 집계 규칙: 동일 날짜 다수 이벤트 → eventId 최솟값, isAnniversary OR

## 테스트
- EventServiceCalendarTest
  - to < from → 빈 결과
  - 60일 초과 → 예외
  - 동일 날짜 다수 이벤트 → 대표 id 최솟값 & isAnniversary OR
  - WEEKLY 반복 전개 → 기간 내 해당 요일 전개 검증