### PR TITLE
feat: 매치 성사 이후 기념일·랜덤 질문 자동 생성

### DIFF
--- a/back/src/main/java/com/qmate/domain/event/service/EventAnniversaryService.java
+++ b/back/src/main/java/com/qmate/domain/event/service/EventAnniversaryService.java
@@ -1,0 +1,95 @@
+package com.qmate.domain.event.service;
+
+import com.qmate.domain.event.entity.Event;
+import com.qmate.domain.event.entity.EventAlarmOption;
+import com.qmate.domain.event.entity.EventRepeatType;
+import com.qmate.domain.event.repository.EventRepository;
+import com.qmate.domain.match.Match;
+import com.qmate.domain.match.RelationType;
+import com.qmate.domain.user.User;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EventAnniversaryService {
+
+  private static final ZoneId ZONE_KST = ZoneId.of("Asia/Seoul");
+
+  private final EventRepository eventRepository;
+
+  public List<Event> createDefaultAnniversaries(Match match, User userA, User userB) {
+    List<Event> toSave = new ArrayList<>();
+
+    // 1) 100일 (startDate 가 있을 때만)
+    if (match.getRelationType().equals(RelationType.COUPLE) && match.getStartDate() != null) {
+      LocalDate hundredth = match.getStartDate().atZone(ZONE_KST).toLocalDate().plusDays(100);
+      toSave.add(
+          Event.builder()
+              .match(match)
+              .title("100일")
+              .description(null)
+              .eventAt(hundredth)
+              .repeatType(EventRepeatType.NONE)
+              .alarmOption(EventAlarmOption.WEEK_BEFORE)
+              .anniversary(true)
+              .build()
+      );
+
+      // 2) N주년 (매년 반복)
+      LocalDate baseAnniv = match.getStartDate().atZone(ZONE_KST).toLocalDate();
+      toSave.add(
+          Event.builder()
+              .match(match)
+              .title("주년")
+              .description(null)
+              .eventAt(baseAnniv)
+              .repeatType(EventRepeatType.YEARLY)
+              .alarmOption(EventAlarmOption.WEEK_BEFORE)
+              .anniversary(true)
+              .build()
+      );
+    }
+
+    // 3) 유저A 생일 (매년 반복)
+    if (userA.getBirthDate() != null) {
+      LocalDate baseBirthdayA = userA.getBirthDate(); // 연도는 무시, 월/일 기준으로 반복
+      toSave.add(
+          Event.builder()
+              .match(match)
+              .title(userA.getNickname() + " 생일")
+              .description(null)
+              .eventAt(baseBirthdayA)
+              .repeatType(EventRepeatType.YEARLY)
+              .alarmOption(EventAlarmOption.WEEK_BEFORE)
+              .anniversary(true)
+              .build()
+      );
+    }
+
+    // 4) 유저B 생일 (매년 반복)
+    if (userB.getBirthDate() != null) {
+      LocalDate baseBirthdayB = userB.getBirthDate();
+      toSave.add(
+          Event.builder()
+              .match(match)
+              .title(userB.getNickname() + " 생일")
+              .description(null)
+              .eventAt(baseBirthdayB)
+              .repeatType(EventRepeatType.YEARLY)
+              .alarmOption(EventAlarmOption.WEEK_BEFORE)
+              .anniversary(true)
+              .build()
+      );
+    }
+
+    if (toSave.isEmpty()) {
+      return List.of();
+    }
+    return eventRepository.saveAll(toSave);
+  }
+}

--- a/back/src/main/java/com/qmate/domain/match/service/MatchService.java
+++ b/back/src/main/java/com/qmate/domain/match/service/MatchService.java
@@ -20,6 +20,10 @@ import com.qmate.domain.match.model.response.MatchMembersResponse;
 import com.qmate.domain.match.repository.MatchMemberRepository;
 import com.qmate.domain.match.repository.MatchRepository;
 import com.qmate.domain.match.repository.MatchSettingRepository;
+import com.qmate.domain.question.repository.QuestionRepository;
+import com.qmate.domain.questioninstance.entity.QuestionInstance;
+import com.qmate.domain.questioninstance.entity.QuestionInstanceStatus;
+import com.qmate.domain.questioninstance.service.RandomAdminQuestionService;
 import com.qmate.domain.user.User;
 import com.qmate.domain.user.UserRepository;
 import com.qmate.exception.BusinessGlobalException;
