### PR TITLE
Feature/start deleting

### DIFF
--- a/back/src/main/java/com/qmate/api/MatchController.java
+++ b/back/src/main/java/com/qmate/api/MatchController.java
@@ -196,10 +196,10 @@ public class MatchController {
 //    matchService.disconnectInactiveMatches();
 //    return ResponseEntity.ok("비활성 매칭 체크 스케줄러를 수동으로 실행했습니다.");
 //  }
-  //자동 delete모드 스케줄링 테스트 코드
-  @PostMapping("/run-finalize-check")
-  public ResponseEntity<String> runFinalizeCheck() {
-    matchService.finalizeExpiredMatches();
-    return ResponseEntity.ok("유예기간 만료 매칭 정리 스케줄러를 수동으로 실행했습니다.");
-  }
+// 자동 delete모드 스케줄링 테스트 코드
+//  @PostMapping("/run-finalize-check")
+//  public ResponseEntity<String> runFinalizeCheck() {
+//    matchService.finalizeExpiredMatches();
+//    return ResponseEntity.ok("유예기간 만료 매칭 정리 스케줄러를 수동으로 실행했습니다.");
+//  }
 }

--- a/back/src/main/java/com/qmate/api/MatchController.java
+++ b/back/src/main/java/com/qmate/api/MatchController.java
@@ -196,5 +196,10 @@ public class MatchController {
 //    matchService.disconnectInactiveMatches();
 //    return ResponseEntity.ok("비활성 매칭 체크 스케줄러를 수동으로 실행했습니다.");
 //  }
-
+  //자동 delete모드 스케줄링 테스트 코드
+  @PostMapping("/run-finalize-check")
+  public ResponseEntity<String> runFinalizeCheck() {
+    matchService.finalizeExpiredMatches();
+    return ResponseEntity.ok("유예기간 만료 매칭 정리 스케줄러를 수동으로 실행했습니다.");
+  }
 }

--- a/back/src/main/java/com/qmate/common/scheduler/match/MatchScheduler.java
+++ b/back/src/main/java/com/qmate/common/scheduler/match/MatchScheduler.java
@@ -24,5 +24,17 @@ public class MatchScheduler {
       log.error("비활성 매칭 자동 연결 끊기 작업 중 오류가 발생했습니다.", e);
     }
   }
+  //매일 자정 0시 0분 0초에 복구 기간 만료된 매칭을 확인
+  @Scheduled(cron = "0 0 0 * * *")
+  public void runFinalizeExpiredMatches(){
+    log.info("복구 기간 만료된 매칭 데이터 정리 작업을 시작합니다...");
+    try {
+      matchService.finalizeExpiredMatches();
+      log.info("복구 기간 만료된 매칭 데이터 정리 작업을 성공적으로 완료했습니다.");
+    } catch (Exception e) {
+      log.error("복구 기간 만료된 매칭 데이터 정리 작업 중 오류가 발생했습니다.", e);
+    }
+
+  }
 
 }

--- a/back/src/main/java/com/qmate/domain/match/Match.java
+++ b/back/src/main/java/com/qmate/domain/match/Match.java
@@ -114,6 +114,12 @@ public class Match {
     return false;
   }
 
