### PR TITLE
feat: 알림(Notification) 상세/리스트/미읽음 카운트 API 구현

### DIFF
--- a/back/src/main/java/com/qmate/api/notification/NotificationController.java
+++ b/back/src/main/java/com/qmate/api/notification/NotificationController.java
@@ -1,0 +1,84 @@
+package com.qmate.api.notification;
+
+import com.qmate.common.constants.notification.NotificationConstants;
+import com.qmate.domain.notification.entity.NotificationCategory;
+import com.qmate.domain.notification.entity.NotificationCode;
+import com.qmate.domain.notification.model.response.NotificationListItem;
+import com.qmate.domain.notification.model.response.NotificationResponse;
+import com.qmate.domain.notification.service.NotificationService;
+import com.qmate.security.UserPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/notifications")
+@RequiredArgsConstructor
+@SecurityRequirement(name = "bearerAuth")
+@Tag(name = "Notification", description = "알림 API")
+public class NotificationController {
+
+  private final NotificationService notificationService;
+
+  @Operation(
+      summary = "알림 상세 조회",
+      description = NotificationConstants.GET_DETAIL_MD,
+      parameters = {
+          @Parameter(name = "notificationId", description = "알림 ID")
+      }
+  )
+  @GetMapping("/{notificationId}")
+  public NotificationResponse getDetail(
+      @AuthenticationPrincipal UserPrincipal principal,
+      @PathVariable Long notificationId
+  ) {
+    return notificationService.getDetail(principal.userId(), notificationId);
+  }
+
+  @Operation(
+      summary = "알림 리스트 조회",
+      description = NotificationConstants.GET_LIST_MD,
+      parameters = {
+          @Parameter(name = "category", description = "알림 카테고리 (optional)", schema = @Schema(implementation = NotificationCategory.class)),
+          @Parameter(name = "code", description = "알림 코드 (optional)", schema = @Schema(implementation = NotificationCode.class)),
+          @Parameter(name = "unread", description = "읽지 않은 알림만 조회 여부 (optional)"),
+          @Parameter(name = "page", description = "페이지 번호 (0..N)"),
+          @Parameter(name = "size", description = "페이지 크기"),
+          @Parameter(name = "sort", description = "사용하지 않음")
+      }
+  )
+  @GetMapping
+  public Page<NotificationListItem> getList(
+      @AuthenticationPrincipal UserPrincipal principal,
+      @RequestParam(required = false) NotificationCategory category,
+      @RequestParam(required = false) NotificationCode code,
+      @RequestParam(required = false) Boolean unread,
+      @PageableDefault(page = 0, size = 20)
+      @ParameterObject Pageable pageable
+  ) {
+    return notificationService.getList(principal.userId(), category, code, unread, pageable);
+  }
+
+  @Operation(
+      summary = "읽지 않은 알림 개수 조회",
+      description = NotificationConstants.GET_UNREAD_COUNT_MD
+  )
+  @GetMapping("/unread-count")
+  public long getUnreadCount(@AuthenticationPrincipal UserPrincipal principal) {
+    return notificationService.getUnreadCount(principal.userId());
+  }
+}

