### PR TITLE
Feature/auth logout

### DIFF
--- a/back/src/main/java/com/qmate/api/AuthController.java
+++ b/back/src/main/java/com/qmate/api/AuthController.java
@@ -12,12 +12,15 @@ import com.qmate.exception.custom.auth.OkTokenInvalidException;
 import com.qmate.security.UserPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -59,6 +62,13 @@ public class AuthController {
   public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest request){
     LoginResponse tokens = authService.login(request.getEmail(), request.getPassword());
     return ResponseEntity.ok(tokens);
+  }
+
+  @PostMapping("/logout")
+  @Operation(summary="로그아웃", description=AuthConstants.LOGOUT_MD)
+  public ResponseEntity<Void> logout(HttpServletRequest req, HttpServletResponse res, Authentication auth) {
+    authService.logout(req, res, auth);
+    return ResponseEntity.noContent().build();
   }
 
   //@PreAuthorize("hasRole('ADMIN')")

--- a/back/src/main/java/com/qmate/common/constants/auth/AuthConstants.java
+++ b/back/src/main/java/com/qmate/common/constants/auth/AuthConstants.java
@@ -28,4 +28,16 @@ public class AuthConstants {
       + "|-----:|-----------|---------|\n"
       + "| " + HttpStatusCode.UNAUTHORIZED + " | " + AuthErrorCode.INVALID_CREDENTIALS_CODE + " | "
       + AuthErrorCode.INVALID_CREDENTIALS_MESSAGE + " |\n";
+
+  public static final String LOGOUT_MD =
+    "로그아웃을 수행합니다.\n\n"
+      + "### 동작\n"
+      + "- 서버: 인증 컨텍스트를 정리하고 204 No Content를 반환합니다.\n"
+      + "- 클라이언트: 저장된 액세스/리프레시 토큰을 삭제합니다.\n\n"
+      + "### 응답\n"
+      + "- 204 No Content: 로그아웃 성공\n\n"
+      + "### 에러 응답\n"
+      + "| HTTP | errorCode | message |\n"
+      + "|-----:|-----------|---------|\n"
+      + "| 401 | UNAUTHORIZED | 인증되지 않은 요청입니다. |\n";
 }

--- a/back/src/main/java/com/qmate/domain/auth/AuthService.java
+++ b/back/src/main/java/com/qmate/domain/auth/AuthService.java
@@ -4,9 +4,13 @@ import com.qmate.domain.user.User;
 import com.qmate.domain.user.UserRepository;
 import com.qmate.domain.auth.model.response.LoginResponse;
 import com.qmate.exception.custom.auth.InvalidCredentialsException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
 import org.springframework.stereotype.Service;
 
 
@@ -16,6 +20,7 @@ public class AuthService {
   private final UserRepository userRepository;
   private final PasswordEncoder passwordEncoder;
   private final JwtService jwtService;
+  private final SecurityContextLogoutHandler delegate = new SecurityContextLogoutHandler();
 
 
   public LoginResponse login(String email, String rawPassword) {
@@ -45,5 +50,9 @@ public class AuthService {
         .refreshTokenExpiresIn(pair.getRefreshTokenTtlSeconds())
         .user(summary)
         .build();
+  }
+
+  public void logout(HttpServletRequest req, HttpServletResponse res, Authentication auth) {
+    delegate.logout(req, res, auth); // 세션 쓰지 않으면 컨텍스트 클리어만 수행
   }
 }

--- a/back/src/main/java/com/qmate/domain/auth/AuthService.java
+++ b/back/src/main/java/com/qmate/domain/auth/AuthService.java
@@ -7,7 +7,6 @@ import com.qmate.exception.custom.auth.InvalidCredentialsException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
@@ -53,6 +52,6 @@ public class AuthService {
   }
 
   public void logout(HttpServletRequest req, HttpServletResponse res, Authentication auth) {
-    delegate.logout(req, res, auth); // 세션 쓰지 않으면 컨텍스트 클리어만 수행
+    delegate.logout(req, res, auth);
   }
 }


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

- JWT(stateless) 구조에서 서버 측 로그아웃 엔드포인트 부재
- 로그아웃 정책/흐름이 문서화되지 않음(Swagger 미노출).
- 향후 블랙리스트, 토큰 버전 증가(강제 로그아웃), RT 폐기, IdP 로그아웃 등 확장 지점 없음.

**TO-BE**

- POST /auth/logout 추가
- AuthController.logout() → AuthService.logout() 위임 → SecurityContextLogoutHandler로 컨텍스트 정리(세션 존재 시 invalidate).
- 응답: 204 No Content (idempotent).
- Swagger 문서 추가
- AuthConstants.LOGOUT_MD 작성
- 로그아웃 동작/응답을 문서로 안내(클라이언트는 저장된 토큰 삭제해야 함).

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- API 테스트 - 204 No Content 반환까지 확인. 액세스 토큰을 서버에서 죽일 수 없어서 토큰 무력화는 테스트하지 못함.