### PR TITLE
feat: 매시 50분 질문 생성 & 정각 알림 발송

### DIFF
--- a/back/src/main/java/com/qmate/domain/match/repository/MatchRepository.java
+++ b/back/src/main/java/com/qmate/domain/match/repository/MatchRepository.java
@@ -1,10 +1,13 @@
 package com.qmate.domain.match.repository;
 
 import com.qmate.domain.match.Match;
+import com.qmate.domain.match.MatchStatus;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MatchRepository extends JpaRepository<Match, Long>, MatchRepositoryCustom {
 
@@ -21,4 +24,17 @@ public interface MatchRepository extends JpaRepository<Match, Long>, MatchReposi
       and u.currentMatchId = :matchId
   """)
   Optional<Match> findAuthorizedById(Long matchId, Long userId);
+
+  /**
+   * ACTIVE 매치 중, match_setting.daily_question_hour == :hour 인 매치 목록 조회.
+   */
+  @Query("""
+      select m
+      from Match m
+        join MatchSetting ms on ms.match.id = m.id
+      where m.status = :status
+        and ms.dailyQuestionHour = :hour
+      """)
+  List<Match> findAllActiveByDailyHour(@Param("hour") int hour,
+      @Param("status") MatchStatus status);
 }

--- a/back/src/main/java/com/qmate/domain/question/repository/CustomQuestionRepository.java
+++ b/back/src/main/java/com/qmate/domain/question/repository/CustomQuestionRepository.java
@@ -1,12 +1,30 @@
 package com.qmate.domain.question.repository;
 
 import com.qmate.domain.question.entity.CustomQuestion;
+import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CustomQuestionRepository extends JpaRepository<CustomQuestion, Long>, CustomQuestionQueryRepository {
 
   @EntityGraph(attributePaths = "match")
   Optional<CustomQuestion> findByIdAndCreatedBy(Long id, Long userId);
+
+  @Query("""
+    select cq
+    from CustomQuestion cq
+    where cq.match.id = :matchId
+      and not exists (
+        select 1
+        from QuestionInstance qi
+        where qi.match.id = :matchId
+          and qi.customQuestion.id = cq.id
+      )
+    order by cq.id asc
+    """)
+  List<CustomQuestion> findFirstUnusedForMatchOrderByIdAsc(@Param("matchId") Long matchId, Pageable pageable);
 }

--- a/back/src/main/java/com/qmate/domain/question/repository/QuestionRepository.java
+++ b/back/src/main/java/com/qmate/domain/question/repository/QuestionRepository.java
@@ -19,7 +19,7 @@ public interface QuestionRepository extends JpaRepository<Question, Long>, JpaSp
   @EntityGraph(attributePaths = "category")
   Page<Question> findAll(Specification<Question> spec, Pageable pageable);
 
-  Optional<Question> findFirstByCategory_NameAndRelationTypeAndActiveTrueOrderByIdAsc(
+  Optional<Question> findFirstByCategory_NameAndRelationTypeAndIsActiveTrueOrderByIdAsc(
       String categoryName,
       RelationType relationType
   );

--- a/back/src/main/java/com/qmate/domain/question/repository/QuestionRepository.java
+++ b/back/src/main/java/com/qmate/domain/question/repository/QuestionRepository.java
@@ -1,16 +1,63 @@
 package com.qmate.domain.question.repository;
 
 import com.qmate.domain.question.entity.Question;
+import com.qmate.domain.question.entity.RelationType;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface QuestionRepository extends JpaRepository<Question, Long>, JpaSpecificationExecutor<Question> {
 
   @Override
   @EntityGraph(attributePaths = "category")
   Page<Question> findAll(Specification<Question> spec, Pageable pageable);
+
+  Optional<Question> findFirstByCategory_NameAndRelationTypeAndActiveTrueOrderByIdAsc(
+      String categoryName,
+      RelationType relationType
+  );
+
+  @Query("""
+    select q
+    from Question q
+      join q.category c
+    where c.name = :categoryName
+      and q.isActive = true
+      and q.relationType = :couple
+    order by q.id asc
+    """)
+  List<Question> findActiveCoupleByCategoryNameOrderByIdAsc(
+      @Param("categoryName") String categoryName,
+      @Param("couple") RelationType couple,
+      Pageable pageable
+  );
+
+  @Query("""
+  select q
+  from Question q
+    join Match m on m.id = :matchId
+  where q.isActive = true
+    and (
+         q.relationType = com.qmate.domain.question.entity.RelationType.BOTH
+      or (m.relationType = com.qmate.domain.match.RelationType.COUPLE
+          and q.relationType = com.qmate.domain.question.entity.RelationType.COUPLE)
+      or (m.relationType = com.qmate.domain.match.RelationType.FRIEND
+          and q.relationType = com.qmate.domain.question.entity.RelationType.FRIEND)
+    )
+    and not exists (
+      select 1
+      from QuestionInstance qi
+      where qi.match.id = :matchId
+        and qi.question.id = q.id
+    )
+  order by function('rand')
+  """)
+  List<Question> pickOneRandomUnusedAdminQuestion(@Param("matchId") Long matchId, Pageable pageable);
 }

--- a/back/src/main/java/com/qmate/domain/questioninstance/entity/QuestionInstance.java
+++ b/back/src/main/java/com/qmate/domain/questioninstance/entity/QuestionInstance.java
@@ -55,7 +55,7 @@ public class QuestionInstance {
   @JoinColumn(name = "custom_question_id")
   private CustomQuestion customQuestion;
 
-  @Column(name = "delivered_at", nullable = false)
+  @Column(name = "delivered_at")
   private LocalDateTime deliveredAt;
 
   @Enumerated(EnumType.STRING)

--- a/back/src/main/java/com/qmate/domain/questioninstance/entity/QuestionInstance.java
+++ b/back/src/main/java/com/qmate/domain/questioninstance/entity/QuestionInstance.java
@@ -56,7 +56,7 @@ public class QuestionInstance {
   private CustomQuestion customQuestion;
 
   @Column(name = "delivered_at", nullable = false)
-  private LocalDateTime deliveredAt;     // 스케줄 목표
+  private LocalDateTime deliveredAt;
 
   @Enumerated(EnumType.STRING)
   @Column(name = "status", nullable = false, length = 20)

--- a/back/src/main/java/com/qmate/domain/questioninstance/repository/QuestionInstanceRepository.java
+++ b/back/src/main/java/com/qmate/domain/questioninstance/repository/QuestionInstanceRepository.java
@@ -53,7 +53,7 @@ public interface QuestionInstanceRepository extends JpaRepository<QuestionInstan
 
   @Lock(LockModeType.PESSIMISTIC_WRITE)
   @Query("select qi from QuestionInstance qi where qi.id = :qiId")
-  @QueryHints(@QueryHint(name = "jakarta.persistence.lock.timeout", value = "3000")) // ms
+  @QueryHints(@QueryHint(name = "jakarta.persistence.lock.timeout", value = "1000")) // ms
   Optional<QuestionInstance> findByIdForUpdate(Long qiId);
 
   boolean existsByCustomQuestion_Id(Long customQuestionId);

--- a/back/src/main/java/com/qmate/domain/questioninstance/repository/QuestionInstanceRepository.java
+++ b/back/src/main/java/com/qmate/domain/questioninstance/repository/QuestionInstanceRepository.java
@@ -1,5 +1,6 @@
 package com.qmate.domain.questioninstance.repository;
 
+import com.qmate.domain.match.MatchStatus;
 import com.qmate.domain.questioninstance.entity.QuestionInstance;
 import com.qmate.domain.questioninstance.entity.QuestionInstanceStatus;
 import jakarta.persistence.LockModeType;
@@ -58,4 +59,22 @@ public interface QuestionInstanceRepository extends JpaRepository<QuestionInstan
   boolean existsByCustomQuestion_Id(Long customQuestionId);
 
   List<QuestionInstance> findByMatchIdAndStatus(Long matchId, QuestionInstanceStatus status);
+
+  @Query("""
+      select distinct qi
+      from QuestionInstance qi
+        join fetch qi.match m
+        join MatchSetting ms on ms.match.id = m.id
+        join fetch m.members mm
+        join fetch mm.user u
+      where qi.status = :pending
+        and qi.deliveredAt is null
+        and m.status = :active
+        and ms.dailyQuestionHour = :hour
+      """)
+  List<QuestionInstance> findPendingToDeliverForHourWithMembersAndUser(
+      @Param("hour") int hour,
+      @Param("active") MatchStatus active,
+      @Param("pending") QuestionInstanceStatus pending
+  );
 }

--- a/back/src/main/java/com/qmate/domain/questioninstance/repository/QuestionInstanceRepository.java
+++ b/back/src/main/java/com/qmate/domain/questioninstance/repository/QuestionInstanceRepository.java
@@ -1,8 +1,10 @@
 package com.qmate.domain.questioninstance.repository;
 
 import com.qmate.domain.questioninstance.entity.QuestionInstance;
+import com.qmate.domain.questioninstance.entity.QuestionInstanceStatus;
 import jakarta.persistence.LockModeType;
 import jakarta.persistence.QueryHint;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
@@ -54,4 +56,6 @@ public interface QuestionInstanceRepository extends JpaRepository<QuestionInstan
   Optional<QuestionInstance> findByIdForUpdate(Long qiId);
 
   boolean existsByCustomQuestion_Id(Long customQuestionId);
+
+  List<QuestionInstance> findByMatchIdAndStatus(Long matchId, QuestionInstanceStatus status);
 }

--- a/back/src/main/java/com/qmate/domain/questioninstance/service/DailyQuestionGenerationService.java
+++ b/back/src/main/java/com/qmate/domain/questioninstance/service/DailyQuestionGenerationService.java
@@ -81,7 +81,7 @@ public class DailyQuestionGenerationService {
       // 기념일(100일) 또는 N주년
       // 100일: 카테고리명만으로 1개 가져와서 QI 생성
       if (isCouple(match) && isHundredthDay(match)) {
-        questionRepository.findFirstByCategory_NameAndRelationTypeAndActiveTrueOrderByIdAsc("기념일(100일)", RelationType.COUPLE)
+        questionRepository.findFirstByCategory_NameAndRelationTypeAndIsActiveTrueOrderByIdAsc("기념일(100일)", RelationType.COUPLE)
             .ifPresent(q -> qiRepository.save(QuestionInstance.builder()
                 .match(match)
                 .question(q)

--- a/back/src/main/java/com/qmate/domain/questioninstance/service/DailyQuestionGenerationService.java
+++ b/back/src/main/java/com/qmate/domain/questioninstance/service/DailyQuestionGenerationService.java
@@ -1,0 +1,142 @@
+package com.qmate.domain.questioninstance.service;
+
+import com.qmate.domain.match.MatchStatus;
+import com.qmate.domain.match.Match;
+import com.qmate.domain.match.repository.MatchRepository;
+import com.qmate.domain.question.entity.CustomQuestion;
+import com.qmate.domain.question.entity.Question;
+import com.qmate.domain.question.entity.RelationType;
+import com.qmate.domain.question.repository.CustomQuestionRepository;
+import com.qmate.domain.question.repository.QuestionRepository;
+import com.qmate.domain.questioninstance.entity.QuestionInstance;
+import com.qmate.domain.questioninstance.entity.QuestionInstanceStatus;
+import com.qmate.domain.questioninstance.repository.QuestionInstanceRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class DailyQuestionGenerationService {
+
+  private final MatchRepository matchRepository;
+  private final QuestionInstanceRepository qiRepository;
+  private final CustomQuestionRepository customQuestionRepository;
+  private final QuestionRepository questionRepository;
+
+  /**
+   * 매시 50분에 실행: now+10분(정각) 슬롯을 대상으로 처리.
+   */
+  @Transactional
+  public void generateForNextSlot(ZonedDateTime nowKst) {
+    LocalDateTime targetDelivery = nowKst.plusMinutes(10).withSecond(0).withNano(0).toLocalDateTime();
+    int targetHour = targetDelivery.getHour();
+    // 예: 11:50 실행이면 targetDelivery = 오늘 12:00:00
+    LocalDateTime threshold = targetDelivery.minusHours(23).minusMinutes(30); // 전날 12:30
+
+    // Match 엔티티 자체를 미리 모두 가져옴
+    List<Match> targetMatches = matchRepository.findAllActiveByDailyHour(targetHour, MatchStatus.ACTIVE);
+
+    for (Match match : targetMatches) {
+      Long matchId = match.getId();
+
+      // 매치내 PENDING 상태인 qi 조회
+      List<QuestionInstance> pendings = qiRepository.findByMatchIdAndStatus(matchId, QuestionInstanceStatus.PENDING);
+
+      // 만료 처리 (created_at < threshold)
+      for (QuestionInstance qi : pendings) {
+        LocalDateTime created = qi.getCreatedAt(); // 정책상 created_at만 사용
+        if (created.isBefore(threshold)) {
+          qi.setStatus(QuestionInstanceStatus.EXPIRED);
+          qiRepository.save(qi);
+        }
+      }
+
+      // 이번 슬롯 중복 생성 스킵 (created_at >= threshold 가 하나라도 남아있으면 스킵)
+      boolean hasRecentPending = pendings.stream()
+          .anyMatch(qi -> qi.getStatus() == QuestionInstanceStatus.PENDING
+              && !qi.getCreatedAt().isBefore(threshold)); // created_at >= threshold
+      if (hasRecentPending) {
+        continue;
+      }
+
+      // 커스텀 질문 우선 (미사용 + id 최소)
+      List<CustomQuestion> customList = customQuestionRepository.findFirstUnusedForMatchOrderByIdAsc(matchId, PageRequest.of(0,1));
+      if (!customList.isEmpty()) {
+        CustomQuestion cq = customList.getFirst();
+        QuestionInstance qi = QuestionInstance.builder()
+            .match(match)
+            .customQuestion(cq)
+            .status(QuestionInstanceStatus.PENDING)
+            .build();
+        qiRepository.save(qi);
+        continue;
+      }
+
+      // 기념일(100일) 또는 N주년
+      // 100일: 카테고리명만으로 1개 가져와서 QI 생성
+      if (isCouple(match) && isHundredthDay(match)) {
+        questionRepository.findFirstByCategory_NameAndRelationTypeAndActiveTrueOrderByIdAsc("기념일(100일)", RelationType.COUPLE)
+            .ifPresent(q -> qiRepository.save(QuestionInstance.builder()
+                .match(match)
+                .question(q)
+                .status(QuestionInstanceStatus.PENDING) // delivered_at은 실제 발송 시 세팅
+                .build()));
+        // 100일이면 여기서 끝
+        continue;
+      }
+      // N주년: 몇 주년인지 계산 후, 카테고리 "기념일(N주년)"에서 id 오름차순 기준 n번째를 선택
+      int years = getAnniversaryYears(match); // 없으면 0 1주년 이상이면 1,2,3...
+      if (isCouple(match) && years > 0) {
+        PageRequest page = PageRequest.of(Math.max(0, years - 1), 1);
+        List<Question> list = questionRepository.findActiveCoupleByCategoryNameOrderByIdAsc(
+            "기념일(N주년)", RelationType.COUPLE, page);
+        if (!list.isEmpty()) {
+          Question q = list.getFirst();
+          qiRepository.save(QuestionInstance.builder()
+              .match(match)
+              .question(q)
+              .status(QuestionInstanceStatus.PENDING)
+              .build());
+          continue;
+        }
+      }
+
+      // 4) 일반 질문 랜덤 1개 (미사용)
+      questionRepository.pickOneRandomUnusedAdminQuestion(matchId, PageRequest.of(0,1))
+          .stream()
+          .findFirst()
+          .ifPresent(q -> qiRepository.save(QuestionInstance.builder()
+              .match(match)
+              .question(q)
+              .status(QuestionInstanceStatus.PENDING)
+              .build()));
+    }
+  }
+
+  private boolean isCouple(Match match) {
+    return match.getRelationType() == com.qmate.domain.match.RelationType.COUPLE;
+  }
+
+  private boolean isHundredthDay(Match match) {
+    if (match.getStartDate() == null) return false;
+    LocalDate s = match.getStartDate().toLocalDate();
+    return s.plusDays(100).isEqual(LocalDate.now());
+  }
+
+  private int getAnniversaryYears(Match match) {
+    if (match.getStartDate() == null) return 0;
+    LocalDate s = match.getStartDate().toLocalDate();
+    LocalDate today = LocalDate.now();
+    if (today.getMonthValue() == s.getMonthValue() && today.getDayOfMonth() == s.getDayOfMonth()) {
+      int years = today.getYear() - s.getYear();
+      return years >= 1 ? years : 0; // 1주년 이상만 인정
+    }
+    return 0;
+  }
+}

--- a/back/src/main/java/com/qmate/domain/questioninstance/service/QuestionInstanceAlarmService.java
+++ b/back/src/main/java/com/qmate/domain/questioninstance/service/QuestionInstanceAlarmService.java
@@ -1,0 +1,68 @@
+package com.qmate.domain.questioninstance.service;
+
+import com.qmate.common.push.PushSender;
+import com.qmate.domain.match.MatchMember;
+import com.qmate.domain.match.MatchStatus;
+import com.qmate.domain.match.repository.MatchMemberRepository;
+import com.qmate.domain.notification.entity.Notification;
+import com.qmate.domain.notification.entity.NotificationCategory;
+import com.qmate.domain.notification.entity.NotificationCode;
+import com.qmate.domain.notification.entity.NotificationResourceType;
+import com.qmate.domain.notification.repository.NotificationRepository;
+import com.qmate.domain.questioninstance.entity.QuestionInstance;
+import com.qmate.domain.questioninstance.entity.QuestionInstanceStatus;
+import com.qmate.domain.questioninstance.repository.QuestionInstanceRepository;
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class QuestionInstanceAlarmService {
+
+  private final QuestionInstanceRepository qiRepository;
+  private final NotificationRepository notificationRepository;
+  private final PushSender pushSender;
+
+  /**
+   * 매 정각에 실행: 아직 delivered_at이 null인 PENDING QI를 발송/기록하고,
+   * 매치 멤버 2명에게 알림 생성 후, 알림설정에 따라 전송한다.
+   */
+  @Transactional
+  public void dispatchTopOfHour(ZonedDateTime nowKst) {
+    int hour = nowKst.getHour();
+    LocalDateTime deliveredAt = nowKst.toLocalDateTime();
+
+    // 1) 정각 대상 QI 조회 (delivered_at IS NULL + PENDING + ACTIVE 매치 + 질문시각 일치)
+    List<QuestionInstance> targets =
+        qiRepository.findPendingToDeliverForHourWithMembersAndUser(hour, MatchStatus.ACTIVE, QuestionInstanceStatus.PENDING);
+
+    // 2) delivered_at 세팅(중복 전송 방지) + 알림 생성/발송
+    for (QuestionInstance qi : targets) {
+      qi.setDeliveredAt(deliveredAt);
+      qiRepository.save(qi); // 먼저 찍어 중복 방지
+
+      List<MatchMember> members = qi.getMatch().getMembers();
+      for (MatchMember mm : members) {
+        Notification notification = Notification.builder()
+            .userId(mm.getUser().getId())
+            .matchId(qi.getMatch().getId())
+            .category(NotificationCategory.QUESTION)
+            .code(NotificationCode.QI_TODAY_READY)
+            .pushTitle(NotificationCode.QI_TODAY_READY.getDescription())
+            .listTitle(NotificationCode.QI_TODAY_READY.getDescription())
+            .resourceType(NotificationResourceType.QUESTION_INSTANCE)
+            .resourceId(qi.getId())
+            .build();
+        notificationRepository.save(notification);
+
+        if (mm.getUser().isPushEnabled()) {
+          pushSender.send(notification);
+        }
+      }
+    }
+  }
+}

--- a/back/src/main/java/com/qmate/schedule/DailyQuestionScheduler.java
+++ b/back/src/main/java/com/qmate/schedule/DailyQuestionScheduler.java
@@ -1,0 +1,25 @@
+package com.qmate.schedule;
+
+import com.qmate.domain.questioninstance.service.DailyQuestionGenerationService;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DailyQuestionScheduler {
+
+  private static final ZoneId ZONE_KST = ZoneId.of("Asia/Seoul");
+  private final DailyQuestionGenerationService generationService;
+
+  /**
+   * 매시 50분마다 실행, KST 기준. 예) 11:50에 실행되면 targetDelivery = 12:00 로 계산.
+   */
+  @Scheduled(cron = "0 50 * * * *", zone = "Asia/Seoul")
+  public void runHourly50() {
+    ZonedDateTime now = ZonedDateTime.now(ZONE_KST);
+    generationService.generateForNextSlot(now);
+  }
+}

--- a/back/src/main/java/com/qmate/schedule/DailyQuestionScheduler.java
+++ b/back/src/main/java/com/qmate/schedule/DailyQuestionScheduler.java
@@ -1,6 +1,7 @@
 package com.qmate.schedule;
 
 import com.qmate.domain.questioninstance.service.DailyQuestionGenerationService;
+import com.qmate.domain.questioninstance.service.QuestionInstanceAlarmService;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +14,7 @@ public class DailyQuestionScheduler {
 
   private static final ZoneId ZONE_KST = ZoneId.of("Asia/Seoul");
   private final DailyQuestionGenerationService generationService;
+  private final QuestionInstanceAlarmService alarmService;
 
   /**
    * 매시 50분마다 실행, KST 기준. 예) 11:50에 실행되면 targetDelivery = 12:00 로 계산.
@@ -21,5 +23,11 @@ public class DailyQuestionScheduler {
   public void runHourly50() {
     ZonedDateTime now = ZonedDateTime.now(ZONE_KST);
     generationService.generateForNextSlot(now);
+  }
+
+  // 매 정각 실행
+  @Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul")
+  public void runTopOfHour() {
+    alarmService.dispatchTopOfHour(ZonedDateTime.now(ZONE_KST));
   }
 }

--- a/back/src/test/java/com/qmate/domain/quetioninstance/repository/QuestionInstanceRepositoryTest.java
+++ b/back/src/test/java/com/qmate/domain/quetioninstance/repository/QuestionInstanceRepositoryTest.java
@@ -1,0 +1,114 @@
+package com.qmate.domain.quetioninstance.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.qmate.config.JpaConfig;
+import com.qmate.config.QuerydslConfig;
+import com.qmate.domain.match.Match;
+import com.qmate.domain.match.MatchMember;
+import com.qmate.domain.match.MatchSetting;
+import com.qmate.domain.match.MatchStatus;
+import com.qmate.domain.question.entity.CustomQuestion;
+import com.qmate.domain.questioninstance.entity.QuestionInstance;
+import com.qmate.domain.questioninstance.entity.QuestionInstanceStatus;
+import com.qmate.domain.questioninstance.repository.QuestionInstanceRepository;
+import com.qmate.domain.user.User;
+import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Import({JpaConfig.class, QuerydslConfig.class})
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+//@Tag("local")
+class QuestionInstanceRepositoryTest {
+
+  @Autowired
+  private EntityManager em;
+  @Autowired
+  private QuestionInstanceRepository qiRepository;
+
+  @Test
+  @DisplayName("fetch join: 정각 대상 QI 조회 시 match/members/user까지 로딩되어 Lazy 문제 없이 접근 가능")
+  void findPendingToDeliverForHourWithMembersAndUser_fetchJoin_ok() {
+    // given: Match + Setting + Members + Users + QI (deliveredAt=null, PENDING)
+
+    Match match = Match.builder()
+        .status(MatchStatus.ACTIVE)
+        .relationType(com.qmate.domain.match.RelationType.COUPLE)
+        .startDate(LocalDateTime.now().minusDays(100))
+        .build();
+    em.persist(match);
+
+    MatchSetting ms = new MatchSetting(match);
+    em.persist(ms);
+
+    User u1 = User.builder()
+        .email("test1@test.com")
+        .nickname("test1")
+        .pushEnabled(true)
+        .build();
+    em.persist(u1);
+
+    User u2 = User.builder()
+        .email("test2@test.com")
+        .nickname("test2")
+        .pushEnabled(false)
+        .build();
+    em.persist(u2);
+
+    MatchMember mm1 = MatchMember.builder()
+        .match(match)
+        .user(u1)
+        .build();
+    em.persist(mm1);
+
+    MatchMember mm2 = MatchMember.builder()
+        .match(match)
+        .user(u2)
+        .build();
+    em.persist(mm2);
+
+    CustomQuestion customQuestion = CustomQuestion.builder()
+        .match(match)
+        .createdBy(u1.getId())
+        .text("test")
+        .build();
+    em.persist(customQuestion);
+
+    QuestionInstance qi = QuestionInstance.builder()
+        .match(match)
+        .status(QuestionInstanceStatus.PENDING)
+        .deliveredAt(null)
+        .customQuestion(customQuestion)
+        .createdAt(LocalDateTime.now())
+        .build();
+    em.persist(qi);
+
+    em.flush();
+    em.clear();
+
+    // when
+    List<QuestionInstance> rows = qiRepository.findPendingToDeliverForHourWithMembersAndUser(
+        12, MatchStatus.ACTIVE, QuestionInstanceStatus.PENDING);
+
+    // then
+    assertThat(rows).hasSize(1);
+    QuestionInstance found = rows.get(0);
+
+    // fetch join 확인
+    var members = found.getMatch().getMembers();
+    assertThat(members).hasSize(2);
+    assertThat(members.get(0).getUser().getId()).isNotNull();
+    assertThat(members.get(1).getUser().getId()).isNotNull();
+  }
+}

--- a/back/src/test/java/com/qmate/domain/quetioninstance/service/DailyQuestionGenerationServiceTest.java
+++ b/back/src/test/java/com/qmate/domain/quetioninstance/service/DailyQuestionGenerationServiceTest.java
@@ -1,0 +1,233 @@
+package com.qmate.domain.quetioninstance.service;
+
+import com.qmate.domain.match.Match;
+import com.qmate.domain.match.MatchStatus;
+import com.qmate.domain.match.repository.MatchRepository;
+import com.qmate.domain.question.entity.CustomQuestion;
+import com.qmate.domain.question.entity.Question;
+import com.qmate.domain.question.entity.RelationType;
+import com.qmate.domain.question.repository.CustomQuestionRepository;
+import com.qmate.domain.question.repository.QuestionRepository;
+import com.qmate.domain.questioninstance.entity.QuestionInstance;
+import com.qmate.domain.questioninstance.entity.QuestionInstanceStatus;
+import com.qmate.domain.questioninstance.repository.QuestionInstanceRepository;
+import com.qmate.domain.questioninstance.service.DailyQuestionGenerationService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.BDDMockito.*;
+import static org.assertj.core.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class DailyQuestionGenerationServiceTest {
+
+  @InjectMocks
+  private DailyQuestionGenerationService service;
+
+  @Mock private MatchRepository matchRepository;
+  @Mock private QuestionInstanceRepository qiRepository;
+  @Mock private CustomQuestionRepository customQuestionRepository;
+  @Mock private QuestionRepository questionRepository;
+
+  private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+  // 공통 now/target 설정 (예: 2025-01-10 11:50 KST → targetDelivery 12:00)
+  private ZonedDateTime fixedNow() {
+    return ZonedDateTime.of(2025, 1, 10, 11, 50, 0, 0, KST);
+  }
+
+  private Match mockMatch(long id, com.qmate.domain.match.RelationType relationType, LocalDateTime startDate) {
+    Match m = mock(Match.class);
+    given(m.getId()).willReturn(id);
+    if (relationType != null)    lenient().when(m.getRelationType()).thenReturn(relationType);
+    if (startDate != null) lenient().when(m.getStartDate()).thenReturn(startDate);
+    return m;
+  }
+
+  @Test
+  @DisplayName("만료/스킵: threshold(전날 12:30) 이전 PENDING은 만료, 이후 PENDING 존재 시 생성 스킵")
+  void expireOldPending_and_skip_whenRecentPendingExists() {
+    // given
+    ZonedDateTime now = fixedNow(); // 11:50
+    LocalDateTime targetDelivery = now.plusMinutes(10).withSecond(0).withNano(0).toLocalDateTime(); // 12:00
+    LocalDateTime threshold = targetDelivery.minusHours(23).minusMinutes(30); // 전날 12:30
+
+    Match match = mockMatch(1L, null, null);
+    given(matchRepository.findAllActiveByDailyHour(12, MatchStatus.ACTIVE))
+        .willReturn(List.of(match));
+
+    // pendings: 하나는 threshold 이전(만료대상), 하나는 threshold와 같거나 이후(스킵 유발)
+    QuestionInstance oldPending = mock(QuestionInstance.class);
+    given(oldPending.getCreatedAt()).willReturn(threshold.minusSeconds(1)); // < threshold
+    given(oldPending.getStatus()).willReturn(QuestionInstanceStatus.PENDING);
+
+    QuestionInstance recentPending = mock(QuestionInstance.class);
+    given(recentPending.getCreatedAt()).willReturn(threshold.plusMinutes(30)); // >= threshold
+    given(recentPending.getStatus()).willReturn(QuestionInstanceStatus.PENDING);
+
+    given(qiRepository.findByMatchIdAndStatus(1L, QuestionInstanceStatus.PENDING))
+        .willReturn(List.of(oldPending, recentPending));
+
+    // when
+    service.generateForNextSlot(now);
+
+    // then
+    // 오래된 건 만료 처리(save 호출), 최근 PENDING 존재로 새 QI 생성은 스킵
+    verify(oldPending).setStatus(QuestionInstanceStatus.EXPIRED);
+    verify(qiRepository, atLeastOnce()).save(oldPending);
+    verify(customQuestionRepository, never()).findFirstUnusedForMatchOrderByIdAsc(anyLong(), any());
+    verify(questionRepository, never()).findFirstByCategory_NameAndRelationTypeAndActiveTrueOrderByIdAsc(anyString(), any());
+    verify(questionRepository, never()).findActiveCoupleByCategoryNameOrderByIdAsc(anyString(), any(), any());
+    verify(questionRepository, never()).pickOneRandomUnusedAdminQuestion(anyLong(), any());
+  }
+
+  @Test
+  @DisplayName("생성: 최근 PENDING 없음 + 커스텀 존재 시 커스텀으로 QI 생성")
+  void create_whenNoRecentPending_and_customExists() {
+    // given
+    ZonedDateTime now = fixedNow();
+    Match match = mockMatch(1L, com.qmate.domain.match.RelationType.FRIEND, null);
+    given(matchRepository.findAllActiveByDailyHour(12, MatchStatus.ACTIVE))
+        .willReturn(List.of(match));
+
+    given(qiRepository.findByMatchIdAndStatus(1L, QuestionInstanceStatus.PENDING))
+        .willReturn(List.of()); // 최근 PENDING 없음
+
+    CustomQuestion cq = mock(CustomQuestion.class);
+    given(customQuestionRepository.findFirstUnusedForMatchOrderByIdAsc(1L, PageRequest.of(0, 1)))
+        .willReturn(List.of(cq));
+
+    ArgumentCaptor<QuestionInstance> captor = ArgumentCaptor.forClass(QuestionInstance.class);
+
+    // when
+    service.generateForNextSlot(now);
+
+    // then
+    verify(qiRepository).save(captor.capture());
+    QuestionInstance saved = captor.getValue();
+    assertThat(saved.getCustomQuestion()).isEqualTo(cq);
+    assertThat(saved.getQuestion()).isNull();
+    assertThat(saved.getStatus()).isEqualTo(QuestionInstanceStatus.PENDING);
+  }
+
+  @Test
+  @DisplayName("생성: 커플 100일이면 100일 질문으로 QI 생성(상수 ID 없이 파생메서드)")
+  void create_coupleHundredthDay_question() {
+    // given
+    ZonedDateTime now = fixedNow();
+    LocalDate hundredDaysAgo = LocalDate.now().minusDays(100); // 테스트 시스템 TZ에 의존 → 운영과 동일 TZ로 실행 가정
+    Match match = mockMatch(1L, com.qmate.domain.match.RelationType.COUPLE, hundredDaysAgo.atStartOfDay());
+
+    given(matchRepository.findAllActiveByDailyHour(12, MatchStatus.ACTIVE))
+        .willReturn(List.of(match));
+    given(qiRepository.findByMatchIdAndStatus(1L, QuestionInstanceStatus.PENDING))
+        .willReturn(List.of());
+
+    Question q100 = mock(Question.class);
+    given(questionRepository.findFirstByCategory_NameAndRelationTypeAndActiveTrueOrderByIdAsc("기념일(100일)", RelationType.COUPLE))
+        .willReturn(Optional.of(q100));
+
+    ArgumentCaptor<QuestionInstance> captor = ArgumentCaptor.forClass(QuestionInstance.class);
+
+    // when
+    service.generateForNextSlot(now);
+
+    // then
+    verify(qiRepository).save(captor.capture());
+    QuestionInstance saved = captor.getValue();
+    assertThat(saved.getQuestion()).isEqualTo(q100);
+    assertThat(saved.getCustomQuestion()).isNull();
+  }
+
+  @Test
+  @DisplayName("생성: 커플 N주년이면 '기념일(N주년)' 카테고리에서 n번째(id 오름차순) 선택")
+  void create_coupleNthAnniversary_question() {
+    // given
+    ZonedDateTime now = fixedNow();
+    // 오늘과 월/일 동일, 정확히 2년 전
+    LocalDate twoYearsAgoSameDay = LocalDate.now().minusYears(2);
+    Match match = mockMatch(1L, com.qmate.domain.match.RelationType.COUPLE, twoYearsAgoSameDay.atStartOfDay());
+
+    given(matchRepository.findAllActiveByDailyHour(12, MatchStatus.ACTIVE))
+        .willReturn(List.of(match));
+    given(qiRepository.findByMatchIdAndStatus(1L, QuestionInstanceStatus.PENDING))
+        .willReturn(List.of());
+
+    // years = 2 → offset = 1, size = 1
+    Question qAnniv = mock(Question.class);
+    given(questionRepository.findActiveCoupleByCategoryNameOrderByIdAsc("기념일(N주년)", RelationType.COUPLE, PageRequest.of(1, 1)))
+        .willReturn(List.of(qAnniv));
+
+    ArgumentCaptor<QuestionInstance> captor = ArgumentCaptor.forClass(QuestionInstance.class);
+
+    // when
+    service.generateForNextSlot(now);
+
+    // then
+    verify(qiRepository).save(captor.capture());
+    assertThat(captor.getValue().getQuestion()).isEqualTo(qAnniv);
+  }
+
+  @Test
+  @DisplayName("폴백: 커스텀/기념일/주년 모두 불가 시 미사용 랜덤 질문으로 생성")
+  void fallback_to_random_when_noCustom_noAnniversary() {
+    // given
+    ZonedDateTime now = fixedNow();
+    Match match = mockMatch(1L, com.qmate.domain.match.RelationType.FRIEND, null);
+
+    given(matchRepository.findAllActiveByDailyHour(12, MatchStatus.ACTIVE))
+        .willReturn(List.of(match));
+    given(qiRepository.findByMatchIdAndStatus(1L, QuestionInstanceStatus.PENDING))
+        .willReturn(List.of());
+    given(customQuestionRepository.findFirstUnusedForMatchOrderByIdAsc(1L, PageRequest.of(0, 1)))
+        .willReturn(List.of()); // 커스텀 없음
+    // 100일/주년 미해당 → 관련 쿼리 미호출 또는 빈 결과
+    given(questionRepository.pickOneRandomUnusedAdminQuestion(1L, PageRequest.of(0, 1)))
+        .willReturn(List.of(mock(Question.class)));
+
+    // when
+    service.generateForNextSlot(now);
+
+    // then
+    verify(questionRepository).pickOneRandomUnusedAdminQuestion(eq(1L), eq(PageRequest.of(0, 1)));
+    verify(qiRepository, atLeastOnce()).save(any(QuestionInstance.class));
+  }
+
+  @Test
+  @DisplayName("우선순위: 커스텀 존재 시 100일/주년/랜덤보다 커스텀이 우선")
+  void priority_custom_over_anniversary_and_random() {
+    // given
+    ZonedDateTime now = fixedNow();
+    LocalDate hundredDaysAgo = LocalDate.now().minusDays(100);
+    Match match = mockMatch(1L, com.qmate.domain.match.RelationType.COUPLE, hundredDaysAgo.atStartOfDay());
+
+    given(matchRepository.findAllActiveByDailyHour(12, MatchStatus.ACTIVE))
+        .willReturn(List.of(match));
+    given(qiRepository.findByMatchIdAndStatus(1L, QuestionInstanceStatus.PENDING))
+        .willReturn(List.of());
+
+    CustomQuestion cq = mock(CustomQuestion.class);
+    given(customQuestionRepository.findFirstUnusedForMatchOrderByIdAsc(1L, PageRequest.of(0, 1)))
+        .willReturn(List.of(cq));
+
+    // when
+    service.generateForNextSlot(now);
+
+    // then: 커스텀 선택 후 나머지는 타지 않음
+    verify(qiRepository).save(any(QuestionInstance.class));
+    verify(questionRepository, never()).findFirstByCategory_NameAndRelationTypeAndActiveTrueOrderByIdAsc(anyString(), any());
+    verify(questionRepository, never()).findActiveCoupleByCategoryNameOrderByIdAsc(anyString(), any(), any());
+    verify(questionRepository, never()).pickOneRandomUnusedAdminQuestion(anyLong(), any());
+  }
+}

--- a/back/src/test/java/com/qmate/domain/quetioninstance/service/DailyQuestionGenerationServiceTest.java
+++ b/back/src/test/java/com/qmate/domain/quetioninstance/service/DailyQuestionGenerationServiceTest.java
@@ -87,7 +87,7 @@ class DailyQuestionGenerationServiceTest {
     verify(oldPending).setStatus(QuestionInstanceStatus.EXPIRED);
     verify(qiRepository, atLeastOnce()).save(oldPending);
     verify(customQuestionRepository, never()).findFirstUnusedForMatchOrderByIdAsc(anyLong(), any());
-    verify(questionRepository, never()).findFirstByCategory_NameAndRelationTypeAndActiveTrueOrderByIdAsc(anyString(), any());
+    verify(questionRepository, never()).findFirstByCategory_NameAndRelationTypeAndIsActiveTrueOrderByIdAsc(anyString(), any());
     verify(questionRepository, never()).findActiveCoupleByCategoryNameOrderByIdAsc(anyString(), any(), any());
     verify(questionRepository, never()).pickOneRandomUnusedAdminQuestion(anyLong(), any());
   }
@@ -135,7 +135,7 @@ class DailyQuestionGenerationServiceTest {
         .willReturn(List.of());
 
     Question q100 = mock(Question.class);
-    given(questionRepository.findFirstByCategory_NameAndRelationTypeAndActiveTrueOrderByIdAsc("기념일(100일)", RelationType.COUPLE))
+    given(questionRepository.findFirstByCategory_NameAndRelationTypeAndIsActiveTrueOrderByIdAsc("기념일(100일)", RelationType.COUPLE))
         .willReturn(Optional.of(q100));
 
     ArgumentCaptor<QuestionInstance> captor = ArgumentCaptor.forClass(QuestionInstance.class);
@@ -226,7 +226,7 @@ class DailyQuestionGenerationServiceTest {
 
     // then: 커스텀 선택 후 나머지는 타지 않음
     verify(qiRepository).save(any(QuestionInstance.class));
-    verify(questionRepository, never()).findFirstByCategory_NameAndRelationTypeAndActiveTrueOrderByIdAsc(anyString(), any());
+    verify(questionRepository, never()).findFirstByCategory_NameAndRelationTypeAndIsActiveTrueOrderByIdAsc(anyString(), any());
     verify(questionRepository, never()).findActiveCoupleByCategoryNameOrderByIdAsc(anyString(), any(), any());
     verify(questionRepository, never()).pickOneRandomUnusedAdminQuestion(anyLong(), any());
   }

--- a/back/src/test/java/com/qmate/domain/quetioninstance/service/QuestionInstanceAlarmServiceTest.java
+++ b/back/src/test/java/com/qmate/domain/quetioninstance/service/QuestionInstanceAlarmServiceTest.java
@@ -1,0 +1,84 @@
+// src/test/java/com/qmate/domain/questioninstance/service/QuestionInstanceAlarmServiceTest.java
+package com.qmate.domain.questioninstance.service;
+
+import com.qmate.common.push.PushSender;
+import com.qmate.domain.match.MatchMember;
+import com.qmate.domain.match.repository.MatchMemberRepository;
+import com.qmate.domain.notification.entity.Notification;
+import com.qmate.domain.notification.repository.NotificationRepository;
+import com.qmate.domain.questioninstance.entity.QuestionInstance;
+import com.qmate.domain.questioninstance.entity.QuestionInstanceStatus;
+import com.qmate.domain.questioninstance.repository.QuestionInstanceRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class QuestionInstanceAlarmServiceTest {
+
+  @InjectMocks private QuestionInstanceAlarmService service;
+
+  @Mock private QuestionInstanceRepository qiRepository;
+  @Mock private NotificationRepository notificationRepository;
+  @Mock private PushSender pushSender;
+
+  private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+  @Test
+  @DisplayName("정각: delivered_at 미설정 PENDING QI → delivered_at 세팅 후 멤버별 알림 생성/전송")
+  void dispatchTopOfHour_sendNotificationsForMembers() {
+    // given
+    ZonedDateTime now = ZonedDateTime.of(2025, 1, 10, 12, 0, 0, 0, KST);
+
+    // QI + Match + Members + Users 를 전부 모킹 (fetch join으로 한 번에 로딩됐다고 가정)
+    QuestionInstance qi = mock(QuestionInstance.class, RETURNS_DEEP_STUBS);
+
+    var user1 = mock(com.qmate.domain.user.User.class);
+    given(user1.getId()).willReturn(101L);
+    given(user1.isPushEnabled()).willReturn(true);
+
+    var user2 = mock(com.qmate.domain.user.User.class);
+    given(user2.getId()).willReturn(102L);
+    given(user2.isPushEnabled()).willReturn(false);
+
+    MatchMember mm1 = mock(MatchMember.class, RETURNS_DEEP_STUBS);
+    given(mm1.getUser()).willReturn(user1);
+
+    MatchMember mm2 = mock(MatchMember.class, RETURNS_DEEP_STUBS);
+    given(mm2.getUser()).willReturn(user2);
+
+    given(qi.getId()).willReturn(999L);
+    given(qi.getStatus()).willReturn(QuestionInstanceStatus.PENDING);
+    given(qi.getMatch().getId()).willReturn(1L);
+    given(qi.getMatch().getMembers()).willReturn(List.of(mm1, mm2));
+
+    given(qiRepository.findPendingToDeliverForHourWithMembersAndUser(
+        anyInt(), any(), any())
+    ).willReturn(List.of(qi));
+
+    // when
+    service.dispatchTopOfHour(now);
+
+    // then
+    // delivered_at 기록
+    verify(qi).setDeliveredAt(now.toLocalDateTime());
+    verify(qiRepository).save(qi);
+
+    // 알림 2건 생성
+    ArgumentCaptor<Notification> notiCaptor = ArgumentCaptor.forClass(Notification.class);
+    verify(notificationRepository, times(2)).save(notiCaptor.capture());
+    assertThat(notiCaptor.getAllValues()).hasSize(2);
+
+    // pushEnabled=true 인 user1 에 대해서만 실제 전송
+    verify(pushSender, times(1)).send(any(Notification.class));
+  }
+}


### PR DESCRIPTION
## 개요
- 매시 **50분**: 다음 정각 슬롯의 **질문(QI) 생성**
- 매시 **정각**: **미전송 QI 알림 발송** 및 `delivered_at` 기록
- **커플 전용** 100일/주년 우선 규칙과 **랜덤 보충** 적용
- 알림 대상 조회 시 **fetch join**로 N+1 제거

---

## 주요 변경사항
### 질문 생성 (DailyQuestionGenerationService)
- 실행 시각: 매시 50분 (KST)
- 슬롯 계산: `targetDelivery = now + 10분(정각)`
- 만료 규칙(생성 10분 전 마감 정책):
  - `created_at < (targetDelivery - 23h30m)` 인 PENDING → **EXPIRED**
  - 위 기준에 해당하지 않는 PENDING이 이미 있으면 **이번 슬롯 생성 스킵**
- 선택 우선순위:
  1) **미사용 커스텀 질문**(id 오름차순 1개)  
  2) **커플 + 100일**: 카테고리 `"기념일(100일)"`에서 1개  
  3) **커플 + N주년**: 카테고리 `"기념일(N주년)"`의 id 오름차순 **n번째**  
  4) **관리자 랜덤**(미사용 & 관계타입 호환)
- `delivered_at`: **실제 발송 시각**으로 사용(생성 시 `null` 유지)

### 알림 발송 (QuestionInstanceAlarmService)
- 실행 시각: 매시 정각 (KST)
- 대상: `status=PENDING` & `delivered_at IS NULL` & `match=ACTIVE` & `matchSetting.dailyHour=현재 시`
- 처리:
  - 먼저 QI의 `delivered_at`을 **정각 시각으로 기록**(중복 전송 예방)
  - 매치 멤버 2명 각각 **Notification 생성**
  - 사용자 알림 설정에 따라 **푸시 발송**

---

## 스케줄
- 질문 생성: 매시 **50분**
- 알림 발송: 매시 **정각**
- 타임존: **Asia/Seoul (KST)**

---

## 핵심 비즈니스 규칙
- 생성 10분 전 마감: 이전 슬롯의 미완료 QI는 50분 작업에서 정리(만료/스킵)
- 100일·주년 로직은 **커플 매치**에만 적용
- 랜덤 질문은 이미 사용된 질문 제외(`NOT EXISTS`) + 관계타입 호환
- 동일 슬롯 중복 생성 방지(최근 PENDING 존재 시 스킵)

---

## 테스트
- **서비스 단위(BDDMockito)**  
  - 만료/스킵 임계값 동작, 우선순위(커스텀 > 100일 > N주년 > 랜덤), 랜덤 폴백  
  - 정각 알림: `delivered_at` 기록, 멤버별 Notification 생성, push 설정에 따른 발송
- **JPA 슬라이스(@DataJpaTest, 테스트 프로필)**  
  - 알림 대상 조회 시 fetch join으로 `match.members.user` 지연 로딩 없이 접근 가능 확인  
  - 미사용/관계타입 조건 및 페이지네이션 동작 확인