### PR TITLE
feat: 웹푸시 도입 + 관리자 알림 테스트 API

### DIFF
--- a/back/build.gradle
+++ b/back/build.gradle
@@ -54,6 +54,11 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
     runtimeOnly 'com.h2database:h2' // doc 프로필에서 메모리 DB로만 띄우기 위함
 
+    // web push
+    implementation 'nl.martijndwars:web-push:5.1.1'
+    implementation 'org.bouncycastle:bcprov-jdk18on:1.78.1'
+    implementation 'org.bouncycastle:bcpkix-jdk18on:1.78.1'
+
     // test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/back/src/main/java/com/qmate/api/admin/notification/AdminNotificationTestController.java
+++ b/back/src/main/java/com/qmate/api/admin/notification/AdminNotificationTestController.java
@@ -1,0 +1,43 @@
+package com.qmate.api.admin.notification;
+
+import com.qmate.common.push.PushSender;
+import com.qmate.domain.notification.entity.Notification;
+import com.qmate.domain.notification.entity.NotificationResourceType;
+import com.qmate.domain.notification.repository.NotificationRepository;
+import jakarta.validation.Valid;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/admin/notifications")
+@RequiredArgsConstructor
+public class AdminNotificationTestController {
+
+    private final NotificationRepository notificationRepository;
+    private final PushSender pushSender;
+
+    @PostMapping("/test")
+    @ResponseStatus(HttpStatus.CREATED)
+    public Map<String, Object> createAndSend(@Valid @RequestBody AdminNotificationTestRequest req) {
+        log.warn("AdminNotificationTestController.createAndSend: userId={}, category={}, code={}",
+                req.userId(), req.category(), req.code());
+        Notification notification = Notification.builder()
+                .userId(req.userId())
+                .category(req.category())
+                .code(req.code())
+                .pushTitle(req.pushTitle())
+                .listTitle(req.listTitle())
+                .resourceType(NotificationResourceType.NONE)
+                .build();
+
+        Notification saved = notificationRepository.save(notification);
+        // 호출 측에서 푸시 설정 ON이라고 가정 → 바로 전송
+        pushSender.send(saved);
+
+        return Map.of("notificationId", saved.getId());
+    }
+}

--- a/back/src/main/java/com/qmate/api/admin/notification/AdminNotificationTestRequest.java
+++ b/back/src/main/java/com/qmate/api/admin/notification/AdminNotificationTestRequest.java
@@ -1,0 +1,14 @@
+package com.qmate.api.admin.notification;
+
+import com.qmate.domain.notification.entity.NotificationCategory;
+import com.qmate.domain.notification.entity.NotificationCode;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record AdminNotificationTestRequest(
+        @NotNull Long userId,
+        @NotNull NotificationCategory category,
+        @NotNull NotificationCode code,
+        @NotBlank String pushTitle,
+        @NotBlank String listTitle
+) {}

--- a/back/src/main/java/com/qmate/common/push/NoopPushSender.java
+++ b/back/src/main/java/com/qmate/common/push/NoopPushSender.java
@@ -1,0 +1,12 @@
+package com.qmate.common.push;
+
+import com.qmate.domain.notification.entity.Notification;
+
+public class NoopPushSender implements PushSender {
+
+  @Override
+  public void send(Notification notification) {
+    // No operation performed
+  }
+
+}

--- a/back/src/main/java/com/qmate/common/push/PushSender.java
+++ b/back/src/main/java/com/qmate/common/push/PushSender.java
@@ -1,0 +1,10 @@
+package com.qmate.common.push;
+
+import com.qmate.domain.notification.entity.Notification;
+
+/**
+ * Notification만 받아 내부에서 모든 전송 절차(설정 확인, 구독 조회/폐기, 전송)를 수행한다.
+ */
+public interface PushSender {
+  void send(Notification notification);
+}