--- a/back/src/main/java/com/qmate/common/constants/notification/NotificationConstants.java
+++ b/back/src/main/java/com/qmate/common/constants/notification/NotificationConstants.java
@@ -1,0 +1,45 @@
+package com.qmate.common.constants.notification;
+
+import com.qmate.common.constants.HttpStatusCode;
+import com.qmate.exception.errorcode.NotificationErrorCode;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
+public class NotificationConstants {
+
+  // code descriptions
+  public static final String QI_TODAY_READY_MSG = "오늘의 질문 도착!";
+  public static final String QI_REMINDER_MSG = "아직 답변하지 않은 질문이 있어요.";
+  public static final String QI_COMPLETED_MSG = "상대의 답변 도착!";
+  public static final String EVENT_SAME_DAY_MSG = "당일 일정 알림";
+  public static final String EVENT_THREE_DAY_BEFORE_MSG = "3일 전 일정 알림";
+  public static final String EVENT_WEEK_BEFORE_MSG = "1주일 전 일정 알림";
+
+  // api docs
+  public static final String GET_DETAIL_MD =
+      "특정 알림의 상세 정보를 조회합니다.\n\n"
+          + "이때, 해당 알림이 읽지 않은 상태였다면 읽음 처리됩니다.\n\n"
+          + "### 에러 응답\n\n"
+          + "| HTTP | errorCode | message |\n"
+          + "|-----:|-----------|---------|\n"
+          + "| " + HttpStatusCode.NOT_FOUND + " | " + NotificationErrorCode.NOTIFICATION_NOT_FOUND_ERROR_CODE + " | "
+          + NotificationErrorCode.NOTIFICATION_NOT_FOUND_MESSAGE + " |\n\n"
+          + "## 알림 코드\n\n"
+          + "### 질문(QI)\n"
+          + "- QI_TODAY_READY: " + QI_TODAY_READY_MSG + "\n"
+          + "- QI_REMINDER: " + QI_REMINDER_MSG + "\n"
+          + "- QI_COMPLETED: " + QI_COMPLETED_MSG + "\n\n"
+          + "### 일정(Event)\n"
+          + "- EVENT_SAME_DAY: " + EVENT_SAME_DAY_MSG + "\n"
+          + "- EVENT_THREE_DAY_BEFORE: " + EVENT_THREE_DAY_BEFORE_MSG + "\n"
+          + "- EVENT_WEEK_BEFORE: " + EVENT_WEEK_BEFORE_MSG + "\n";
+
+  public static final String GET_LIST_MD =
+      "알림 목록을 조회합니다.\n\n"
+          + "- 필터: `category`(옵션), `code`(옵션), `unread`(옵션; true이면 미읽음만)\n"
+          + "- 페이징: `page`(0..N), `size`(기본 20)\n"
+          + "- 정렬: 생성시각 내림차순 고정(요청의 `sort`는 무시)";
+
+  public static final String GET_UNREAD_COUNT_MD =
+      "읽지 않은 알림의 개수를 조회합니다.\n\n";
+}

--- a/back/src/main/java/com/qmate/domain/notification/entity/Notification.java
+++ b/back/src/main/java/com/qmate/domain/notification/entity/Notification.java
@@ -48,6 +48,7 @@ public class Notification {
   @Column(name = "resource_id")
   private Long resourceId;
 
+  @Setter
   @Column(name = "read_at")
   private LocalDateTime readAt;
 

--- a/back/src/main/java/com/qmate/domain/notification/entity/Notification.java
+++ b/back/src/main/java/com/qmate/domain/notification/entity/Notification.java
@@ -1,0 +1,61 @@
+package com.qmate.domain.notification.entity;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "notification")
+@EntityListeners(AuditingEntityListener.class)
+public class Notification {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "notification_id")
+  private Long id;
+
+  @Column(name = "user_id", nullable = false)
+  private Long userId;
+
+  @Column(name = "match_id")
+  private Long matchId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "category", length = 30, nullable = false)
+  private NotificationCategory category;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "code", length = 40, nullable = false)
+  private NotificationCode code;
+
+  @Column(name = "list_title", length = 150, nullable = false)
+  private String listTitle;
+
+  @Column(name = "push_title", length = 150, nullable = false)
+  private String pushTitle;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "resource_type", length = 30, nullable = false)
+  private NotificationResourceType resourceType;
+
+  @Column(name = "resource_id")
+  private Long resourceId;
+
+  @Column(name = "read_at")
+  private LocalDateTime readAt;
+
+  @CreatedDate
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate
+  @Column(name = "updated_at", nullable = false)
+  private LocalDateTime updatedAt;
+}

--- a/back/src/main/java/com/qmate/domain/notification/entity/NotificationCategory.java
+++ b/back/src/main/java/com/qmate/domain/notification/entity/NotificationCategory.java
@@ -1,0 +1,5 @@
+package com.qmate.domain.notification.entity;
+
+public enum NotificationCategory {
+  QUESTION, EVENT, MATCH
+}

