### PR TITLE
feat: 알림 삭제 API 추가

### DIFF
--- a/back/src/main/java/com/qmate/api/notification/NotificationController.java
+++ b/back/src/main/java/com/qmate/api/notification/NotificationController.java
@@ -18,11 +18,15 @@ import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -80,5 +84,16 @@ public class NotificationController {
   @GetMapping("/unread-count")
   public long getUnreadCount(@AuthenticationPrincipal UserPrincipal principal) {
     return notificationService.getUnreadCount(principal.userId());
+  }
+
+  @Operation(summary = "알림 삭제", description = NotificationConstants.DELETE_MD)
+  @DeleteMapping("/{notificationId}")
+  @ResponseStatus(HttpStatus.NO_CONTENT) // 204
+  public ResponseEntity<Void> delete(
+      @AuthenticationPrincipal UserPrincipal principal,
+      @PathVariable long notificationId
+  ) {
+    notificationService.deleteAuthorized(principal.userId(), notificationId);
+    return ResponseEntity.noContent().build();
   }
 }

--- a/back/src/main/java/com/qmate/common/constants/notification/NotificationConstants.java
+++ b/back/src/main/java/com/qmate/common/constants/notification/NotificationConstants.java
@@ -42,4 +42,12 @@ public class NotificationConstants {
 
   public static final String GET_UNREAD_COUNT_MD =
       "읽지 않은 알림의 개수를 조회합니다.\n\n";
+
+  public static final String DELETE_MD =
+      "특정 알림을 삭제합니다.\n\n"
+          + "### 에러 응답\n\n"
+          + "| HTTP | errorCode | message |\n"
+          + "|-----:|-----------|---------|\n"
+          + "| " + HttpStatusCode.NOT_FOUND + " | " + NotificationErrorCode.NOTIFICATION_NOT_FOUND_ERROR_CODE + " | "
+          + NotificationErrorCode.NOTIFICATION_NOT_FOUND_MESSAGE + " |\n\n";
 }

--- a/back/src/main/java/com/qmate/domain/notification/service/NotificationService.java
+++ b/back/src/main/java/com/qmate/domain/notification/service/NotificationService.java
@@ -74,4 +74,13 @@ public class NotificationService {
   public long getUnreadCount(Long userId) {
     return notificationRepository.countAuthorizedUnread(userId);
   }
+
+  /**
+   * 본인 소유 알림인지 확인 후 삭제 (204 No Content 용)
+   */
+  public void deleteAuthorized(long userId, long notificationId) {
+    Notification n = notificationRepository.findAuthorizedDetail(userId, notificationId)
+        .orElseThrow(NotificationNotFoundException::new);
+    notificationRepository.delete(n);
+  }
 }


### PR DESCRIPTION
## 요약
- 사용자의 notificationId로 본인 소유 알림을 삭제하는 API를 추가했습니다.
- 조회에서 권한 검증을 통과한 뒤 즉시 삭제하며, 응답은 204 No Content를 반환합니다.
- 트랜잭션 어노테이션은 사용하지 않습니다.

## 변경 사항
- API 레이어: DELETE /api/notifications/{notificationId}
- 서비스 레이어: findAuthorizedDetail(userId, notificationId) 조회 후 delete 수행
- 예외 처리: 권한 불일치 또는 미존재 시 NotificationNotFoundException 발생
- 스웨거: ResponseStatus를 NO_CONTENT로 명시