+  // 상태 값 삭제로 변경 및 detachedAt 업데이트
+  public void markAsDeleted(){
+    this.status = MatchStatus.BROKEN;
+    this.deletedAt = LocalDateTime.now();
+  }
+
 
   //정적 팩토리 메서드 추가
   public static Match create(RelationType relationType, LocalDateTime startDate) {

--- a/back/src/main/java/com/qmate/domain/match/MatchStatus.java
+++ b/back/src/main/java/com/qmate/domain/match/MatchStatus.java
@@ -4,5 +4,5 @@ public enum MatchStatus {
   WAITING,
   ACTIVE,
   DETACHED_PENDING_DELETE,
-  DELETED
+  BROKEN
 }

--- a/back/src/main/java/com/qmate/domain/match/repository/MatchRepositoryCustom.java
+++ b/back/src/main/java/com/qmate/domain/match/repository/MatchRepositoryCustom.java
@@ -8,4 +8,6 @@ public interface MatchRepositoryCustom {
 
   List<Match> findInactiveMatches(LocalDateTime cutoffDate);
 
+  List<Match> findMatchesForHardDelete(LocalDateTime cutoffDate);
+
 }

--- a/back/src/main/java/com/qmate/domain/match/repository/MatchRepositoryCustom.java
+++ b/back/src/main/java/com/qmate/domain/match/repository/MatchRepositoryCustom.java
@@ -8,6 +8,6 @@ public interface MatchRepositoryCustom {
 
   List<Match> findInactiveMatches(LocalDateTime cutoffDate);
 
-  List<Match> findMatchesForHardDelete(LocalDateTime cutoffDate);
+  List<Match> findMatchesForSoftDelete(LocalDateTime cutoffDate);
 
 }

--- a/back/src/main/java/com/qmate/domain/match/repository/MatchRepositoryImpl.java
+++ b/back/src/main/java/com/qmate/domain/match/repository/MatchRepositoryImpl.java
@@ -32,7 +32,7 @@ public class MatchRepositoryImpl implements MatchRepositoryCustom{
   }
 
   @Override
-  public List<Match> findMatchesForHardDelete(LocalDateTime cutoffDate){
+  public List<Match> findMatchesForSoftDelete(LocalDateTime cutoffDate){
     QMatch match = QMatch.match;
 
     return queryFactory

--- a/back/src/main/java/com/qmate/domain/match/repository/MatchRepositoryImpl.java
+++ b/back/src/main/java/com/qmate/domain/match/repository/MatchRepositoryImpl.java
@@ -31,4 +31,17 @@ public class MatchRepositoryImpl implements MatchRepositoryCustom{
       .fetch();
   }
 
+  @Override
+  public List<Match> findMatchesForHardDelete(LocalDateTime cutoffDate){
+    QMatch match = QMatch.match;
+
+    return queryFactory
+        .selectFrom(match)
+        .where(
+            match.status.eq(MatchStatus.DETACHED_PENDING_DELETE),
+            match.detachedAt.before(cutoffDate)
+        )
+        .fetch();
+  }
+
 }

--- a/back/src/main/java/com/qmate/domain/match/service/MatchService.java
+++ b/back/src/main/java/com/qmate/domain/match/service/MatchService.java
@@ -342,7 +342,7 @@ public class MatchService {
   @Transactional
   public void finalizeExpiredMatches(){
     LocalDateTime toWeeksAgo = LocalDateTime.now().minusWeeks(2);
-    List<Match> expiredMatches = matchRepository.findMatchesForHardDelete(toWeeksAgo);
+    List<Match> expiredMatches = matchRepository.findMatchesForSoftDelete(toWeeksAgo);
 
     for (Match match : expiredMatches){
       // user의 current_match_id는 이미 null이므로 추가 작업 필요 없음

--- a/back/src/main/java/com/qmate/domain/match/service/MatchService.java
+++ b/back/src/main/java/com/qmate/domain/match/service/MatchService.java
@@ -337,4 +337,17 @@ public class MatchService {
     }
   log.info("{}개의 비활성 매칭을 연결 끊기 상태로 전환했습니다.", inactiveMatches.size());
   }
+
+  // 유예기간 지난 상태 델리트로 변경.
+  @Transactional
+  public void finalizeExpiredMatches(){
+    LocalDateTime toWeeksAgo = LocalDateTime.now().minusWeeks(2);
+    List<Match> expiredMatches = matchRepository.findMatchesForHardDelete(toWeeksAgo);
+
+    for (Match match : expiredMatches){
+      // user의 current_match_id는 이미 null이므로 추가 작업 필요 없음
+    match.markAsDeleted();
+    }
+    log.info("{}개의 만료된 매칭을 삭제 처리했습니다.", expiredMatches.size());
+  }
 }

--- a/back/src/test/java/com/qmate/domain/match/service/MatchServiceSchedulerFinalizeTest.java
+++ b/back/src/test/java/com/qmate/domain/match/service/MatchServiceSchedulerFinalizeTest.java
@@ -39,7 +39,7 @@ class MatchServiceSchedulerFinalizeTest {
         .build());
 
     // "findMatchesForHardDelete가 호출되면, 위에서 만든 '만료된 매칭' 1개만 담긴 리스트를 돌려줘"
-    given(matchRepository.findMatchesForHardDelete(any(LocalDateTime.class)))
+    given(matchRepository.findMatchesForSoftDelete(any(LocalDateTime.class)))
         .willReturn(List.of(expiredMatch));
 
     // when: 서비스 메서드를 실행하면

--- a/back/src/test/java/com/qmate/domain/match/service/MatchServiceSchedulerFinalizeTest.java
+++ b/back/src/test/java/com/qmate/domain/match/service/MatchServiceSchedulerFinalizeTest.java
@@ -1,0 +1,51 @@
+package com.qmate.domain.match.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.qmate.domain.match.MatchStatus;
+import com.qmate.domain.match.Match;
+import com.qmate.domain.match.repository.MatchRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MatchServiceSchedulerFinalizeTest {
+
+  @InjectMocks
+  private MatchService sut;
+
+  @Mock
+  private MatchRepository matchRepository;
+
+  @Test
+  @DisplayName("유예기간 만료 매칭 처리: 만료된 매칭 목록을 받아 상태를 올바르게 변경한다")
+  void finalizeExpiredMatches_success() {
+    // given: 3주가 지나 복구 기간이 만료된 Match 객체를 준비합니다.
+    // '진짜' 객체의 메서드 호출을 감시하기 위해 spy로 생성합니다.
+    Match expiredMatch = spy(Match.builder()
+        .id(1L)
+        .status(MatchStatus.DETACHED_PENDING_DELETE)
+        .detachedAt(LocalDateTime.now().minusWeeks(3))
+        .build());
+
+    // "findMatchesForHardDelete가 호출되면, 위에서 만든 '만료된 매칭' 1개만 담긴 리스트를 돌려줘"
+    given(matchRepository.findMatchesForHardDelete(any(LocalDateTime.class)))
+        .willReturn(List.of(expiredMatch));
+
+    // when: 서비스 메서드를 실행하면
+    sut.finalizeExpiredMatches();
+
+    // then: 만료된 매칭(expiredMatch)의 markAsDeleted() 메서드가 정확히 1번 호출되었는지 검증
+    verify(expiredMatch, times(1)).markAsDeleted();
+  }
+}


### PR DESCRIPTION
### 개요
기획서의 요구사항에 따라, **연결 끊김 유예 기간(2주)이 만료된** `DETACHED_PENDING_DELETE` 상태의 매칭을 **자동으로 '삭제됨' 상태로 전환**하는 백그라운드 배치(Batch) 작업을 구현했습니다.

데이터 보존 및 분석을 위해 물리적으로 데이터를 삭제하는 **Hard Delete** 대신, `status`를 `BROKEN`으로 변경하고 `deleted_at` 타임스탬프를 기록하는 **Soft Delete** 방식을 채택했습니다.

### 변경 사항

#### Scheduler
- **`MatchScheduler.java` (수정)**
    - Spring Scheduler(`@Scheduled`)를 사용하여 **매일 자정 00시에** 유예 기간이 만료된 매칭을 정리하는 `runFinalizeExpiredMatches` 작업을 추가했습니다.

#### Service
- **`MatchService#finalizeExpiredMatches()` (신규)**
    - 스케줄러가 호출할, 실제 '삭제' 처리를 수행하는 비즈니스 로직을 구현했습니다.
    - 2주 전을 기준으로 만료된 매칭 목록을 조회한 뒤, 각 매칭에 대해 `markAsBroken()` 메서드를 호출하여 상태를 변경합니다.

#### Repository
- **`MatchRepository` (수정)**
    - "복구 유예 기간(2주)이 지난 `DETACHED_PENDING_DELETE` 상태의 매칭"을 조회하는 `findMatchesForSoftDelete` 커스텀 메서드를 추가했습니다.
    - 해당 쿼리는 **QueryDSL**을 사용하여 `MatchRepositoryImpl`에 구현했습니다.

#### Entity
- **`Match.java` (수정)**
    - `markAsBroken()`: `status`를 `BROKEN`으로 변경하고 `deleted_at`에 현재 시각을 기록하는, 의도가 명확한 비즈니스 메서드를 추가했습니다.
- **`MatchStatus.java` (수정)**
    - DDL 스키마와의 일관성을 위해, `DELETED` Enum 값을 **`BROKEN`**으로 수정했습니다.

### 테스트

- **[X] 서비스 단위 테스트**
    - `MatchServiceSchedulerFinalizeTest.java`를 통해 `finalizeExpiredMatches` 메서드의 핵심 로직을 검증했습니다.
    - `findMatchesForSoftDelete`가 만료된 매칭 목록을 반환했을 때, 해당 매칭의 `markAsBroken()` 메서드가 정확히 호출되는지 `spy`와 `verify`를 사용하여 확인했습니다.

- **[X] API 테스트 (Postman + DB 조작)**
    - 로컬 환경에서만 동작하는 테스트용 API(`POST /api/test/run-finalize-check`)를 추가하여 스케줄러를 수동으로 트리거했습니다.
    - DBeaver를 통해 특정 `match`의 `detached_at` 값을 3주 전으로 수동 조작했습니다.
    - 테스트 API를 호출한 결과, 해당 `match`의 `status`가 `BROKEN`으로, `deleted_at` 컬럼에 현재 시간이 정상적으로 기록되는 것을 DB에서 최종 확인했습니다.

### 기타
혹시 소프트 삭제가 아닌 DB까지 삭제해버리는 하드 삭제 원할 시 코멘트로 전달 부탁드립니다.
