### PR TITLE
changed securityConfig and added application-prod.yml

### DIFF
--- a/back/src/main/java/com/qmate/config/SecurityConfig.java
+++ b/back/src/main/java/com/qmate/config/SecurityConfig.java
@@ -71,8 +71,8 @@ public class SecurityConfig {
             })
         )
         .authorizeHttpRequests(authz -> authz
-            .requestMatchers("/auth/**",
-                "/oauth2/**", "/login/oauth2/**", "/oauth2/authorization/**").permitAll()
+            .requestMatchers("/auth/**", "/oauth2/**",
+                "/login/oauth2/**", "/oauth2/authorization/**", "/actuator/**").permitAll()
 
             .requestMatchers(SWAGGER_WHITELIST).permitAll()
             .requestMatchers("/api/admin/**").hasRole("ADMIN")

--- a/back/src/main/resources/application-prod.yml
+++ b/back/src/main/resources/application-prod.yml
@@ -1,0 +1,45 @@
+server:
+  port: 8080
+
+spring:
+  config:
+    activate:
+      on-profile: prod
+
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: org.mariadb.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: update      # 초기 배포용. 운영 전환 시 validate 권장
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MariaDBDialect
+        format_sql: true
+        show_sql: false
+
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+      ssl: ${REDIS_SSL:false}
+      timeout: 2s
+      connect-timeout: 2s
+
+security:
+  jwt:
+    secret: ${JWT_SECRET}
+    access-ttl-seconds: ${SECURITY_JWT_ACCESS_TTL_SECONDS:10800}
+    refresh-ttl-seconds: ${SECURITY_JWT_REFRESH_TTL_SECONDS:1209600}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info
+  endpoint:
+    health:
+      show-details: when_authorized


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

- 배포 단계에서 헬스체크 엔드포인트가 보안 필터(Spring Security) 에 막혀서, 비로그인(비JWT) 요청이 “인증 실패”로 처리 됌
- application-prod.yml의 부재로 DB 연결이 배포 url이 아닌, localhost로 가져와짐

**TO-BE**

- SecurityConfig 파일에 `.requestMatchers("/actuator/**").permitAll()` 추가함
- application-prod.yml 파일 생성함