### PR TITLE
CI: CodeDeploy 배포 번들 골격 + 수동(Sandbox) S3 업로드 워크플로우 추가

### DIFF
--- a/.github/workflows/deploy-sandbox.yml
+++ b/.github/workflows/deploy-sandbox.yml
@@ -1,0 +1,58 @@
+name: Deploy Sandbox (S3 Upload)
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "sandbox 하위 폴더명 (미입력 시 git SHA)"
+        required: false
+
+jobs:
+  build-and-upload:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Gradle cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Build (prod)
+        run: ./gradlew :back:clean :back:bootJar -Pprofile=prod
+
+      - name: Make bundle.zip
+        run: |
+          rm -rf bundle && mkdir -p bundle/scripts
+          cp appspec.yml bundle/
+          cp -r scripts/* bundle/scripts/
+          cp back/build/libs/*.jar bundle/app.jar
+          chmod +x bundle/scripts/*.sh
+          (cd bundle && zip -r ../bundle.zip .)
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-northeast-2
+
+      - name: Upload to S3
+        env:
+          S3_BUCKET: qmate-deploy-artifacts-470246886205-apne2
+          BUILD_ID: ${{ github.event.inputs.tag || github.sha }}
+        run: |
+          aws s3 cp bundle.zip s3://$S3_BUCKET/qmate/sandbox/$BUILD_ID/bundle.zip

--- a/appspec.yml
+++ b/appspec.yml
@@ -1,0 +1,27 @@
+version: 0.0
+os: linux
+files:
+  - source: app.jar
+    destination: /opt/qmate/release
+permissions:
+  - object: /opt/qmate
+    owner: ec2-user
+    group: ec2-user
+    pattern: "**"
+hooks:
+  BeforeInstall:
+    - location: scripts/before_install.sh
+      timeout: 180
+      runas: root
+  AfterInstall:
+    - location: scripts/after_install.sh
+      timeout: 180
+      runas: root
+  ApplicationStart:
+    - location: scripts/application_start.sh
+      timeout: 180
+      runas: root
+  ValidateService:
+    - location: scripts/validate_service.sh
+      timeout: 60
+      runas: root

--- a/scripts/after_install.sh
+++ b/scripts/after_install.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# 이전 잔여 파일 정리(옵션)
+find /opt/qmate/release -maxdepth 1 -name "*.jar" -type f -mtime +7 -exec rm -f {} \; || true
+
+# 권한 보정
+chown -R ec2-user:ec2-user /opt/qmate/release

--- a/scripts/application_start.sh
+++ b/scripts/application_start.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# 기존 프로세스가 systemd로 관리된다고 가정
+systemctl daemon-reload || true
+systemctl enable qmate.service || true
+systemctl restart qmate.service

--- a/scripts/before_install.sh
+++ b/scripts/before_install.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# 디렉터리 준비
+mkdir -p /opt/qmate/release
+chown -R ec2-user:ec2-user /opt/qmate

--- a/scripts/validate_service.sh
+++ b/scripts/validate_service.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# 헬스체크(필요 시 엔드포인트 변경)
+# 127.0.0.1:8080/actuator/health 기준
+for i in {1..20}; do
+  if curl -sf http://127.0.0.1:8080/actuator/health | grep -q '"status":"UP"'; then
+    exit 0
+  fi
+  sleep 3
+done
+
+echo "Health check failed"
+exit 1


### PR DESCRIPTION
## 요약
- 레포 루트에 CodeDeploy 배포 번들 골격 추가(appspec.yml, scripts/*).
- 수동 실행 가능한 GitHub Actions 워크플로우 추가(.github/workflows/deploy-sandbox.yml).
- prod 프로필 빌드 → bundle.zip 생성 → S3(sandbox 프리픽스) 업로드까지 자동화.

## 변경 사항
- appspec.yml 추가
- scripts/
  - before_install.sh, after_install.sh, application_start.sh, validate_service.sh 추가
- .github/workflows/deploy-sandbox.yml 추가
  - workflow_dispatch 입력(tag) 지원
  - :back:bootJar(prod) 빌드 → bundle.zip 생성 → S3 업로드

## 설정/시크릿
- GitHub Secrets
  - `AWS_ACCESS_KEY_ID`
  - `AWS_SECRET_ACCESS_KEY`
- 워크플로우 내 상수(필요 시 수정)
  - `aws-region: ap-northeast-2`
  - `S3_BUCKET: qmate-deploy-artifacts-470246886205-apne2`