--- a/back/src/main/java/com/qmate/domain/notification/entity/NotificationCode.java
+++ b/back/src/main/java/com/qmate/domain/notification/entity/NotificationCode.java
@@ -1,13 +1,26 @@
 package com.qmate.domain.notification.entity;
 
+import com.qmate.common.constants.notification.NotificationConstants;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
 public enum NotificationCode {
   // QUESTION (QI)
-  QI_TODAY_READY,
-  QI_REMINDER,
-  QI_COMPLETED,
+  QI_TODAY_READY(NotificationConstants.QI_TODAY_READY_MSG),
+  QI_REMINDER(NotificationConstants.QI_REMINDER_MSG),
+  QI_COMPLETED(NotificationConstants.QI_COMPLETED_MSG),
 
   // EVENT
-  EVENT_DUE_SOON
+  EVENT_SAME_DAY(NotificationConstants.EVENT_SAME_DAY_MSG),
+  EVENT_THREE_DAY_BEFORE(NotificationConstants.EVENT_THREE_DAY_BEFORE_MSG),
+  EVENT_WEEK_BEFORE(NotificationConstants.EVENT_WEEK_BEFORE_MSG),;
 
   // MATCH
+
+  private final String description;
+
+  NotificationCode(String description) {
+    this.description = description;
+  }
 }

--- a/back/src/main/java/com/qmate/domain/notification/entity/NotificationCode.java
+++ b/back/src/main/java/com/qmate/domain/notification/entity/NotificationCode.java
@@ -1,0 +1,13 @@
+package com.qmate.domain.notification.entity;
+
+public enum NotificationCode {
+  // QUESTION (QI)
+  QI_TODAY_READY,
+  QI_REMINDER,
+  QI_COMPLETED,
+
+  // EVENT
+  EVENT_DUE_SOON
+
+  // MATCH
+}

--- a/back/src/main/java/com/qmate/domain/notification/entity/NotificationResourceType.java
+++ b/back/src/main/java/com/qmate/domain/notification/entity/NotificationResourceType.java
@@ -1,0 +1,8 @@
+package com.qmate.domain.notification.entity;
+
+public enum NotificationResourceType {
+  QUESTION_INSTANCE,
+  EVENT,
+  MATCH,
+  NONE
+}

--- a/back/src/main/java/com/qmate/domain/notification/model/response/NotificationListItem.java
+++ b/back/src/main/java/com/qmate/domain/notification/model/response/NotificationListItem.java
@@ -1,0 +1,30 @@
+package com.qmate.domain.notification.model.response;
+
+import com.qmate.domain.notification.entity.Notification;
+import com.qmate.domain.notification.entity.NotificationCategory;
+import com.qmate.domain.notification.entity.NotificationCode;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class NotificationListItem {
+  private final Long notificationId;
+  private final NotificationCategory category;
+  private final NotificationCode code;
+  private final String listTitle;
+  private final LocalDateTime createdAt;
+  private final boolean read;
+
+  public static NotificationListItem from(Notification n) {
+    return NotificationListItem.builder()
+        .notificationId(n.getId())
+        .category(n.getCategory())
+        .code(n.getCode())
+        .listTitle(n.getListTitle())
+        .createdAt(n.getCreatedAt())
+        .read(n.getReadAt() != null)
+        .build();
+  }
+}