--- a/back/src/main/java/com/qmate/common/push/WebPushSender.java
+++ b/back/src/main/java/com/qmate/common/push/WebPushSender.java
@@ -1,0 +1,84 @@
+package com.qmate.common.push;
+
+import com.qmate.domain.notification.entity.Notification;
+import com.qmate.domain.notification.entity.PushSubscription;
+import com.qmate.domain.notification.repository.PushSubscriptionRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import nl.martijndwars.webpush.PushService;
+import nl.martijndwars.webpush.Subscription;
+import org.apache.http.HttpResponse;
+
+/**
+ * - Notification만 받아서:
+ * 1) userId 기반 구독 전부 조회
+ * 2) 각 구독에 최소 페이로드(title, notificationId) 전송
+ * 3) 404/410 응답 시 해당 구독 즉시 폐기
+ * - 푸시 설정 OFF 여부 체크는 호출 측에서 수행
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class WebPushSender implements PushSender {
+
+  private final PushService pushService;
+  private final PushSubscriptionRepository pushSubscriptionRepository;
+
+  @Override
+  public void send(Notification notification) {
+    if (notification == null) {
+      return;
+    }
+
+    final Long userId = notification.getUserId();
+    final Long notificationId = notification.getId();
+
+    // 1) 구독 조회
+    List<PushSubscription> subs = pushSubscriptionRepository.findAllByUserId(userId);
+    if (subs.isEmpty()) {
+      log.debug("[notification:{}] user:{} no subscriptions → skip", notificationId, userId);
+      return;
+    }
+
+    // 2) 최소 페이로드(title, notificationId)
+    final String payload = minimalPayload(notification.getPushTitle(), notificationId);
+
+    // 3) 각 구독에 전송 (개별 실패 허용, 404/410은 구독 삭제)
+    for (PushSubscription sub : subs) {
+      try {
+        Subscription.Keys keys = new Subscription.Keys(sub.getKeyP256dh(), sub.getKeyAuth());
+        Subscription subscription = new Subscription(sub.getEndpoint(), keys);
+
+        // 클래스명 중복 때문에 nl.martijndwars.webpush.Notification 임에 주의
+        HttpResponse resp = pushService.send(new nl.martijndwars.webpush.Notification(subscription, payload));
+
+        int status = resp.getStatusLine().getStatusCode();
+
+        if (status == 404 || status == 410) {
+          // 사용 불가 구독 폐기
+          pushSubscriptionRepository.delete(sub);
+          log.info("Deleted invalid subscription. user={} subId={} status={}",
+              userId, sub.getId(), status);
+        } else if (status < 200 || status >= 300) {
+          log.warn("Non-2xx push response. user={} subId={} status={}",
+              userId, sub.getId(), status);
+        }
+      } catch (Exception e) {
+        log.error("Push send failed. user={} subId={} notif={}",
+            userId, sub.getId(), notificationId, e);
+      }
+    }
+  }
+
+  private String minimalPayload(String title, Long notificationId) {
+    return "{\"title\":\"" + escape(title) + "\",\"notificationId\":" + notificationId + "}";
+  }
+
+  private String escape(String s) {
+    if (s == null) {
+      return "";
+    }
+    return s.replace("\\", "\\\\").replace("\"", "\\\"");
+  }
+
+}

--- a/back/src/main/java/com/qmate/config/WebPushConfig.java
+++ b/back/src/main/java/com/qmate/config/WebPushConfig.java
@@ -1,0 +1,59 @@
+package com.qmate.config;
+
+import com.qmate.common.push.NoopPushSender;
+import com.qmate.common.push.PushSender;
+import com.qmate.common.push.WebPushSender;
+import com.qmate.domain.notification.repository.PushSubscriptionRepository;
+import java.security.KeyPair;
+import java.security.Security;
+import java.security.interfaces.ECPrivateKey;
+import java.security.interfaces.ECPublicKey;
+import lombok.extern.slf4j.Slf4j;
+import nl.martijndwars.webpush.PushService;
+import nl.martijndwars.webpush.Utils;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Slf4j
+@Configuration
+public class WebPushConfig {
+
+  @Value("${webpush.vapid.subject}")
+  private String subject;
+
+  @Value("${webpush.vapid.public-key}")
+  private String publicKey;
+
+  @Value("${webpush.vapid.private-key}")
+  private String privateKey;
+
+  @Bean
+  public PushSender pushSender(PushSubscriptionRepository pushSubscriptionRepository) {
+    KeyPair keyPair = null;
+    if (privateKey.isEmpty()) {
+      log.warn("VAPID keys are not configured, WebPushSender will not be created.");
+      return new NoopPushSender();
+    }
+    if (Security.getProvider("BC") == null) {
+      Security.addProvider(new BouncyCastleProvider());
+    }
+    log.info("private key : {}", privateKey);
+    log.info("public key : {}", publicKey);
+    try {
+      keyPair = new KeyPair(
+          Utils.loadPublicKey(publicKey),
+          Utils.loadPrivateKey(privateKey)
+      );
+    } catch (Exception e) {
+      log.error("Failed to load VAPID keys", e);
+      throw new RuntimeException("Failed to load VAPID keys", e);
+    }
+    PushService service = new PushService();
+    service.setSubject(subject);
+    service.setPublicKey(keyPair.getPublic());
+    service.setPrivateKey(keyPair.getPrivate());
+    return new WebPushSender(service, pushSubscriptionRepository);
+  }
+}

--- a/back/src/main/java/com/qmate/domain/notification/repository/PushSubscriptionRepository.java
+++ b/back/src/main/java/com/qmate/domain/notification/repository/PushSubscriptionRepository.java
@@ -1,9 +1,12 @@
 package com.qmate.domain.notification.repository;
 
 import com.qmate.domain.notification.entity.PushSubscription;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PushSubscriptionRepository extends JpaRepository<PushSubscription, Long> {
   Optional<PushSubscription> findByEndpointHash(byte[] endpointHash);
+
+  List<PushSubscription> findAllByUserId(Long userId);
 }

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -8,4 +8,6 @@ spring:
 
 webpush:
   vapid:
+    subject: "mailto:demo@demo.com" # 배포 단계에서 적절한 이메일로 변경
     public-key: BAyiTTiiEObOVfRK-VgIztsE5tgtNs-J84ZsIqxb1AHyC2ubQhidiJijmGi48PKL-AYiMRIfhM3U-JqWZHSlJ0I
+    private-key: ${VAPID_PRIVATE_KEY:}


### PR DESCRIPTION
## 요약
- Web Push 인프라 도입 (VAPID 기반)
- PushSender(WebPush/Noop) 빈 구성
- 관리자 테스트 API 추가: 알림 엔티티 생성 후 즉시 전송

## 주요 변경
- build: web-push 및 (필요 시) BouncyCastle 의존성 추가
- config: WebPushConfig (VAPID 키 미구성 시 Noop으로 안전 동작)
- common: PushSender 인터페이스, WebPushSender/NoopPushSender 구현
- api(admin): /api/admin/notifications/test 엔드포인트

## 사용 방법
1) 환경변수
   - `webpush.vapid.subject`
   - `webpush.vapid.public-key`
   - `webpush.vapid.private-key`
2) 관리자 API 호출
   - POST `/api/admin/notifications/test`
   - body: `{ userId, category, code, pushTitle, listTitle }` (category/code는 enum)
3) 푸시 설정 OFF 사용자는 전송 스킵 (알림 저장은 수행)