@@ -40,6 +44,7 @@ import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -54,6 +59,7 @@ public class MatchService {
   private final RedisHelper redisHelper;
   private final MatchSettingRepository matchSettingRepository;
   private final EventAnniversaryService eventAnniversaryService;
+  private final RandomAdminQuestionService randomAdminQuestionService;
 
   //초대 코드 생성 로직
   @Transactional
@@ -115,6 +121,9 @@ public class MatchService {
 
       // 기념일 생성
       eventAnniversaryService.createDefaultAnniversaries(match, joiner, partner);
+
+      // 첫 질문 생성
+      randomAdminQuestionService.createOneRandomForMatch(match);
 
       return MatchJoinResponse.builder()
           .matchId(matchId)

--- a/back/src/main/java/com/qmate/domain/match/service/MatchService.java
+++ b/back/src/main/java/com/qmate/domain/match/service/MatchService.java
@@ -1,6 +1,7 @@
 package com.qmate.domain.match.service;
 
 import com.qmate.common.redis.RedisHelper;
+import com.qmate.domain.event.service.EventAnniversaryService;
 import com.qmate.domain.match.Match;
 import com.qmate.domain.match.MatchMember;
 import com.qmate.domain.match.MatchSetting;
@@ -52,6 +53,7 @@ public class MatchService {
   private final UserRepository userRepository;
   private final RedisHelper redisHelper;
   private final MatchSettingRepository matchSettingRepository;
+  private final EventAnniversaryService eventAnniversaryService;
 
   //초대 코드 생성 로직
   @Transactional
@@ -110,6 +112,9 @@ public class MatchService {
       joiner.joinMatch(match);
       partner.joinMatch(match);
       redisHelper.deleteInviteCode(inviteCode);
+
+      // 기념일 생성
+      eventAnniversaryService.createDefaultAnniversaries(match, joiner, partner);
 
       return MatchJoinResponse.builder()
           .matchId(matchId)

--- a/back/src/main/java/com/qmate/domain/questioninstance/service/RandomAdminQuestionService.java
+++ b/back/src/main/java/com/qmate/domain/questioninstance/service/RandomAdminQuestionService.java
@@ -1,0 +1,41 @@
+package com.qmate.domain.questioninstance.service;
+
+import com.qmate.domain.match.Match;
+import com.qmate.domain.question.entity.Question;
+import com.qmate.domain.question.repository.QuestionRepository;
+import com.qmate.domain.questioninstance.entity.QuestionInstance;
+import com.qmate.domain.questioninstance.repository.QuestionInstanceRepository;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RandomAdminQuestionService {
+
+  private final QuestionRepository questionRepository;
+  private final QuestionInstanceRepository questionInstanceRepository;
+
+  public Optional<QuestionInstance> createOneRandomForMatch(Match match) {
+    // 랜덤 후보 1건 조회 (미사용 + 활성 + 관계타입 일치)
+    List<Question> picked = questionRepository
+        .pickOneRandomUnusedAdminQuestion(match.getId(), PageRequest.of(0, 1));
+
+    if (picked.isEmpty()) {
+      return Optional.empty();
+    }
+
+    Question question = picked.getFirst();
+
+    // 인스턴스 생성 및 저장
+    QuestionInstance instance = QuestionInstance.builder()
+        .match(match)
+        .question(question)
+        .build();
+
+    QuestionInstance saved = questionInstanceRepository.save(instance);
+    return Optional.of(saved);
+  }
+}

--- a/back/src/test/java/com/qmate/domain/event/service/EventAnniversaryServiceTest.java
+++ b/back/src/test/java/com/qmate/domain/event/service/EventAnniversaryServiceTest.java
@@ -1,0 +1,140 @@
+package com.qmate.domain.event.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.ArgumentMatchers.anyList;
+
+import com.qmate.domain.event.entity.Event;
+import com.qmate.domain.event.entity.EventAlarmOption;
+import com.qmate.domain.event.entity.EventRepeatType;
+import com.qmate.domain.event.repository.EventRepository;
+import com.qmate.domain.match.RelationType;
+import com.qmate.domain.match.Match;
+import com.qmate.domain.user.User;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class EventAnniversaryServiceTest {
+
+  @Mock private EventRepository eventRepository;
+
+  @InjectMocks private EventAnniversaryService service;
+
+  @Captor private ArgumentCaptor<List<Event>> eventsCaptor;
+
+  @Test
+  void coupleWithStartDateAndBirthdays_createsFourEvents_andSavesAll() {
+    // given
+    Match match = mock(Match.class);
+    given(match.getRelationType()).willReturn(RelationType.COUPLE);
+    given(match.getStartDate()).willReturn(LocalDateTime.of(2025, 1, 1, 0, 0));
+
+    User userA = mock(User.class);
+    given(userA.getNickname()).willReturn("A");
+    given(userA.getBirthDate()).willReturn(LocalDate.of(1990, 5, 10));
+
+    User userB = mock(User.class);
+    given(userB.getNickname()).willReturn("B");
+    given(userB.getBirthDate()).willReturn(LocalDate.of(1992, 12, 3));
+
+    // saveAll -> 그대로 반환
+    willAnswer(invocation -> invocation.getArgument(0)).given(eventRepository).saveAll(anyList());
+
+    // when
+    List<Event> saved = service.createDefaultAnniversaries(match, userA, userB);
+
+    // then
+    then(eventRepository).should().saveAll(eventsCaptor.capture());
+    List<Event> toSave = eventsCaptor.getValue();
+
+    assertThat(toSave).hasSize(4);
+    assertThat(saved).hasSize(4);
+
+    // 타이틀 검증 (코드에서 "100일", "주년", "{닉네임} 생일")
+    assertThat(toSave.stream().map(Event::getTitle))
+        .containsExactlyInAnyOrder("100일", "주년", "A 생일", "B 생일");
+
+    // 반복/알림/날짜 일부 검증
+    Event hundred = toSave.stream().filter(e -> e.getTitle().equals("100일")).findFirst().orElseThrow();
+    assertThat(hundred.getRepeatType()).isEqualTo(EventRepeatType.NONE);
+    assertThat(hundred.getAlarmOption()).isEqualTo(EventAlarmOption.WEEK_BEFORE);
+    assertThat(hundred.getEventAt()).isEqualTo(LocalDate.of(2025, 4, 11)); // 2025-01-01 + 100d
+
+    Event anniv = toSave.stream().filter(e -> e.getTitle().equals("주년")).findFirst().orElseThrow();
+    assertThat(anniv.getRepeatType()).isEqualTo(EventRepeatType.YEARLY);
+    assertThat(anniv.getAlarmOption()).isEqualTo(EventAlarmOption.WEEK_BEFORE);
+    assertThat(anniv.getEventAt()).isEqualTo(LocalDate.of(2025, 1, 1));
+
+    Event aBday = toSave.stream().filter(e -> e.getTitle().equals("A 생일")).findFirst().orElseThrow();
+    assertThat(aBday.getRepeatType()).isEqualTo(EventRepeatType.YEARLY);
+    assertThat(aBday.getAlarmOption()).isEqualTo(EventAlarmOption.WEEK_BEFORE);
+    assertThat(aBday.getEventAt()).isEqualTo(LocalDate.of(1990, 5, 10));
+
+    Event bBday = toSave.stream().filter(e -> e.getTitle().equals("B 생일")).findFirst().orElseThrow();
+    assertThat(bBday.getRepeatType()).isEqualTo(EventRepeatType.YEARLY);
+    assertThat(bBday.getAlarmOption()).isEqualTo(EventAlarmOption.WEEK_BEFORE);
+    assertThat(bBday.getEventAt()).isEqualTo(LocalDate.of(1992, 12, 3));
+  }
+
+  @Test
+  void friendRelation_withBirthdays_createsTwoBirthdays_only() {
+    // given
+    Match match = mock(Match.class);
+    given(match.getRelationType()).willReturn(RelationType.FRIEND);
+
+    User userA = mock(User.class);
+    given(userA.getNickname()).willReturn("A");
+    given(userA.getBirthDate()).willReturn(LocalDate.of(1990, 5, 10));
+
+    User userB = mock(User.class);
+    given(userB.getNickname()).willReturn("B");
+    given(userB.getBirthDate()).willReturn(LocalDate.of(1992, 12, 3));
+
+    willAnswer(invocation -> invocation.getArgument(0)).given(eventRepository).saveAll(anyList());
+
+    // when
+    List<Event> saved = service.createDefaultAnniversaries(match, userA, userB);
+
+    // then
+    then(eventRepository).should().saveAll(eventsCaptor.capture());
+    List<Event> toSave = eventsCaptor.getValue();
+
+    assertThat(toSave).hasSize(2);
+    assertThat(saved).hasSize(2);
+    assertThat(toSave.stream().map(Event::getTitle))
+        .containsExactlyInAnyOrder("A 생일", "B 생일");
+  }
+
+  @Test
+  void coupleWithoutBirthdays_stillCreates100thAndAnniversary() {
+    // given
+    Match match = mock(Match.class);
+    given(match.getRelationType()).willReturn(RelationType.COUPLE);
+    given(match.getStartDate()).willReturn(LocalDateTime.of(2024, 2, 1, 0, 0));
+
+    User userA = mock(User.class);
+    given(userA.getBirthDate()).willReturn(null);
+
+    User userB = mock(User.class);
+    given(userB.getBirthDate()).willReturn(null);
+
+    willAnswer(invocation -> invocation.getArgument(0)).given(eventRepository).saveAll(anyList());
+
+    // when
+    List<Event> saved = service.createDefaultAnniversaries(match, userA, userB);
+
+    // then
+    then(eventRepository).should().saveAll(eventsCaptor.capture());
+    List<Event> toSave = eventsCaptor.getValue();
+
+    assertThat(toSave).hasSize(2);
+    assertThat(saved).hasSize(2);
+    assertThat(toSave.stream().map(Event::getTitle)).containsExactlyInAnyOrder("100일", "주년");
+  }
+}

--- a/back/src/test/java/com/qmate/domain/quetioninstance/service/RandomAdminQuestionServiceTest.java
+++ b/back/src/test/java/com/qmate/domain/quetioninstance/service/RandomAdminQuestionServiceTest.java
@@ -1,0 +1,68 @@
+package com.qmate.domain.quetioninstance.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.never;
+
+import com.qmate.domain.match.Match;
+import com.qmate.domain.question.entity.Question;
+import com.qmate.domain.question.repository.QuestionRepository;
+import com.qmate.domain.questioninstance.entity.QuestionInstance;
+import com.qmate.domain.questioninstance.repository.QuestionInstanceRepository;
+import com.qmate.domain.questioninstance.service.RandomAdminQuestionService;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+
+@ExtendWith(MockitoExtension.class)
+class RandomAdminQuestionServiceTest {
+
+  @Mock private QuestionRepository questionRepository;
+  @Mock private QuestionInstanceRepository questionInstanceRepository;
+
+  @InjectMocks private RandomAdminQuestionService service;
+
+  @Test
+  void createOneRandomForMatch_candidateExists_savesAndReturnsInstance() {
+    // given
+    Match match = mock(Match.class);
+    given(match.getId()).willReturn(10L);
+
+    Question q = mock(Question.class);
+    given(questionRepository.pickOneRandomUnusedAdminQuestion(eq(10L), eq(PageRequest.of(0, 1))))
+        .willReturn(List.of(q));
+
+    // save -> 그대로 반환 (id 설정 없어도 무방)
+    willAnswer(invocation -> invocation.getArgument(0))
+        .given(questionInstanceRepository).save(any(QuestionInstance.class));
+
+    // when
+    Optional<QuestionInstance> result = service.createOneRandomForMatch(match);
+
+    // then
+    assertThat(result).isPresent();
+    then(questionInstanceRepository).should().save(argThat(inst ->
+        inst.getMatch() == match && inst.getQuestion() == q
+    ));
+  }
+
+  @Test
+  void createOneRandomForMatch_noCandidate_doesNotSave_returnsEmpty() {
+    // given
+    Match match = mock(Match.class);
+    given(match.getId()).willReturn(20L);
+    given(questionRepository.pickOneRandomUnusedAdminQuestion(eq(20L), eq(PageRequest.of(0, 1))))
+        .willReturn(List.of());
+
+    // when
+    Optional<QuestionInstance> result = service.createOneRandomForMatch(match);
+
+    // then
+    assertThat(result).isEmpty();
+    then(questionInstanceRepository).should(never()).save(any());
+  }
+}


### PR DESCRIPTION
## 개요
매치가 성사되어 `ACTIVE`로 전환되는 시점에 아래 두 로직을 자동 수행합니다.
- 기본 기념일 4종 생성: 100일, 연애기념일(매년), 사용자 A 생일(매년), 사용자 B 생일(매년)
- 관리자 질문 풀에서 활성·관계타입 일치·미사용 조건의 질문을 랜덤 1건 선택하여 QuestionInstance 생성

## 변경 사항
- 서비스 추가
  - EventAnniversaryService#createDefaultAnniversaries(match, userA, userB)
  - RandomAdminQuestionService#createOneRandomForMatch(match)
- 연동 지점
  - MatchService#joinMatch(): 기념일 생성 직후 랜덤 질문 1건 생성 호출을 추가

## 구현 상세
- 기념일 생성
  - RelationType이 COUPLE이고 startDate가 존재할 때 100일·연애기념일 생성
  - 각 사용자 생일이 존재할 경우 생일 이벤트 생성
  - 기본 알림 옵션: WEEK_BEFORE, 반복 규칙: YEARLY(해당 항목)
- 랜덤 질문 생성
  - Repository 쿼리 pickOneRandomUnusedAdminQuestion(matchId, Pageable.ofSize(1)) 사용
  - 후보가 없으면 생성 생략하여 기존 플로우에 영향 없음
- 트랜잭션
  - joinMatch()의 트랜잭션 범위에 함께 참여하여 일괄 커밋

## 테스트
- EventAnniversaryServiceTest
  - 커플+startDate+양측 생일: 4건 생성 검증
  - 친구 관계: 생일 2건만 생성 검증
  - 커플이지만 생일 없음: 100일·연애기념일 2건 생성 검증
- RandomAdminQuestionServiceTest
  - 후보 존재 시 QuestionInstance 저장 및 반환
  - 후보 미존재 시 저장하지 않고 Optional.empty 반환