--- a/back/src/main/java/com/qmate/domain/notification/model/response/NotificationResponse.java
+++ b/back/src/main/java/com/qmate/domain/notification/model/response/NotificationResponse.java
@@ -1,0 +1,41 @@
+package com.qmate.domain.notification.model.response;
+
+import com.qmate.domain.notification.entity.Notification;
+import com.qmate.domain.notification.entity.NotificationCategory;
+import com.qmate.domain.notification.entity.NotificationCode;
+import com.qmate.domain.notification.entity.NotificationResourceType;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class NotificationResponse {
+  private final Long notificationId;
+  private final Long userId;
+  private final Long matchId;
+  private final NotificationCategory category;
+  private final NotificationCode code;
+  private final String listTitle;
+  private final String pushTitle;
+  private final NotificationResourceType resourceType;
+  private final Long resourceId;
+  private final LocalDateTime readAt;
+  private final LocalDateTime createdAt;
+
+  public static NotificationResponse from(Notification n) {
+    return NotificationResponse.builder()
+        .notificationId(n.getId())
+        .userId(n.getUserId())
+        .matchId(n.getMatchId())
+        .category(n.getCategory())
+        .code(n.getCode())
+        .listTitle(n.getListTitle())
+        .pushTitle(n.getPushTitle())
+        .resourceType(n.getResourceType())
+        .resourceId(n.getResourceId())
+        .readAt(n.getReadAt())
+        .createdAt(n.getCreatedAt())
+        .build();
+  }
+}

--- a/back/src/main/java/com/qmate/domain/notification/repository/NotificationRepository.java
+++ b/back/src/main/java/com/qmate/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,8 @@
+package com.qmate.domain.notification.repository;
+
+import com.qmate.domain.notification.entity.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+}

--- a/back/src/main/java/com/qmate/domain/notification/repository/NotificationRepository.java
+++ b/back/src/main/java/com/qmate/domain/notification/repository/NotificationRepository.java
@@ -1,8 +1,57 @@
 package com.qmate.domain.notification.repository;
 
 import com.qmate.domain.notification.entity.Notification;
+import com.qmate.domain.notification.entity.NotificationCategory;
+import com.qmate.domain.notification.entity.NotificationCode;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
+  @Query("""
+      select n
+      from Notification n, User u
+      where u.id = :userId
+        and n.id = :notificationId
+        and n.userId = u.id
+        and (n.matchId is null or u.currentMatchId = n.matchId)
+      """)
+  Optional<Notification> findAuthorizedDetail(@Param("userId") Long userId,
+      @Param("notificationId") Long notificationId);
+
+  @Query("""
+      select n
+        from Notification n, User u
+       where u.id = :userId
+         and n.userId = u.id
+         and (n.matchId is null or u.currentMatchId = n.matchId)
+         and (:category is null or n.category = :category)
+         and (:code     is null or n.code     = :code)
+         and (
+              :unread is null
+              or (:unread = true  and n.readAt is null)
+              or (:unread = false and n.readAt is not null)
+         )
+       order by n.createdAt desc, n.id desc
+      """)
+  Page<Notification> findAuthorizedList(
+      @Param("userId") Long userId,
+      @Param("category") NotificationCategory category, // nullable
+      @Param("code") NotificationCode code, // nullable
+      @Param("unread") Boolean unread, // nullable
+      Pageable pageable);
+
+  @Query("""
+      select count(n)
+        from Notification n, User u
+       where u.id = :userId
+         and n.userId = u.id
+         and (n.matchId is null or u.currentMatchId = n.matchId)
+         and n.readAt is null
+      """)
+  long countAuthorizedUnread(@Param("userId") Long userId);
 }

