### PR TITLE
feat: 펫 기능 추가(Pet/PetExpLog) 및 EXP 조회 API / refactor: MatchNotFound 문구 상수화 & AdminNotificationTestController 스웨거 비노출

### DIFF
--- a/back/src/main/java/com/qmate/api/admin/notification/AdminNotificationTestController.java
+++ b/back/src/main/java/com/qmate/api/admin/notification/AdminNotificationTestController.java
@@ -4,6 +4,7 @@ import com.qmate.common.push.PushSender;
 import com.qmate.domain.notification.entity.Notification;
 import com.qmate.domain.notification.entity.NotificationResourceType;
 import com.qmate.domain.notification.repository.NotificationRepository;
+import io.swagger.v3.oas.annotations.Hidden;
 import jakarta.validation.Valid;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/admin/notifications")
 @RequiredArgsConstructor
+@Hidden
 public class AdminNotificationTestController {
 
     private final NotificationRepository notificationRepository;

--- a/back/src/main/java/com/qmate/api/pet/PetController.java
+++ b/back/src/main/java/com/qmate/api/pet/PetController.java
@@ -1,0 +1,38 @@
+package com.qmate.api.pet;
+
+import com.qmate.common.constants.HttpStatusCode;
+import com.qmate.domain.pet.model.response.PetExpResponse;
+import com.qmate.domain.pet.service.PetService;
+import com.qmate.exception.MatchErrorCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/matches")
+@RequiredArgsConstructor
+@SecurityRequirement(name = "bearer-key")
+@Tag(name = "Pet", description = "펫 API")
+public class PetController {
+  private final PetService petService;
+
+  @Operation(
+      summary = "매치 ID로 펫 경험치 조회",
+      description = "매치 ID로 펫 경험치를 조회합니다.\n\n"
+          + "### 에러 응답\n\n"
+          + "| HTTP | errorCode | message |\n"
+          + "|-----:|-----------|---------|\n"
+          + "| " + HttpStatusCode.NOT_FOUND + " | " + MatchErrorCode.MATCH_NOT_FOUND_ERROR_CODE + " | "
+          + MatchErrorCode.MATCH_NOT_FOUND_MESSAGE + " |\n"
+  )
+  @GetMapping("/{matchId}/pet")
+  public ResponseEntity<PetExpResponse> getExp(@PathVariable Long matchId) {
+    return ResponseEntity.ok(petService.getExpByMatchId(matchId));
+  }
+}

--- a/back/src/main/java/com/qmate/common/constants/event/EventConstants.java
+++ b/back/src/main/java/com/qmate/common/constants/event/EventConstants.java
@@ -25,15 +25,14 @@ public class EventConstants {
   public static final String EVENT_DESCRIPTION_SIZE_MESSAGE = "일정 설명은 최대 " + EVENT_DESCRIPTION_MAX_LENGTH + "자까지 가능합니다.";
 
   // api doc
-  // TODO MatchErrorCode 변경 시 참조 필요
   public static final String CREATE_MD =
       "매치 하위에 일정을 생성합니다.\n\n"
           + "- matchId, userId(인증)로 권한과 존재를 함께 검증합니다.\n\n"
           + "### 에러 응답\n\n"
           + "| HTTP | errorCode | message |\n"
           + "|-----:|-----------|---------|\n"
-          + "| " + HttpStatusCode.NOT_FOUND + " | " + "MATCH_002" + " | "
-          + "해당 매칭을 찾을 수 없습니다." + " |\n";
+          + "| " + HttpStatusCode.NOT_FOUND + " | " + MatchErrorCode.MATCH_NOT_FOUND_ERROR_CODE + " | "
+          + MatchErrorCode.MATCH_NOT_FOUND_MESSAGE + " |\n";
 
   public static final String GET_DETAIL_MD =
       "일정을 조회합니다.\n\n"

--- a/back/src/main/java/com/qmate/common/constants/question/CustomQuestionConstants.java
+++ b/back/src/main/java/com/qmate/common/constants/question/CustomQuestionConstants.java
@@ -16,14 +16,13 @@ public class CustomQuestionConstants {
   public static final String SORT_KEY_UPDATED_AT = "updatedAt";
 
   // api 문서 메시지
-  // TODO MatchErrorCode 변경 시 참조 필요
   public static final String CREATE_MD =
       "특정 매치에 대한 커스텀 질문을 생성합니다.\n\n"
           + "### 에러 응답\n\n"
           + "| HTTP | errorCode | message |\n"
           + "|-----:|-----------|---------|\n"
-          + "| " + HttpStatusCode.NOT_FOUND + " | " + "MATCH_002" + " | "
-          + "해당 매칭을 찾을 수 없습니다." + " |\n";
+          + "| " + HttpStatusCode.NOT_FOUND + " | " + MatchErrorCode.MATCH_NOT_FOUND_ERROR_CODE + " | "
+          + MatchErrorCode.MATCH_NOT_FOUND_MESSAGE + " |\n";
 
   public static final String UPDATE_MD =
       "특정 커스텀 질문을 수정합니다.\n\n"

--- a/back/src/main/java/com/qmate/domain/pet/entity/Pet.java
+++ b/back/src/main/java/com/qmate/domain/pet/entity/Pet.java
@@ -1,0 +1,58 @@
+package com.qmate.domain.pet.entity;
+
+import com.qmate.domain.match.Match;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Getter
+@Setter
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "pet")
+public class Pet {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "pet_id")
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "match_id")
+  private Match match;
+
+  @Column(name = "exp")
+  private long exp;
+
+  @CreatedDate
+  @Column(nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate
+  @Column(nullable = false)
+  private LocalDateTime updatedAt;
+
+  public void addExp(long delta) {
+    this.exp += delta;
+  }
+}

--- a/back/src/main/java/com/qmate/domain/pet/entity/PetExpLog.java
+++ b/back/src/main/java/com/qmate/domain/pet/entity/PetExpLog.java
@@ -1,0 +1,39 @@
+package com.qmate.domain.pet.entity;
+
+import com.qmate.domain.match.Match;
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Table(name = "pet_exp_log")
+@Getter
+@Setter
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class PetExpLog {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "pet_exp_log_id")
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "match_id")
+  private Match match;
+
+  @Column(name = "delta")
+  private int delta;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "reason")
+  private PetExpReason reason;
+
+  @CreatedDate
+  @Column(nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+}

