### PR TITLE
feat: 일정 알림 전개/생성 및 일일 스케줄러

### DIFF
--- a/back/src/main/java/com/qmate/common/constants/notification/NotificationConstants.java
+++ b/back/src/main/java/com/qmate/common/constants/notification/NotificationConstants.java
@@ -11,9 +11,9 @@ public class NotificationConstants {
   public static final String QI_TODAY_READY_MSG = "오늘의 질문 도착!";
   public static final String QI_REMINDER_MSG = "아직 답변하지 않은 질문이 있어요.";
   public static final String QI_COMPLETED_MSG = "상대의 답변 도착!";
-  public static final String EVENT_SAME_DAY_MSG = "당일 일정 알림";
-  public static final String EVENT_THREE_DAY_BEFORE_MSG = "3일 전 일정 알림";
-  public static final String EVENT_WEEK_BEFORE_MSG = "1주일 전 일정 알림";
+  public static final String EVENT_SAME_DAY_MSG = "[당일 일정 알림]";
+  public static final String EVENT_THREE_DAYS_BEFORE_MSG = "[3일 전 일정 알림]";
+  public static final String EVENT_WEEK_BEFORE_MSG = "[1주일 전 일정 알림]";
 
   // api docs
   public static final String GET_DETAIL_MD =
@@ -31,7 +31,7 @@ public class NotificationConstants {
           + "- QI_COMPLETED: " + QI_COMPLETED_MSG + "\n\n"
           + "### 일정(Event)\n"
           + "- EVENT_SAME_DAY: " + EVENT_SAME_DAY_MSG + "\n"
-          + "- EVENT_THREE_DAY_BEFORE: " + EVENT_THREE_DAY_BEFORE_MSG + "\n"
+          + "- EVENT_THREE_DAY_BEFORE: " + EVENT_THREE_DAYS_BEFORE_MSG + "\n"
           + "- EVENT_WEEK_BEFORE: " + EVENT_WEEK_BEFORE_MSG + "\n";
 
   public static final String GET_LIST_MD =

--- a/back/src/main/java/com/qmate/domain/event/repository/EventQueryRepository.java
+++ b/back/src/main/java/com/qmate/domain/event/repository/EventQueryRepository.java
@@ -16,4 +16,18 @@ public interface EventQueryRepository {
       @Nullable EventRepeatType repeatTypeFilter,
       @Nullable Boolean anniversaryFilter
   );
+
+  /**
+   * 오늘/3일후/7일후 알림 대상 "이벤트"만 조회
+   * 매치 ACTIVE 검증 포함
+   */
+  List<DueEventRow> findDueEventAlarmRows(LocalDate today);
+
+  record DueEventRow(
+      String code,
+      Long eventId,
+      Long matchId,
+      String title,
+      LocalDate occurDate
+  ) {}
 }

--- a/back/src/main/java/com/qmate/domain/event/repository/EventQueryRepositoryImpl.java
+++ b/back/src/main/java/com/qmate/domain/event/repository/EventQueryRepositoryImpl.java
@@ -1,8 +1,19 @@
 package com.qmate.domain.event.repository;
 
+import com.qmate.domain.event.entity.EventAlarmOption;
+import com.qmate.domain.match.MatchStatus;
+import com.qmate.domain.match.QMatch;
+import com.qmate.domain.notification.entity.NotificationCode;
 import com.qmate.domain.user.QUser;
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.DateExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.core.types.dsl.StringExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.qmate.domain.event.entity.Event;
@@ -18,7 +29,12 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class EventQueryRepositoryImpl implements EventQueryRepository {
 
-  private final JPAQueryFactory qf;
+  private final JPAQueryFactory query;
+
+  private static final QEvent e = QEvent.event;
+  private static final QMatch m = QMatch.match;
+  private static final QMatchMember mm = QMatchMember.matchMember;
+  private static final QUser u = QUser.user;
 
   @Override
   public List<Event> findCandidates(
@@ -29,10 +45,6 @@ public class EventQueryRepositoryImpl implements EventQueryRepository {
       EventRepeatType repeatTypeFilter,
       Boolean anniversaryFilter
   ) {
-    QEvent e = QEvent.event;
-    QMatchMember mm = QMatchMember.matchMember;
-    QUser u = QUser.user;
-
     BooleanBuilder where = new BooleanBuilder();
 
     where.and(e.match.id.eq(matchId));
@@ -73,9 +85,108 @@ public class EventQueryRepositoryImpl implements EventQueryRepository {
       where.and(e.anniversary.eq(anniversaryFilter));
     }
 
-    return qf.selectFrom(e)
+    return query.selectFrom(e)
         .where(where)
         .orderBy(e.id.asc())
         .fetch();
+  }
+
+  @Override
+  public List<DueEventRow> findDueEventAlarmRows(LocalDate today) {
+    LocalDate d0 = today;
+    LocalDate d3 = today.plusDays(3);
+    LocalDate d7 = today.plusDays(7);
+
+    BooleanExpression occursOnD0 = occursOn(d0);
+    BooleanExpression occursOnD3 = occursOn(d3);
+    BooleanExpression occursOnD7 = occursOn(d7);
+
+    BooleanExpression sameDay =
+        e.alarmOption.eq(EventAlarmOption.SAME_DAY).and(occursOnD0);
+    BooleanExpression threeDays =
+        e.alarmOption.eq(EventAlarmOption.THREE_DAYS_BEFORE).and(occursOnD3);
+    BooleanExpression weekBefore =
+        e.alarmOption.eq(EventAlarmOption.WEEK_BEFORE).and(occursOnD7);
+
+    StringExpression codeExpr = new CaseBuilder()
+        .when(sameDay).then(NotificationCode.EVENT_SAME_DAY.name())
+        .when(threeDays).then(NotificationCode.EVENT_THREE_DAYS_BEFORE.name())
+        .when(weekBefore).then(NotificationCode.EVENT_WEEK_BEFORE.name())
+        .otherwise("UNKNOWN");
+
+    Expression<LocalDate> occurDateExpr = new CaseBuilder()
+        .when(sameDay).then(Expressions.constant(d0))
+        .when(threeDays).then(Expressions.constant(d3))
+        .when(weekBefore).then(Expressions.constant(d7))
+        .otherwise(Expressions.constant(d0));
+
+    DateExpression<LocalDate> occurDateOrderExpr =
+        Expressions.dateTemplate(LocalDate.class, "{0}", occurDateExpr);
+
+    BooleanExpression lowerBound = e.eventAt.goe(d7.minusYears(1));
+
+    return query
+        .select(Projections.constructor(DueEventRow.class,
+            codeExpr,
+            e.id,
+            e.match.id,
+            e.title,
+            occurDateExpr
+        ))
+        .from(e)
+        // 🔹 특정 매치 한정 + ACTIVE 확인
+        .join(e.match, m)
+        .where(
+            lowerBound,
+            m.status.eq(MatchStatus.ACTIVE),
+            sameDay.or(threeDays).or(weekBefore)
+        )
+        .orderBy(occurDateOrderExpr.asc(), e.id.asc())
+        .fetch();
+  }
+
+  /**
+   * 전개 없이 target 날짜가 발생일인지 평가하는 규칙
+   * - WEEKLY : DATEDIFF % 7 == 0
+   * - MONTHLY: '일' 일치 or 말일 보정(시작일이 말일이면 대상도 말일 인정)
+   * - YEARLY : 월/일 일치 (2/29 보정은 필요시 추가)
+   * - NONE   : eventAt == target
+   */
+  private BooleanExpression occursOn(LocalDate target) {
+    NumberExpression<Integer> diffDays =
+        Expressions.numberTemplate(Integer.class, "DATEDIFF({0}, {1})", Expressions.constant(target), e.eventAt);
+
+    BooleanExpression weeklyRule =
+        e.repeatType.eq(EventRepeatType.WEEKLY)
+            .and(e.eventAt.loe(Expressions.constant(target)))
+            .and(Expressions.numberTemplate(Integer.class, "MOD({0}, 7)", diffDays).eq(0));
+
+    BooleanExpression monthlyRule =
+        e.repeatType.eq(EventRepeatType.MONTHLY)
+            .and(e.eventAt.loe(Expressions.constant(target)))
+            .and(Expressions.booleanTemplate(
+                "(DAY({0}) = DAY({1})) OR (LAST_DAY({0}) = {0} AND LAST_DAY({1}) = {1})",
+                Expressions.constant(target), e.eventAt
+            ));
+
+    BooleanExpression yearlyRule =
+        e.repeatType.eq(EventRepeatType.YEARLY)
+            .and(Expressions.booleanTemplate(
+                "MONTH({0}) = MONTH({1}) AND DAY({0}) = DAY({1})",
+                Expressions.constant(target), e.eventAt
+            ));
+    // 윤년 2/29 보정 추가
+    yearlyRule = yearlyRule.or(
+        e.repeatType.eq(EventRepeatType.YEARLY)
+            .and(Expressions.booleanTemplate(
+                "(MONTH({1})=2 AND DAY({1})=29) AND (MONTH({0})=2 AND LAST_DAY({0})={0})",
+                Expressions.constant(target), e.eventAt
+            ))
+    );
+
+    BooleanExpression noneRule =
+        e.repeatType.eq(EventRepeatType.NONE).and(e.eventAt.eq(Expressions.constant(target)));
+
+    return noneRule.or(weeklyRule).or(monthlyRule).or(yearlyRule);
   }
 }

--- a/back/src/main/java/com/qmate/domain/event/repository/EventQueryRepositoryImpl.java
+++ b/back/src/main/java/com/qmate/domain/event/repository/EventQueryRepositoryImpl.java
@@ -1,25 +1,25 @@
 package com.qmate.domain.event.repository;
 
+import com.qmate.domain.event.entity.Event;
 import com.qmate.domain.event.entity.EventAlarmOption;
+import com.qmate.domain.event.entity.EventRepeatType;
+import com.qmate.domain.event.entity.QEvent;
 import com.qmate.domain.match.MatchStatus;
 import com.qmate.domain.match.QMatch;
+import com.qmate.domain.match.QMatchMember;
 import com.qmate.domain.notification.entity.NotificationCode;
 import com.qmate.domain.user.QUser;
 import com.querydsl.core.BooleanBuilder;
-import com.querydsl.core.types.Expression;
-import com.querydsl.core.types.Projections;
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.core.types.dsl.DateExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.core.types.dsl.StringExpression;
+import com.querydsl.core.types.dsl.StringPath;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import com.qmate.domain.event.entity.Event;
-import com.qmate.domain.event.entity.EventRepeatType;
-import com.qmate.domain.event.entity.QEvent;
-import com.qmate.domain.match.QMatchMember;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -114,35 +114,45 @@ public class EventQueryRepositoryImpl implements EventQueryRepository {
         .when(weekBefore).then(NotificationCode.EVENT_WEEK_BEFORE.name())
         .otherwise("UNKNOWN");
 
-    Expression<LocalDate> occurDateExpr = new CaseBuilder()
-        .when(sameDay).then(Expressions.constant(d0))
-        .when(threeDays).then(Expressions.constant(d3))
-        .when(weekBefore).then(Expressions.constant(d7))
-        .otherwise(Expressions.constant(d0));
-
-    DateExpression<LocalDate> occurDateOrderExpr =
-        Expressions.dateTemplate(LocalDate.class, "{0}", occurDateExpr);
+    NumberExpression<Integer> orderKey = new CaseBuilder()
+        .when(sameDay).then(0)
+        .when(threeDays).then(1)
+        .when(weekBefore).then(2)
+        .otherwise(9);
 
     BooleanExpression lowerBound = e.eventAt.goe(d7.minusYears(1));
 
-    return query
-        .select(Projections.constructor(DueEventRow.class,
-            codeExpr,
-            e.id,
-            e.match.id,
-            e.title,
-            occurDateExpr
-        ))
+    StringPath codeAlias = Expressions.stringPath("codeAlias");
+
+    List<Tuple> tuples = query
+        .select(codeExpr.as(codeAlias), e.id, e.match.id, e.title)
         .from(e)
-        // 🔹 특정 매치 한정 + ACTIVE 확인
         .join(e.match, m)
         .where(
             lowerBound,
             m.status.eq(MatchStatus.ACTIVE),
             sameDay.or(threeDays).or(weekBefore)
         )
-        .orderBy(occurDateOrderExpr.asc(), e.id.asc())
+        .orderBy(orderKey.asc(), e.id.asc())
         .fetch();
+
+    return tuples.stream()
+        .map(t -> {
+          String code = t.get(codeAlias);
+          LocalDate occurDate =
+              NotificationCode.EVENT_SAME_DAY.name().equals(code) ? d0 :
+                  NotificationCode.EVENT_THREE_DAYS_BEFORE.name().equals(code) ? d3 :
+                      NotificationCode.EVENT_WEEK_BEFORE.name().equals(code) ? d7 : d0;
+
+          return new DueEventRow(
+              code,
+              t.get(e.id),
+              t.get(e.match.id),
+              t.get(e.title),
+              occurDate
+          );
+        })
+        .toList();
   }
 
   /**
@@ -153,39 +163,41 @@ public class EventQueryRepositoryImpl implements EventQueryRepository {
    * - NONE   : eventAt == target
    */
   private BooleanExpression occursOn(LocalDate target) {
+    DateExpression<LocalDate> targetExpr = Expressions.dateTemplate(LocalDate.class, "CAST({0} AS DATE)", target);
+
     NumberExpression<Integer> diffDays =
-        Expressions.numberTemplate(Integer.class, "DATEDIFF({0}, {1})", Expressions.constant(target), e.eventAt);
+        Expressions.numberTemplate(Integer.class, "DATEDIFF({0}, {1})", targetExpr, e.eventAt);
 
     BooleanExpression weeklyRule =
         e.repeatType.eq(EventRepeatType.WEEKLY)
-            .and(e.eventAt.loe(Expressions.constant(target)))
+            .and(e.eventAt.loe(target))
             .and(Expressions.numberTemplate(Integer.class, "MOD({0}, 7)", diffDays).eq(0));
 
     BooleanExpression monthlyRule =
         e.repeatType.eq(EventRepeatType.MONTHLY)
-            .and(e.eventAt.loe(Expressions.constant(target)))
+            .and(e.eventAt.loe(target))
             .and(Expressions.booleanTemplate(
                 "(DAY({0}) = DAY({1})) OR (LAST_DAY({0}) = {0} AND LAST_DAY({1}) = {1})",
-                Expressions.constant(target), e.eventAt
+                targetExpr, e.eventAt
             ));
 
     BooleanExpression yearlyRule =
         e.repeatType.eq(EventRepeatType.YEARLY)
             .and(Expressions.booleanTemplate(
                 "MONTH({0}) = MONTH({1}) AND DAY({0}) = DAY({1})",
-                Expressions.constant(target), e.eventAt
+                targetExpr, e.eventAt
             ));
     // 윤년 2/29 보정 추가
     yearlyRule = yearlyRule.or(
         e.repeatType.eq(EventRepeatType.YEARLY)
             .and(Expressions.booleanTemplate(
                 "(MONTH({1})=2 AND DAY({1})=29) AND (MONTH({0})=2 AND LAST_DAY({0})={0})",
-                Expressions.constant(target), e.eventAt
+                targetExpr, e.eventAt
             ))
     );
 
     BooleanExpression noneRule =
-        e.repeatType.eq(EventRepeatType.NONE).and(e.eventAt.eq(Expressions.constant(target)));
+        e.repeatType.eq(EventRepeatType.NONE).and(e.eventAt.eq(target));
 
     return noneRule.or(weeklyRule).or(monthlyRule).or(yearlyRule);
   }

--- a/back/src/main/java/com/qmate/domain/event/service/EventAlarmService.java
+++ b/back/src/main/java/com/qmate/domain/event/service/EventAlarmService.java
@@ -1,0 +1,113 @@
+package com.qmate.domain.event.service;
+
+import com.qmate.common.push.PushSender;
+import com.qmate.domain.event.repository.EventQueryRepository;
+import com.qmate.domain.event.repository.EventQueryRepository.DueEventRow;
+import com.qmate.domain.event.repository.EventRepository;
+import com.qmate.domain.match.repository.MatchMemberRepository;
+import com.qmate.domain.notification.entity.Notification;
+import com.qmate.domain.notification.entity.NotificationCategory;
+import com.qmate.domain.notification.entity.NotificationCode;
+import com.qmate.domain.notification.entity.NotificationResourceType;
+import com.qmate.domain.notification.repository.NotificationRepository;
+import com.qmate.domain.user.User;
+import com.qmate.domain.user.UserRepository;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+@Service
+@RequiredArgsConstructor
+public class EventAlarmService {
+
+  private final EventRepository eventRepository;
+  private final MatchMemberRepository matchMemberRepository;
+  private final UserRepository userRepository;
+  private final NotificationRepository notificationRepository;
+  private final PushSender pushSender;
+
+  @Transactional
+  public int registerAndSendAll(LocalDate today) {
+    // 1) due 이벤트 일괄 조회
+    List<DueEventRow> due = eventRepository.findDueEventAlarmRows(today);
+    if (due.isEmpty()) {
+      return 0;
+    }
+
+    // 2) 매치별 멤버 userIds 수집 및 캐시
+    Map<Long, List<Long>> matchToUserIds = new HashMap<>();
+    Set<Long> allUserIds = new HashSet<>();
+    for (Long matchId : due.stream().map(EventQueryRepository.DueEventRow::matchId).collect(Collectors.toSet())) {
+      List<Long> userIds = matchMemberRepository.findAllUser_IdByMatch_Id(matchId);
+      matchToUserIds.put(matchId, userIds);
+      allUserIds.addAll(userIds);
+    }
+    if (allUserIds.isEmpty()) {
+      return 0;
+    }
+
+    // 3) 알림 생성
+    List<Notification> toSave = new ArrayList<>();
+    for (DueEventRow r : due) {
+      NotificationCode code = NotificationCode.valueOf(r.code());
+      for (Long uid : matchToUserIds.getOrDefault(r.matchId(), List.of())) {
+
+        Notification n = Notification.builder()
+            .userId(uid)
+            .matchId(r.matchId())
+            .category(NotificationCategory.EVENT)
+            .code(code)
+            .listTitle(code.getDescription() + " " + r.title())
+            .pushTitle(code.getDescription())
+            .resourceType(NotificationResourceType.EVENT)
+            .resourceId(r.eventId())
+            .build();
+        toSave.add(n);
+      }
+    }
+    if (toSave.isEmpty()) {
+      return 0;
+    }
+
+    // 4) 저장
+    List<Notification> saved = notificationRepository.saveAll(toSave);
+
+    // 5) 커밋 후 푸시 전송 (설정/푸시 가능 여부 체크는 '전송 단계'에서만)
+    TransactionSynchronizationManager.registerSynchronization(
+        new TransactionSynchronization() {
+          @Override
+          public void afterCommit() {
+            Set<Long> enabledUserIds = userRepository
+                .findAllById(saved.stream().map(Notification::getUserId).collect(Collectors.toSet()))
+                .stream().filter(User::isPushEnabled).map(User::getId).collect(Collectors.toSet());
+            if (enabledUserIds.isEmpty()) {
+              return;
+            }
+            for (Notification n : saved) {
+              if (!enabledUserIds.contains(n.getUserId())) {
+                continue;
+              }
+              try {
+                pushSender.send(n);
+              } catch (Exception ignore) {
+                // 전송 실패는 WebPushSender에서 로깅/정리하므로 무시
+              }
+
+            }
+          }
+        }
+    );
+    return saved.size();
+  }
+
+}

--- a/back/src/main/java/com/qmate/domain/match/repository/MatchMemberRepository.java
+++ b/back/src/main/java/com/qmate/domain/match/repository/MatchMemberRepository.java
@@ -5,6 +5,7 @@ import com.qmate.domain.match.MatchStatus;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface MatchMemberRepository extends JpaRepository<MatchMember, Long>,MatchMemberRepositoryCustom {
 
@@ -14,4 +15,6 @@ public interface MatchMemberRepository extends JpaRepository<MatchMember, Long>,
 
   Optional<MatchMember> findByUser_IdAndMatch_Status(Long id, MatchStatus status);
 
+  @Query("select mm.user.id from MatchMember mm where mm.match.id = :matchId")
+  List<Long> findAllUser_IdByMatch_Id(Long matchId);
 }

--- a/back/src/main/java/com/qmate/domain/notification/entity/Notification.java
+++ b/back/src/main/java/com/qmate/domain/notification/entity/Notification.java
@@ -8,6 +8,7 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
+@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
@@ -48,7 +49,6 @@ public class Notification {
   @Column(name = "resource_id")
   private Long resourceId;
 
-  @Setter
   @Column(name = "read_at")
   private LocalDateTime readAt;
 

--- a/back/src/main/java/com/qmate/domain/notification/entity/NotificationCode.java
+++ b/back/src/main/java/com/qmate/domain/notification/entity/NotificationCode.java
@@ -1,7 +1,6 @@
 package com.qmate.domain.notification.entity;
 
 import com.qmate.common.constants.notification.NotificationConstants;
-import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 @Getter
@@ -13,7 +12,7 @@ public enum NotificationCode {
 
   // EVENT
   EVENT_SAME_DAY(NotificationConstants.EVENT_SAME_DAY_MSG),
-  EVENT_THREE_DAY_BEFORE(NotificationConstants.EVENT_THREE_DAY_BEFORE_MSG),
+  EVENT_THREE_DAYS_BEFORE(NotificationConstants.EVENT_THREE_DAYS_BEFORE_MSG),
   EVENT_WEEK_BEFORE(NotificationConstants.EVENT_WEEK_BEFORE_MSG),;
 
   // MATCH

--- a/back/src/main/java/com/qmate/schedule/EventAlarmJob.java
+++ b/back/src/main/java/com/qmate/schedule/EventAlarmJob.java
@@ -1,0 +1,35 @@
+package com.qmate.schedule;
+
+import com.qmate.domain.event.service.EventAlarmService;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EventAlarmJob {
+  private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+  private final EventAlarmService eventAlarmService;
+
+  /**
+   * 매일 00:10 KST 실행
+   * cron: 초 분 시 일 월 요일
+   * 일정 알림 생성 및 전송
+   */
+  @Scheduled(cron = "0 10 0 * * *", zone = "Asia/Seoul")
+  public void processDailyEventAlarms() {
+    LocalDate todayKst = LocalDate.now(KST);
+    try {
+      int created = eventAlarmService.registerAndSendAll(todayKst);
+      log.info("[EventAlarmJob] {} notifications created ({}).", created, todayKst);
+    } catch (Exception e) {
+      // 서비스 내부에서 푸시는 afterCommit + try/catch 처리됨
+      log.error("[EventAlarmJob] failed. date={}", todayKst, e);
+    }
+  }
+}

--- a/back/src/test/java/com/qmate/domain/event/repository/EventQueryRepositoryTest.java
+++ b/back/src/test/java/com/qmate/domain/event/repository/EventQueryRepositoryTest.java
@@ -9,6 +9,8 @@ import com.qmate.domain.event.entity.EventAlarmOption;
 import com.qmate.domain.event.entity.EventRepeatType;
 import com.qmate.domain.match.Match;
 import com.qmate.domain.match.MatchMember;
+import com.qmate.domain.match.MatchStatus;
+import com.qmate.domain.match.RelationType;
 import com.qmate.domain.user.User;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -19,11 +21,13 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @ActiveProfiles("test")
 @DataJpaTest
 @Import({JpaConfig.class, QuerydslConfig.class})
@@ -44,6 +48,8 @@ class EventQueryRepositoryTest {
   void setUp() {
     // ===== seed: Match + User(currentMatchId=matchId) + MatchMember =====
     Match match = Match.builder()
+        .relationType(RelationType.COUPLE)
+        .status(MatchStatus.ACTIVE)
         .startDate(LocalDateTime.now())
         .createdAt(LocalDateTime.now())
         .updatedAt(LocalDateTime.now())
@@ -51,6 +57,8 @@ class EventQueryRepositoryTest {
     tem.persist(match);
 
     Match other = Match.builder()
+        .relationType(RelationType.COUPLE)
+        .status(MatchStatus.ACTIVE)
         .startDate(LocalDateTime.now())
         .createdAt(LocalDateTime.now())
         .updatedAt(LocalDateTime.now())
@@ -239,6 +247,128 @@ class EventQueryRepositoryTest {
         .eventAt(seedDate)
         .repeatType(type)
         .alarmOption(EventAlarmOption.WEEK_BEFORE)
+        .anniversary(anniversary)
+        .createdAt(LocalDateTime.now())
+        .updatedAt(LocalDateTime.now())
+        .build();
+    tem.persist(e);
+    return e.getId();
+  }
+
+  /* ---------------------------
+     알림 전개 쿼리: today / +3 / +7
+     --------------------------- */
+  @Nested
+  @DisplayName("알림 전개 쿼리")
+  class AlarmDueQuery {
+
+    private LocalDate today;
+
+    @BeforeEach
+    void initToday() {
+      today = LocalDate.of(2025, 10, 10); // 테스트 기준일
+    }
+
+    @Test
+    @DisplayName("NONE + SAME_DAY / +3 / +7 각각 매칭")
+    void none_sameDay_and_offsets() {
+      // SAME_DAY → today
+      Long eSameDay = persistEventWithAlarm(matchId, "NONE_SAME_DAY",
+          today, EventRepeatType.NONE, EventAlarmOption.SAME_DAY, false);
+
+      // THREE_DAYS_BEFORE → today+3
+      Long eD3 = persistEventWithAlarm(matchId, "NONE_D3",
+          today.plusDays(3), EventRepeatType.NONE, EventAlarmOption.THREE_DAYS_BEFORE, false);
+
+      // WEEK_BEFORE → today+7
+      Long eD7 = persistEventWithAlarm(matchId, "NONE_D7",
+          today.plusDays(7), EventRepeatType.NONE, EventAlarmOption.WEEK_BEFORE, false);
+
+      tem.flush(); tem.clear();
+
+      var rows = eventRepository.findDueEventAlarmRows(today);
+
+      assertThat(rows).extracting(r -> r.eventId())
+          .contains(eSameDay, eD3, eD7);
+
+      // 코드 매핑 확인
+      assertThat(rows).filteredOn(r -> r.eventId().equals(eSameDay))
+          .extracting(r -> r.code()).containsExactly("EVENT_SAME_DAY");
+      assertThat(rows).filteredOn(r -> r.eventId().equals(eD3))
+          .extracting(r -> r.code()).containsExactly("EVENT_THREE_DAYS_BEFORE");
+      assertThat(rows).filteredOn(r -> r.eventId().equals(eD7))
+          .extracting(r -> r.code()).containsExactly("EVENT_WEEK_BEFORE");
+    }
+
+    @Test
+    @DisplayName("WEEKLY: seed ≤ target, DATEDIFF%7==0 → WEEK_BEFORE(+7)에 매칭")
+    void weekly_matches_on_d7() {
+      // today+7 = 2025-10-17 이므로
+      // 2025-09-05를 seed로 두면 DATEDIFF(10/17, 9/05)=42 → 7의 배수
+      Long eWeekly = persistEventWithAlarm(matchId, "WEEKLY_D7",
+          LocalDate.of(2025, 9, 5), EventRepeatType.WEEKLY, EventAlarmOption.WEEK_BEFORE, false);
+
+      tem.flush(); tem.clear();
+
+      var rows = eventRepository.findDueEventAlarmRows(today);
+      assertThat(rows).extracting(r -> r.eventId()).contains(eWeekly);
+    }
+
+    @Test
+    @DisplayName("MONTHLY: '일' 일치 → WEEK_BEFORE(+7)의 day 일치에 매칭")
+    void monthly_matches_on_day() {
+      // today+7 = 10/17 → seed 를 매월 17일로 설정
+      Long eMonthly = persistEventWithAlarm(matchId, "MONTHLY_17",
+          LocalDate.of(2025, 1, 17), EventRepeatType.MONTHLY, EventAlarmOption.WEEK_BEFORE, false);
+
+      tem.flush(); tem.clear();
+
+      var rows = eventRepository.findDueEventAlarmRows(today);
+      assertThat(rows).extracting(r -> r.eventId()).contains(eMonthly);
+    }
+
+    @Test
+    @DisplayName("ACTIVE 매치 전역 포함, INACTIVE 매치 제외")
+    void include_active_exclude_inactive() {
+      // ACTIVE 매치 2곳 → 포함
+      Long eActive1 = persistEventWithAlarm(matchId, "ACTIVE_MATCH_SAME_DAY_1",
+          today, EventRepeatType.NONE, EventAlarmOption.SAME_DAY, false);
+      Long eActive2 = persistEventWithAlarm(otherMatchId, "ACTIVE_MATCH_SAME_DAY_2",
+          today, EventRepeatType.NONE, EventAlarmOption.SAME_DAY, false);
+
+      // INACTIVE 매치 하나 더 만들어서 제외 확인
+      Match inactive = Match.builder()
+          .relationType(RelationType.FRIEND)
+          .startDate(LocalDateTime.now())
+          .createdAt(LocalDateTime.now())
+          .updatedAt(LocalDateTime.now())
+          .build();
+      tem.persist(inactive);
+      Long eInactive = persistEventWithAlarm(inactive.getId(), "INACTIVE_MATCH_SAME_DAY",
+          today, EventRepeatType.NONE, EventAlarmOption.SAME_DAY, false);
+
+      tem.flush();
+      tem.clear();
+
+      var rows = eventRepository.findDueEventAlarmRows(today);
+
+      assertThat(rows).extracting(r -> r.eventId())
+          .contains(eActive1, eActive2)
+          .doesNotContain(eInactive);
+    }
+  }
+
+  // --- 알림옵션 지정 가능한 헬퍼 추가 ---
+  private Long persistEventWithAlarm(Long matchId, String title, LocalDate seedDate,
+      EventRepeatType type, EventAlarmOption alarm, boolean anniversary) {
+    Match match = tem.find(Match.class, matchId);
+    Event e = Event.builder()
+        .match(match)
+        .title(title)
+        .description(title)
+        .eventAt(seedDate)
+        .repeatType(type)
+        .alarmOption(alarm)
         .anniversary(anniversary)
         .createdAt(LocalDateTime.now())
         .updatedAt(LocalDateTime.now())

--- a/back/src/test/java/com/qmate/domain/event/service/EventAlarmServiceTest.java
+++ b/back/src/test/java/com/qmate/domain/event/service/EventAlarmServiceTest.java
@@ -1,0 +1,104 @@
+package com.qmate.domain.event.service;
+
+import static org.mockito.BDDMockito.*;
+import static org.assertj.core.api.Assertions.*;
+
+import com.qmate.common.push.PushSender;
+import com.qmate.domain.event.repository.EventQueryRepository.DueEventRow;
+import com.qmate.domain.event.repository.EventRepository;
+import com.qmate.domain.match.repository.MatchMemberRepository;
+import com.qmate.domain.notification.entity.Notification;
+import com.qmate.domain.notification.entity.NotificationCategory;
+import com.qmate.domain.notification.entity.NotificationCode;
+import com.qmate.domain.notification.entity.NotificationResourceType;
+import com.qmate.domain.notification.repository.NotificationRepository;
+import com.qmate.domain.user.User;
+import com.qmate.domain.user.UserRepository;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+@DisplayName("EventAlarmService")
+@ExtendWith(MockitoExtension.class)
+class EventAlarmServiceTest {
+
+  @Mock private EventRepository eventRepository;
+  @Mock private MatchMemberRepository matchMemberRepository;
+  @Mock private UserRepository userRepository;
+  @Mock private NotificationRepository notificationRepository;
+  @Mock private PushSender pushSender;
+
+  @InjectMocks
+  private EventAlarmService service;
+
+  private final LocalDate today = LocalDate.of(2025, 10, 10);
+
+  @BeforeEach
+  void initSync() {
+    // afterCommit 테스트용 수동 초기화
+    if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+      TransactionSynchronizationManager.initSynchronization();
+    }
+  }
+
+  @Test
+  @DisplayName("due 이벤트에 대해 인박스 생성하고, pushEnabled 사용자에게만 전송")
+  void register_and_send_all_basic_flow() {
+    // given
+    DueEventRow row1 = new DueEventRow(
+        NotificationCode.EVENT_SAME_DAY.name(), 101L, 11L, "TITLE1", today);
+    DueEventRow row2 = new DueEventRow(
+        NotificationCode.EVENT_WEEK_BEFORE.name(), 102L, 12L, "TITLE2", today.plusDays(7));
+
+    given(eventRepository.findDueEventAlarmRows(today)).willReturn(List.of(row1, row2));
+
+    // match 11 → users: 1,2 / match 12 → users: 3
+    given(matchMemberRepository.findAllUser_IdByMatch_Id(11L)).willReturn(List.of(1L, 2L));
+    given(matchMemberRepository.findAllUser_IdByMatch_Id(12L)).willReturn(List.of(3L));
+
+    // pushEnabled: user1=true, user2=false, user3=true
+    User u1 = User.builder().id(1L).pushEnabled(true).build();
+    User u2 = User.builder().id(2L).pushEnabled(false).build();
+    User u3 = User.builder().id(3L).pushEnabled(true).build();
+    given(userRepository.findAllById(Set.of(1L,2L,3L))).willReturn(List.of(u1,u2,u3));
+
+    // 저장될 Notification 더미 id 세팅
+    ArgumentCaptor<Iterable<Notification>> captor = ArgumentCaptor.forClass(Iterable.class);
+    willAnswer(inv -> {
+      @SuppressWarnings("unchecked")
+      Iterable<Notification> it = inv.getArgument(0, Iterable.class);
+      long id = 1000L;
+      for (Notification n : it) n.setId(id++);
+      return it;
+    }).given(notificationRepository).saveAll(captor.capture());
+
+    // when
+    int created = service.registerAndSendAll(today);
+
+    // then (DB 저장)
+    assertThat(created).isEqualTo(3); // match 11: 2명, match 12: 1명 → 총 3건 생성
+    Iterable<Notification> saved = captor.getValue();
+    assertThat(saved).allSatisfy(n -> {
+      assertThat(n.getCategory()).isEqualTo(NotificationCategory.EVENT);
+      assertThat(n.getResourceType()).isEqualTo(NotificationResourceType.EVENT);
+    });
+
+    // afterCommit 강제 호출하여 전송 경로 검증
+    for (TransactionSynchronization sync : TransactionSynchronizationManager.getSynchronizations()) {
+      sync.afterCommit();
+    }
+    TransactionSynchronizationManager.clearSynchronization();
+
+    // pushEnabled true: user1, user3 → 최소 2회 호출
+    then(pushSender).should(times(2)).send(any(Notification.class));
+    then(pushSender).shouldHaveNoMoreInteractions();
+  }
+}

--- a/back/src/test/java/com/qmate/domain/event/service/EventServiceTest.java
+++ b/back/src/test/java/com/qmate/domain/event/service/EventServiceTest.java
@@ -1,4 +1,4 @@
-package com.qmate.domain.event;
+package com.qmate.domain.event.service;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -18,7 +18,6 @@ import com.qmate.domain.event.entity.Event;
 import com.qmate.domain.event.entity.EventAlarmOption;
 import com.qmate.domain.event.entity.EventRepeatType;
 import com.qmate.domain.event.repository.EventRepository;
-import com.qmate.domain.event.service.EventService;
 import com.qmate.domain.match.Match;
 import com.qmate.domain.match.repository.MatchRepository;
 import com.qmate.exception.custom.event.EventCalendarDateRangeExceededException;


### PR DESCRIPTION
## 요약
- 반복 전개 없이 **발생일 평가(occursOn)** 규칙으로 `today / +3 / +7`에 해당하는 이벤트를 조회
- 조회 결과로 **알림을 일괄 생성**하고, **개인 설정이 ON인 사용자**에게만 푸시 전송
- **매일 00:10 KST**에 실행되는 스케줄러 추가
- **리포지토리/서비스 테스트** 추가 및 테스트 프로필 정리

---

## 변경 사항

### 1) Query 레이어
- `EventQueryRepositoryImpl`
  - `occursOn(LocalDate)` 로직 정비  
    - 템플릿에는 **컬럼만** 사용(`DAYOFWEEK(e.eventAt)`, `DAY(e.eventAt)`, `MONTH(e.eventAt)`, `LAST_DAY(e.eventAt)=e.eventAt`)  
    - WEEKLY: 시드 ≤ target & 요일 일치  
    - MONTHLY: 시드 ≤ target & (일자 동일) *or* (시드 말일 & target 말일)  
    - YEARLY: 월/일 일치 (+ target이 2월 말일일 때 2/29 시드 허용)
  - `findDueEventAlarmRows(LocalDate today)`  
    - 코드(case)만 DB에서 계산하고 발생일(d0/d3/d7)은 자바에서 결정  
    - 정렬은 `orderKey`(0:당일, 1:+3, 2:+7)로 수행

### 2) Service 레이어
- `EventAlarmService`
  - due 조회 → **알림 무조건 생성**
  - 트랜잭션 **commit 후** 사용자 설정 확인하여 **푸시 전송**
  - 전송 실패는 내부 `try/catch` 처리

### 3) 스케줄러
- `EventAlarmJob`
  - `@Scheduled(cron = "0 10 0 * * *", zone = "Asia/Seoul")`
  - 메서드명: `processDailyEventAlarms`

### 4) 테스트
- `EventQueryRepositoryTest`
  - NONE/WEEKLY/MONTHLY/YEARLY 규칙별 매칭 케이스
  - SAME_DAY / THREE_DAYS_BEFORE / WEEK_BEFORE 코드 매핑 검증
  - **ACTIVE 매치 전역 조회** 전제
- `EventAlarmServiceTest` (BDDMockito)
  - 알림 생성 수 및 `pushEnabled` 사용자만 전송 검증