--- a/back/src/main/java/com/qmate/domain/notification/service/NotificationService.java
+++ b/back/src/main/java/com/qmate/domain/notification/service/NotificationService.java
@@ -1,0 +1,77 @@
+package com.qmate.domain.notification.service;
+
+import com.qmate.domain.notification.entity.Notification;
+import com.qmate.domain.notification.entity.NotificationCategory;
+import com.qmate.domain.notification.entity.NotificationCode;
+import com.qmate.domain.notification.model.response.NotificationListItem;
+import com.qmate.domain.notification.model.response.NotificationResponse;
+import com.qmate.domain.notification.repository.NotificationRepository;
+import com.qmate.exception.custom.notification.NotificationNotFoundException;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+  private final NotificationRepository notificationRepository;
+
+  /**
+   * 알림 상세 조회
+   *
+   * @param userId         조회 대상 사용자 ID
+   * @param notificationId 알림 ID
+   * @return 알림 상세
+   * @throws NotificationNotFoundException 권한이 없거나 존재하지 않는 알림인 경우
+   */
+  @Transactional
+  public NotificationResponse getDetail(Long userId, Long notificationId) {
+    Notification n = notificationRepository.findAuthorizedDetail(userId, notificationId)
+        .orElseThrow(NotificationNotFoundException::new);
+
+    if (n.getReadAt() == null) {
+      n.setReadAt(LocalDateTime.now());
+    }
+
+    return NotificationResponse.from(n);
+  }
+
+  /**
+   * 알림 리스트 조회
+   *
+   * @param userId   조회 대상 사용자 ID
+   * @param category 알림 카테고리 (nullable)
+   * @param code     알림 코드 (nullable)
+   * @param unread   읽지 않은 알림만 조회 여부 (nullable)
+   * @param pageable 페이지 정보
+   * @return 알림 리스트 (페이지네이션)
+   */
+  @Transactional(readOnly = true)
+  public Page<NotificationListItem> getList(
+      Long userId, NotificationCategory category, NotificationCode code, Boolean unread, Pageable pageable) {
+
+    // sort는 무조건 createdAt desc, id desc
+    PageRequest pr = PageRequest.of(
+        pageable.getPageNumber(),
+        pageable.getPageSize(),
+        Sort.by(Sort.Direction.DESC, "createdAt").and(Sort.by(Sort.Direction.DESC, "id"))
+    );
+
+    return notificationRepository.findAuthorizedList(userId, category, code, unread, pr)
+        .map(NotificationListItem::from);
+  }
+
+  /**
+   * 읽지 않은 알림 개수 조회
+   */
+  @Transactional(readOnly = true)
+  public long getUnreadCount(Long userId) {
+    return notificationRepository.countAuthorizedUnread(userId);
+  }
+}

--- a/back/src/main/java/com/qmate/exception/custom/notification/NotificationNotFoundException.java
+++ b/back/src/main/java/com/qmate/exception/custom/notification/NotificationNotFoundException.java
@@ -1,0 +1,12 @@
+package com.qmate.exception.custom.notification;
+
+import com.qmate.exception.BusinessGlobalException;
+import com.qmate.exception.errorcode.NotificationErrorCode;
+
+public class NotificationNotFoundException extends BusinessGlobalException {
+
+  public NotificationNotFoundException() {
+    super(NotificationErrorCode.notificationNotFound());
+  }
+
+}

--- a/back/src/main/java/com/qmate/exception/errorcode/NotificationErrorCode.java
+++ b/back/src/main/java/com/qmate/exception/errorcode/NotificationErrorCode.java
@@ -1,0 +1,22 @@
+package com.qmate.exception.errorcode;
+
+import com.qmate.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class NotificationErrorCode extends ErrorCode {
+
+  // message
+  public static final String NOTIFICATION_NOT_FOUND_MESSAGE = "알림이 존재하지 않습니다.";
+
+  // error code
+  public static final String NOTIFICATION_NOT_FOUND_ERROR_CODE = "NOTIFICATION-001";
+
+  // instances
+  public static ErrorCode notificationNotFound() {
+    return new NotificationErrorCode(HttpStatus.NOT_FOUND, NOTIFICATION_NOT_FOUND_ERROR_CODE, NOTIFICATION_NOT_FOUND_MESSAGE);
+  }
+
+  private NotificationErrorCode(HttpStatus httpStatus, String code, String message) {
+    super(httpStatus, code, message);
+  }
+}