--- a/back/src/main/java/com/qmate/domain/pet/entity/PetExpReason.java
+++ b/back/src/main/java/com/qmate/domain/pet/entity/PetExpReason.java
@@ -1,0 +1,7 @@
+package com.qmate.domain.pet.entity;
+
+public enum PetExpReason {
+  ANSWER_COMPLETED,
+  ADMIN_ADJUST,
+  OTHER
+}

--- a/back/src/main/java/com/qmate/domain/pet/model/response/PetExpResponse.java
+++ b/back/src/main/java/com/qmate/domain/pet/model/response/PetExpResponse.java
@@ -1,0 +1,17 @@
+package com.qmate.domain.pet.model.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PetExpResponse {
+
+  long exp;
+}

--- a/back/src/main/java/com/qmate/domain/pet/repository/PetExpLogRepository.java
+++ b/back/src/main/java/com/qmate/domain/pet/repository/PetExpLogRepository.java
@@ -1,0 +1,8 @@
+package com.qmate.domain.pet.repository;
+
+import com.qmate.domain.pet.entity.PetExpLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PetExpLogRepository extends JpaRepository<PetExpLog, Long> {
+
+}

--- a/back/src/main/java/com/qmate/domain/pet/repository/PetRepository.java
+++ b/back/src/main/java/com/qmate/domain/pet/repository/PetRepository.java
@@ -1,0 +1,10 @@
+package com.qmate.domain.pet.repository;
+
+import com.qmate.domain.pet.entity.Pet;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PetRepository extends JpaRepository<Pet, Long> {
+
+  Optional<Pet> findByMatch_Id(Long matchId);
+}

--- a/back/src/main/java/com/qmate/domain/pet/service/PetService.java
+++ b/back/src/main/java/com/qmate/domain/pet/service/PetService.java
@@ -1,0 +1,28 @@
+package com.qmate.domain.pet.service;
+
+import com.qmate.domain.pet.entity.Pet;
+import com.qmate.domain.pet.model.response.PetExpResponse;
+import com.qmate.domain.pet.repository.PetRepository;
+import com.qmate.exception.custom.matchinstance.MatchNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PetService {
+
+  private final PetRepository petRepository;
+
+  /**
+   * matchId로 펫 경험치 조회
+   */
+  @Transactional(readOnly = true)
+  public PetExpResponse getExpByMatchId(Long matchId) {
+    Pet pet = petRepository.findByMatch_Id(matchId)
+        .orElseThrow(MatchNotFoundException::new);
+    return PetExpResponse.builder()
+        .exp(pet.getExp())
+        .build();
+  }
+}


### PR DESCRIPTION
## 변경 요약
- 펫 도메인 엔티티 추가: Pet, PetExpLog
- Repository 추가: PetRepository(`findByMatch_Id`)
- 서비스/컨트롤러 추가: matchId 기반 EXP 조회 API
- 문서 리팩토링: MatchNotFound 에러 문구 상수화
- 스웨거 정리: AdminNotificationTestController 비노출 처리