### PR TITLE
refactor:스웨거 오류 통일 안 수정

### DIFF
--- a/back/src/main/java/com/qmate/api/InviteController.java
+++ b/back/src/main/java/com/qmate/api/InviteController.java
@@ -1,5 +1,6 @@
 package com.qmate.api;
 
+import com.qmate.common.constants.match.MatchConstants;
 import com.qmate.domain.match.model.request.InviteCodeValidationRequest;
 import com.qmate.domain.match.model.response.InviteCodeValidationResponse;
 import com.qmate.domain.match.service.MatchService;
@@ -24,7 +25,7 @@ public class InviteController {
   @PostMapping("/validate")
   @Operation(
       summary = "초대코드 유효성 검증",
-      description = "발급받은 초대코드의 유효한지 및 파트너 닉네임 리턴"
+      description = MatchConstants.VALIDATE_INVITE_CODE_MD
   )
   public ResponseEntity<InviteCodeValidationResponse> validateInviteCode(
       @RequestBody @Valid InviteCodeValidationRequest request

--- a/back/src/main/java/com/qmate/api/MatchController.java
+++ b/back/src/main/java/com/qmate/api/MatchController.java
@@ -169,7 +169,7 @@ public class MatchController {
   @GetMapping("/lock-status")
   @Operation(
       summary = "잠금 상태 조회",
-      description = "초대코드 입력 횟수 초과시 조회 잠금 상태 조회"
+      description = MatchConstants.GET_LOCK_STATUS_MD
   )
   public ResponseEntity<LockStatusResponse> getLockStatus(
       @AuthenticationPrincipal UserPrincipal principal

--- a/back/src/main/java/com/qmate/common/constants/match/MatchConstants.java
+++ b/back/src/main/java/com/qmate/common/constants/match/MatchConstants.java
@@ -1,8 +1,10 @@
 package com.qmate.common.constants.match;
 
 import com.qmate.common.constants.HttpStatusCode;
+import com.qmate.domain.user.User;
 import com.qmate.exception.CommonErrorCode;
 import com.qmate.exception.MatchErrorCode;
+import com.qmate.exception.UserErrorCode;
 
 public class MatchConstants {
 
@@ -22,6 +24,7 @@ public class MatchConstants {
   public static final String DISCONNECT_SUCCESS_MESSAGE = "매칭 연결 끊기 요청이 처리되었습니다. 2주 후에 데이터가 삭제됩니다.";
   public static final String RESTORE_SUCCESS_MESSAGE = "매칭이 성공적으로 복구되었습니다.";
   public static final String RESTORE_AGREED_AWAITING_PARTNER_MESSAGE = "복구에 동의했습니다. 상대방의 동의를 기다려주세요.";
+
   private static final String ERROR_RESPONSE_HEADER =
 
       "\n\n### 에러 응답\n\n"
@@ -33,14 +36,18 @@ public class MatchConstants {
   public static final String CREATE_MATCH_MD =
       "사용자가 관계 유형(친구/연인)을 선택하여 새로운 매칭을 생성하고, 12시간 동안 유효한 초대 코드를 발급받습니다."
           + ERROR_RESPONSE_HEADER
+          + "| " + HttpStatusCode.BAD_REQUEST + " | " + UserErrorCode.USER_NOT_FOUND_ERROR_CODE + " | " + UserErrorCode.USER_NOT_FOUND_MESSAGE + " |\n"
           + "| " + HttpStatusCode.BAD_REQUEST + " | " + MatchErrorCode.INVALID_START_DATE_FOR_COUPLE_ERROR_CODE + " | " + MatchErrorCode.INVALID_START_DATE_FOR_COUPLE_MESSAGE + " |\n"
           + "| " + HttpStatusCode.CONFLICT + " | " + MatchErrorCode.ALREADY_IN_MATCH_ERROR_CODE + " | " + MatchErrorCode.ALREADY_IN_MATCH_MESSAGE + " |\n";
 
   public static final String JOIN_MATCH_MD =
       "초대 코드를 사용하여 기존 매칭에 참여합니다. 매칭이 성사되면 `User`의 `current_match_id`가 업데이트되고, Redis의 초대 코드는 삭제됩니다."
           + ERROR_RESPONSE_HEADER
+          + "| " + HttpStatusCode.BAD_REQUEST + " | " + UserErrorCode.USER_NOT_FOUND_ERROR_CODE + " | " + UserErrorCode.USER_NOT_FOUND_MESSAGE + " |\n"
           + "| " + HttpStatusCode.BAD_REQUEST + " | " + MatchErrorCode.INVITE_CODE_EXPIRED_ERROR_CODE + " | " + MatchErrorCode.INVITE_CODE_EXPIRED_MESSAGE + " |\n"
-          + "| " + HttpStatusCode.FORBIDDEN + " | " + MatchErrorCode.INVITE_ATTEMPT_LOCKED_ERROR_CODE + " | " + MatchErrorCode.INVITE_ATTEMPT_LOCKED_MESSAGE + " |\n"
+          + "| " + HttpStatusCode.BAD_REQUEST + " | " + MatchErrorCode.CANNOT_MATCH_WITH_SELF_ERROR_CODE + " | " + MatchErrorCode.CANNOT_MATCH_WITH_SELF_MESSAGE + " |\n"
+          + "| " + HttpStatusCode.FORBIDDEN + " | " + MatchErrorCode.INVITE_ATTEMPT_LOCKED_ERROR_CODE + " | " +  MatchErrorCode.INVITE_ATTEMPT_LOCKED_MESSAGE + " |\n"
+          + "| " + HttpStatusCode.NOT_FOUND + " | " + MatchErrorCode.MATCH_NOT_FOUND_ERROR_CODE + " | " + MatchErrorCode.MATCH_NOT_FOUND_MESSAGE + " |\n"
           + "| " + HttpStatusCode.CONFLICT + " | " + MatchErrorCode.ALREADY_IN_MATCH_ERROR_CODE + " | " + MatchErrorCode.ALREADY_IN_MATCH_MESSAGE + " |\n";
 
   public static final String GET_MATCH_INFO_MD =
@@ -75,6 +82,18 @@ public class MatchConstants {
           + "| " + HttpStatusCode.FORBIDDEN + " | " + MatchErrorCode.MATCH_FORBIDDEN_ERROR_CODE + " | " + MatchErrorCode.MATCH_FORBIDDEN_MESSAGE + " |\n"
           + "| " + HttpStatusCode.CONFLICT + " | " + MatchErrorCode.MATCH_STATE_CONFLICT_ERROR_CODE + " | " + MatchErrorCode.MATCH_STATE_CONFLICT_MESSAGE + " |\n"
           + "| " + HttpStatusCode.CONFLICT + " | " + MatchErrorCode.MATCH_RECOVERY_EXPIRED_ERROR_CODE + " | " + MatchErrorCode.MATCH_RECOVERY_EXPIRED_MESSAGE + " |\n";
+
+  public static final String VALIDATE_INVITE_CODE_MD =
+      "사용자가 매칭에 참여하기 전에, 초대 코드의 유효성과 상대방의 닉네임을 미리 확인합니다."
+          + ERROR_RESPONSE_HEADER
+          + "| " + HttpStatusCode.BAD_REQUEST + " | " + MatchErrorCode.INVITE_CODE_EXPIRED_ERROR_CODE + " | " + MatchErrorCode.INVITE_CODE_EXPIRED_MESSAGE + " |\n"
+          + "| " + HttpStatusCode.NOT_FOUND + " | " + MatchErrorCode.MATCH_NOT_FOUND_ERROR_CODE + " | " + MatchErrorCode.MATCH_NOT_FOUND_MESSAGE + " |\n"
+          + "| " + HttpStatusCode.INTERNAL_SERVER_ERROR + " | " + CommonErrorCode.INTERNAL_SERVER_ERROR_CODE + " | " + CommonErrorCode.INTERNAL_SERVER_ERROR_CODE + " |\n";
+
+  public static final String GET_LOCK_STATUS_MD =
+      "초대 코드 입력 5회 실패로 계정이 잠겼을 경우, 남은 잠금 시간을 조회합니다."
+          + ERROR_RESPONSE_HEADER
+          + "| " + HttpStatusCode.UNAUTHORIZED + " | " + CommonErrorCode.UNAUTHORIZED_ERROR_CODE + " | " + CommonErrorCode.UNAUTHORIZED_MESSAGE + " |\n";
 
   public static final String GET_DETACHED_STATUS_MD =
       "로그인한 사용자가 복구 가능한 '연결 끊김' 상태의 매칭이 있는지 조회합니다."

--- a/back/src/main/java/com/qmate/exception/UserErrorCode.java
+++ b/back/src/main/java/com/qmate/exception/UserErrorCode.java
@@ -6,13 +6,19 @@ import org.springframework.http.HttpStatus;
 @Getter
 public class UserErrorCode extends ErrorCode {
 
+  //에러 메시지 코드 상수
   public static final String USER_NOT_FOUND_MESSAGE = "해당 사용자를 찾을 수 없습니다.";
+
+  //에러 코드 상수
+  public static final String USER_NOT_FOUND_ERROR_CODE = "USER_001";
+
 
   //에러 코드 객체 반환 메서드
   public static ErrorCode userNotFound() {
-    return new UserErrorCode(HttpStatus.NOT_FOUND, "USER_001", USER_NOT_FOUND_MESSAGE);
+    return new UserErrorCode(HttpStatus.NOT_FOUND, USER_NOT_FOUND_ERROR_CODE, USER_NOT_FOUND_MESSAGE);
 
   }
+
 
   private UserErrorCode(HttpStatus httpStatus, String code, String message) {
     super(httpStatus, code, message);


### PR DESCRIPTION
개요
팀의 API 문서 표준을 준수하기 위해, 기존에 구현된 모든 API의 Swagger/OpenAPI 문서를 통일된 형식으로 리팩토링하였으나, 문서 중 에러 처리 사항 중 빠진 예외사항 있어 추가.

변경 사항
MatchConstants.java :
JOIN_MATCH_MD 메소드 안에 USER_NOT_FOUND_ERROR_CODE 등 2개의 예외 추가.
VALIDATE_INVITE_CODE_MD 메소드 (BAD_REQUEST,NOT_FOUND, INTERNAL_SERVER_ERROR) 작성.
GET_LOCK_STATUS_MD 메소드 (UNAUTHORIZED) 추가
3. UserErrorCode 수정
MatchConstants에서 에러 코드와 메시지를 쉽게 참조할 수 있도록, UserErrorCode와 CommonErrorCode에 각 에러의 코드(USER_001)와 메시지("...")를 public static final String 상수로 노출하도록 수정했습니다.
테스트
 애플리케이션을 재실행하여, Swagger UI (/swagger-ui.html) 페이지가 오류 없이 정상적으로 렌더링되고, 모든 API 설명이 의도한 대로 표 형식으로 잘 보이는지 확인했습니다.
 (문서 관련 리팩토링이므로, 별도의 기능 테스트 코드는 추가되지 않았습니다.)