--- a/back/src/test/java/com/qmate/domain/notification/repository/NotificationRepositoryTest.java
+++ b/back/src/test/java/com/qmate/domain/notification/repository/NotificationRepositoryTest.java
@@ -1,0 +1,113 @@
+package com.qmate.domain.notification.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.qmate.config.JpaConfig;
+import com.qmate.config.QuerydslConfig;
+import com.qmate.domain.notification.entity.Notification;
+import com.qmate.domain.notification.entity.NotificationCategory;
+import com.qmate.domain.notification.entity.NotificationCode;
+import com.qmate.domain.notification.entity.NotificationResourceType;
+import com.qmate.domain.notification.repository.NotificationRepository;
+import com.qmate.domain.user.User;
+import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@DataJpaTest
+@Import({JpaConfig.class, QuerydslConfig.class})
+@Tag("local")
+class NotificationRepositoryTest {
+
+  @Autowired
+  EntityManager em;
+  @Autowired
+  NotificationRepository notificationRepository;
+
+  private User saveUser(Long currentMatchId) {
+    User u = new User();
+    u.setEmail("test@test.com");
+    u.setNickname("nick");
+    u.setCurrentMatchId(currentMatchId);
+    em.persist(u);
+    return u;
+  }
+
+  private Notification saveNotif(Long userId, Long matchId, boolean read,
+      NotificationCategory cat, NotificationCode code) {
+    Notification n = Notification.builder()
+        .userId(userId)
+        .matchId(matchId)
+        .category(cat)
+        .code(code)
+        .listTitle("list")
+        .pushTitle("push")
+        .resourceType(NotificationResourceType.NONE)
+        .resourceId(null)
+        .readAt(read ? LocalDateTime.now() : null)
+        .build();
+    em.persist(n);
+    return n;
+  }
+
+  @Test
+  @DisplayName("현재 매치이거나 매치 없음 → 상세 조회 가능")
+  void findAuthorizedDetail_matchesCurrentOrNull_returnsPresent() {
+    // given
+    User u = saveUser(10L);
+    Notification n1 = saveNotif(u.getId(), 10L, false, NotificationCategory.QUESTION, NotificationCode.QI_REMINDER);
+    Notification n2 = saveNotif(u.getId(), null, false, NotificationCategory.EVENT, NotificationCode.EVENT_SAME_DAY);
+    em.flush(); em.clear();
+
+    // when
+    var ok1 = notificationRepository.findAuthorizedDetail(u.getId(), n1.getId());
+    var ok2 = notificationRepository.findAuthorizedDetail(u.getId(), n2.getId());
+
+    // then
+    assertThat(ok1).isPresent();
+    assertThat(ok2).isPresent();
+  }
+
+  @Test
+  @DisplayName("unread/category/code 필터가 올바르게 적용된다")
+  void findAuthorizedList_appliesUnreadCategoryAndCodeFilters() {
+    // given
+    User u = saveUser(10L);
+    saveNotif(u.getId(), 10L, false, NotificationCategory.QUESTION, NotificationCode.QI_TODAY_READY);
+    saveNotif(u.getId(), 10L, true,  NotificationCategory.QUESTION, NotificationCode.QI_TODAY_READY);
+    saveNotif(u.getId(), 99L, false, NotificationCategory.QUESTION, NotificationCode.QI_TODAY_READY); // 다른 매치 → 제외
+    em.flush(); em.clear();
+
+    // when
+    var page = notificationRepository.findAuthorizedList(
+        u.getId(), NotificationCategory.QUESTION, NotificationCode.QI_TODAY_READY, true,
+        org.springframework.data.domain.PageRequest.of(0, 20));
+
+    // then
+    assertThat(page.getTotalElements()).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("미읽음 개수는 현재 매치 기준으로만 집계된다")
+  void countAuthorizedUnread_countsOnlyForCurrentMatch() {
+    // given
+    User u = saveUser(10L);
+    saveNotif(u.getId(), 10L, false, NotificationCategory.EVENT, NotificationCode.EVENT_SAME_DAY);
+    saveNotif(u.getId(), 10L, true,  NotificationCategory.EVENT, NotificationCode.EVENT_SAME_DAY);
+    saveNotif(u.getId(), 99L, false, NotificationCategory.EVENT, NotificationCode.EVENT_SAME_DAY); // 제외
+    em.flush(); em.clear();
+
+    // when
+    long cnt = notificationRepository.countAuthorizedUnread(u.getId());
+
+    // then
+    assertThat(cnt).isEqualTo(1);
+  }
+}

--- a/back/src/test/java/com/qmate/domain/notification/service/NotificationServiceTest.java
+++ b/back/src/test/java/com/qmate/domain/notification/service/NotificationServiceTest.java
@@ -1,0 +1,49 @@
+package com.qmate.domain.notification.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import com.qmate.domain.notification.entity.Notification;
+import com.qmate.domain.notification.entity.NotificationCategory;
+import com.qmate.domain.notification.entity.NotificationCode;
+import com.qmate.domain.notification.entity.NotificationResourceType;
+import com.qmate.domain.notification.model.response.NotificationResponse;
+import com.qmate.domain.notification.repository.NotificationRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceTest {
+
+  @Mock
+  NotificationRepository repo;
+  @InjectMocks
+  NotificationService service;
+
+  @Test
+  @DisplayName("상세 조회 시 미읽음이면 읽음 처리된다")
+  void getDetail_marksAsRead() {
+    // given
+    Notification n = Notification.builder()
+        .userId(1L)
+        .matchId(10L)
+        .category(NotificationCategory.QUESTION)
+        .code(NotificationCode.QI_TODAY_READY)
+        .listTitle("list")
+        .pushTitle("push")
+        .resourceType(NotificationResourceType.NONE)
+        .build();
+    given(repo.findAuthorizedDetail(1L, 100L)).willReturn(Optional.of(n));
+
+    // when
+    NotificationResponse res = service.getDetail(1L, 100L);
+
+    // then
+    assertThat(res.getReadAt()).isNotNull(); // 읽음 처리 반영
+  }
+}


### PR DESCRIPTION
## 개요
알림 도메인 기반으로 상세 조회(읽음 처리 포함), 리스트 조회(필터/페이지), 미읽음 카운트 API를 추가했습니다. 문서 상수도 정리했습니다.

## 변경 사항
- 도메인/엔티티
  - notification: userId, matchId, category, code, listTitle, pushTitle, resourceType, resourceId, readAt, createdAt, updatedAt
  - enum: NotificationCategory(QUESTION, EVENT), NotificationCode(QI_TODAY_READY, QI_REMINDER, QI_COMPLETED, EVENT_SAME_DAY, EVENT_THREE_DAY_BEFORE, EVENT_WEEK_BEFORE), NotificationResourceType
- 레포지토리
  - findAuthorizedDetail(userId, notificationId): (n.matchId is null or u.currentMatchId = n.matchId) 권한 조건
  - findAuthorizedList(userId, category?, code?, unread?, pageable): 동일 권한 + 필터/페이지
  - countAuthorizedUnread(userId): 동일 권한 + 미읽음 집계
- 서비스
  - getDetail(userId, notificationId): 상세 조회 + 미읽음 시 readAt 설정(멱등)
  - getList(userId, category?, code?, unread?, pageable): createdAt desc 고정 정렬 반환
  - getUnreadCount(userId): 미읽음 개수 반환
- 컨트롤러
  - GET /api/notifications/{notificationId}: 상세 조회(읽음 처리)
  - GET /api/notifications: 리스트 조회(category, code, unread 필터; pageable, sort 무시)
  - GET /api/notifications/unread-count: 미읽음 개수
  - Swagger: SecurityRequirement(bearerAuth), Tag/Operation 적용
- DTO
  - NotificationListItem: notificationId, category, code, listTitle, createdAt, read(boolean)
  - NotificationResponse: 상세 응답(UpdatedAt 제외)
- 문서 상수(NotificationConstants)
  - 상세/리스트/미읽음 카운트 설명 상수 추가
  - 코드 설명은 표 대신 목록으로 분리

## 테스트
- Repository: 상세 권한 조건, 리스트 필터(unread/category/code), 미읽음 카운트(현재 매치 기준) 검증
- Service: 상세 조회 시 읽음 처리 검증
