### PR TITLE
feat: 매칭 완료 시 알림 생성 및 푸시 알림 발송 기능 구현

### DIFF
--- a/back/src/main/java/com/qmate/common/constants/notification/NotificationConstants.java
+++ b/back/src/main/java/com/qmate/common/constants/notification/NotificationConstants.java
@@ -14,6 +14,7 @@ public class NotificationConstants {
   public static final String EVENT_SAME_DAY_MSG = "[당일 일정 알림]";
   public static final String EVENT_THREE_DAYS_BEFORE_MSG = "[3일 전 일정 알림]";
   public static final String EVENT_WEEK_BEFORE_MSG = "[1주일 전 일정 알림]";
+  public static final String MATCH_COMPLETED_MSG = "매칭이 성사되었습니다.";
 
   // api docs
   public static final String GET_DETAIL_MD =

--- a/back/src/main/java/com/qmate/domain/match/service/MatchService.java
+++ b/back/src/main/java/com/qmate/domain/match/service/MatchService.java
@@ -1,5 +1,6 @@
 package com.qmate.domain.match.service;
 
+import com.qmate.common.push.PushSender;
 import com.qmate.common.redis.RedisHelper;
 import com.qmate.domain.event.service.EventAnniversaryService;
 import com.qmate.domain.match.Match;
@@ -20,6 +21,11 @@ import com.qmate.domain.match.model.response.MatchMembersResponse;
 import com.qmate.domain.match.repository.MatchMemberRepository;
 import com.qmate.domain.match.repository.MatchRepository;
 import com.qmate.domain.match.repository.MatchSettingRepository;
+import com.qmate.domain.notification.entity.Notification;
+import com.qmate.domain.notification.entity.NotificationCategory;
+import com.qmate.domain.notification.entity.NotificationCode;
+import com.qmate.domain.notification.entity.NotificationResourceType;
+import com.qmate.domain.notification.repository.NotificationRepository;
 import com.qmate.domain.pet.service.PetService;
 import com.qmate.domain.question.repository.QuestionRepository;
 import com.qmate.domain.questioninstance.entity.QuestionInstance;
@@ -62,6 +68,8 @@ public class MatchService {
   private final MatchSettingRepository matchSettingRepository;
   private final EventAnniversaryService eventAnniversaryService;
   private final RandomAdminQuestionService randomAdminQuestionService;
+  private final NotificationRepository notificationRepository;
+  private final PushSender pushSender;
 
   //초대 코드 생성 로직
   @Transactional
@@ -121,6 +129,9 @@ public class MatchService {
 
       joiner.joinMatch(match);
       partner.joinMatch(match);
+      // 매칭이 성사되었으므로, 두 멤버 모두에게 알림을 보냅니다.
+      sendMatchCompletionNotification(joiner, partner, match);
+      sendMatchCompletionNotification(partner, joiner, match);
       redisHelper.deleteInviteCode(inviteCode);
 
       // 기념일 생성
@@ -291,7 +302,34 @@ public class MatchService {
   }
 
 
-  //가독성을 위한 private 헬퍼 메서드(초대 생성 관련)
+  //자동 연결 끊기 서비스 로직 구현
+  @Transactional
+  public void disconnectInactiveMatches(){
+    LocalDateTime toWeeksAgo = LocalDateTime.now().minusWeeks(2);
+    List<Match> inactiveMatches = matchRepository.findInactiveMatches(toWeeksAgo);
+
+    for (Match match : inactiveMatches){
+      match.getMembers().forEach(matchMember -> matchMember.getUser().leaveMatch());
+      match.disconnect();
+    }
+  log.info("{}개의 비활성 매칭을 연결 끊기 상태로 전환했습니다.", inactiveMatches.size());
+  }
+
+  // 유예기간 지난 상태 델리트로 변경.
+  @Transactional
+  public void finalizeExpiredMatches(){
+    LocalDateTime toWeeksAgo = LocalDateTime.now().minusWeeks(2);
+    List<Match> expiredMatches = matchRepository.findMatchesForSoftDelete(toWeeksAgo);
+
+    for (Match match : expiredMatches){
+      // user의 current_match_id는 이미 null이므로 추가 작업 필요 없음
+    match.markAsDeleted();
+    }
+    log.info("{}개의 만료된 매칭을 삭제 처리했습니다.", expiredMatches.size());
+  }
+
+
+  //=======가독성을 위한 private 헬퍼 메서드(초대 생성 관련)==========
   private void validateUserNotInActiveMatch(Long userId) {
     matchMemberRepository.findByUser_IdAndMatch_Status(userId, MatchStatus.ACTIVE)
         .ifPresent(matchMember -> {
@@ -323,7 +361,7 @@ public class MatchService {
     throw new RuntimeException("초대 코드 생성에 10회 이상 실패했습니다.");
   }
 
-  //가독성을 위한 private 헬퍼 메서드(매칭 조인 관련)
+  //========가독성을 위한 private 헬퍼 메서드(매칭 조인 관련)==========
   private void validateJoinAttempt(Match match, Long joinerId) {
     if (match.getStatus() != MatchStatus.WAITING) {
       throw new AlreadyInMatchException();
@@ -343,29 +381,33 @@ public class MatchService {
         .findFirst()
         .orElseThrow(PartnerNotFoundException::new);
   }
-  //자동 연결 끊기 서비스 로직 구현
-  @Transactional
-  public void disconnectInactiveMatches(){
-    LocalDateTime toWeeksAgo = LocalDateTime.now().minusWeeks(2);
-    List<Match> inactiveMatches = matchRepository.findInactiveMatches(toWeeksAgo);
+  //가독성을 위한 private 헬퍼 메서드(매칭알림 관련)
+  /**
+   * 매칭 완료 알림을 생성하고 발송하는 헬퍼 메서드
+   * @param recipient 알림을 받을 사용자
+   * @param partner 매칭된 상대방
+   * @param match 성사된 매칭
+   */
+  private void sendMatchCompletionNotification(User recipient, User partner, Match match) {
+    String title = partner.getNickname() + "님과 매칭되었습니다!";
 
-    for (Match match : inactiveMatches){
-      match.getMembers().forEach(matchMember -> matchMember.getUser().leaveMatch());
-      match.disconnect();
+    // 1. DB에 저장할 Notification 객체 생성 (보내주신 엔티티 구조에 맞게)
+    Notification notification = Notification.builder()
+        .userId(recipient.getId()) // Notification은 User 객체가 아닌 Long ID를 가짐
+        .matchId(match.getId())
+        .category(NotificationCategory.MATCH) // 보내주신 Enum 사용
+        .code(NotificationCode.MATCH_COMPLETED)   // 위에서 추가한 Enum 값
+        .listTitle(title)
+        .pushTitle(title)
+        .resourceType(NotificationResourceType.MATCH) // 보내주신 Enum 사용
+        .resourceId(match.getId())
+        .build();
+
+    notificationRepository.save(notification);
+
+    // 2. 사용자가 푸시 알림을 켜놨다면, 실제 푸시 알림 발송
+    if (recipient.isPushEnabled()) { // 보내주신 User 엔티티의 pushEnabled 필드 사용
+      pushSender.send(notification); // 보내주신 PushSender 인터페이스 사용
     }
-  log.info("{}개의 비활성 매칭을 연결 끊기 상태로 전환했습니다.", inactiveMatches.size());
-  }
-
-  // 유예기간 지난 상태 델리트로 변경.
-  @Transactional
-  public void finalizeExpiredMatches(){
-    LocalDateTime toWeeksAgo = LocalDateTime.now().minusWeeks(2);
-    List<Match> expiredMatches = matchRepository.findMatchesForSoftDelete(toWeeksAgo);
-
-    for (Match match : expiredMatches){
-      // user의 current_match_id는 이미 null이므로 추가 작업 필요 없음
-    match.markAsDeleted();
-    }
-    log.info("{}개의 만료된 매칭을 삭제 처리했습니다.", expiredMatches.size());
   }
 }

--- a/back/src/main/java/com/qmate/domain/notification/entity/NotificationCode.java
+++ b/back/src/main/java/com/qmate/domain/notification/entity/NotificationCode.java
@@ -13,9 +13,11 @@ public enum NotificationCode {
   // EVENT
   EVENT_SAME_DAY(NotificationConstants.EVENT_SAME_DAY_MSG),
   EVENT_THREE_DAYS_BEFORE(NotificationConstants.EVENT_THREE_DAYS_BEFORE_MSG),
-  EVENT_WEEK_BEFORE(NotificationConstants.EVENT_WEEK_BEFORE_MSG),;
+  EVENT_WEEK_BEFORE(NotificationConstants.EVENT_WEEK_BEFORE_MSG),
 
   // MATCH
+  MATCH_COMPLETED(NotificationConstants.MATCH_COMPLETED_MSG),;
+
 
   private final String description;
 

--- a/back/src/test/java/com/qmate/domain/match/service/MatchServiceNotificationTest.java
+++ b/back/src/test/java/com/qmate/domain/match/service/MatchServiceNotificationTest.java
@@ -1,0 +1,77 @@
+package com.qmate.domain.match.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.qmate.common.push.PushSender;
+import com.qmate.domain.event.service.EventAnniversaryService;
+import com.qmate.domain.match.Match;
+import com.qmate.domain.match.MatchMember;
+import com.qmate.domain.match.model.request.MatchJoinRequest;
+import com.qmate.domain.match.repository.MatchMemberRepository;
+import com.qmate.domain.match.repository.MatchRepository;
+import com.qmate.domain.notification.entity.Notification;
+import com.qmate.domain.notification.repository.NotificationRepository;
+import com.qmate.domain.notification.service.NotificationService;
+import com.qmate.domain.pet.service.PetService;
+import com.qmate.domain.questioninstance.service.RandomAdminQuestionService;
+import com.qmate.domain.user.User;
+import com.qmate.domain.user.UserRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import com.qmate.common.redis.RedisHelper;
+
+@ExtendWith(MockitoExtension.class)
+class MatchServiceNotificationTest {
+
+  @InjectMocks
+  private MatchService sut;
+
+  @Mock private MatchRepository matchRepository;
+  @Mock private MatchMemberRepository matchMemberRepository;
+  @Mock private UserRepository userRepository;
+  @Mock private RedisHelper redisHelper;
+  @Mock private NotificationRepository notificationRepository;
+  @Mock private PushSender pushSender;
+  @Mock private PetService petService;
+  @Mock private NotificationService notificationService;
+  @Mock private EventAnniversaryService eventAnniversaryService;
+  @Mock private RandomAdminQuestionService randomAdminQuestionService;
+  @Test
+  @DisplayName("매칭 성공 알림: 두 멤버 모두 알림 기록이 생성되고, pushEnabled=true인 멤버에게만 푸시가 발송된다")
+  void joinMatch_sendsNotification_whenMatchCompleted() {
+    // given: 1번 유저(푸시 ON)와 2번 유저(푸시 OFF)가 매칭되는 상황
+    Long matchId = 1L;
+    User user1 = User.builder().id(1L).nickname("푸시ON유저").pushEnabled(true).build();
+    User user2 = User.builder().id(2L).nickname("푸시OFF유저").pushEnabled(false).build();
+    Match match = Match.builder().id(matchId).build();
+    match.addMember(MatchMember.create(user1, match)); // 초대자가 이미 방에 있는 상태
+
+    var request = new MatchJoinRequest();
+    request.setInviteCode("123456");
+
+    given(userRepository.findById(2L)).willReturn(Optional.of(user2));
+    given(redisHelper.getMatchIdByInviteCode("123456")).willReturn(Optional.of(matchId));
+    given(matchRepository.findById(matchId)).willReturn(Optional.of(match));
+    given(matchMemberRepository.findAllByMatch_Id(matchId)).willReturn(List.of(match.getMembers().get(0)));
+
+    // when: 2번 유저가 매칭에 참여하면
+    sut.joinMatch(request, 2L);
+
+    // then:
+    // 1. NotificationRepository의 save가 '총 2번' 호출되었는지 검증 (두 멤버 모두 기록은 남아야 함)
+    verify(notificationRepository, times(2)).save(any(Notification.class));
+
+    // 2. PushSender의 send가 '오직 1번만' 호출되었는지 검증 (푸시 ON인 유저에게만)
+    verify(pushSender, times(1)).send(any(Notification.class));
+  }
+}


### PR DESCRIPTION
### 개요
팀원분의 가이드라인에 따라, **매칭이 최종적으로 성사되었을 때 두 멤버 모두에게 알림을 보내는 기능**을 구현했습니다.

이 기능은 **(1) DB에 알림 내역을 기록**하고, **(2) 사용자의 푸시 알림 설정(`pushEnabled`) 여부에 따라** `PushSender`를 통해 **실제 푸시 알림을 발송**하는 두 가지 역할을 수행합니다. 이를 통해 사용자에게 매칭 성사 사실을 즉시 알려주어 사용자 경험을 개선합니다.

### 변경 사항

#### Enum 수정
- **`NotificationCode.java`**: '매칭 완료'를 나타내는 `MATCH_COMPLETED` Enum 값을 새로 추가했습니다.
- **`NotificationConstants.java`**: `MATCH_COMPLETED`에 대한 설명 메시지 상수를 추가했습니다.

#### Service
- **`MatchService#joinMatch` (수정)**
    - `PushSender`와 `NotificationRepository`를 의존성으로 주입받도록 수정했습니다.
    - 매칭 상태가 `ACTIVE`로 변경된 직후, `sendMatchCompletionNotification` 헬퍼 메서드를 호출하여 두 멤버 모두에게 알림을 보내는 로직을 추가했습니다.
- **`MatchService#sendMatchCompletionNotification` (신규 헬퍼 메서드)**
    - 팀의 `Notification` 엔티티 스키마에 맞춰, 알림을 받을 사용자(`recipient`)와 상대방(`partner`) 정보를 바탕으로 `Notification` 객체를 생성합니다.
    - 생성된 `Notification` 객체를 `notificationRepository.save()`를 통해 DB에 저장합니다.
    - `recipient.isPushEnabled()` 값을 확인하여, `true`일 경우에만 `pushSender.send(notification)`을 호출하여 실제 푸시 알림을 발송합니다.

### 테스트
- **[X] 서비스 단위 테스트**
    - `MatchServiceNotificationTest.java`를 신규 작성하여 알림 발송 로직을 검증했습니다.
    - **시나리오:** 한 명은 푸시 알림을 켜고(`pushEnabled=true`), 다른 한 명은 끈(`false`) 상태에서 매칭이 성사되는 상황을 가정했습니다.
    - **검증 내용:**
        - `notificationRepository.save()`가 **총 2번** 호출되어 두 멤버 모두의 알림이 DB에 기록되는지 확인했습니다.
        - `pushSender.send()`는 **오직 1번만** 호출되어, 알림을 켜놓은 사용자에게만 푸시가 발송되는지 확인했습니다.