### PR TITLE
Feature/notification

### DIFF
--- a/front/src/api/notification.ts
+++ b/front/src/api/notification.ts
@@ -59,6 +59,11 @@ export const fetchNotificationDetail = async (notificationId: number) => {
   const res = await axios.get(`/api/notifications/${notificationId}`);
   return res.data;
 };
+// 알림 삭제
+export const deleteNotification = async (notificationId: number) => {
+  const res = await axios.delete(`/api/notifications/${notificationId}`);
+  return res.data;
+};
 //읽지않은 알림갯수
 export const fetchUnreadCount = async () => {
   const res = await axios.get('/api/notifications/unread-count');

--- a/front/src/api/schedule.ts
+++ b/front/src/api/schedule.ts
@@ -81,9 +81,13 @@ export const updateSchedule = async ({
   });
   return res.data;
 };
-export const fetchEventMonth = async (year: number, month: number): Promise<EventMonthResponse> => {
-  const res = await axios.get<EventMonthResponse>(`http://localhost:3006/calendarMonth`, {
-    params: { year, month },
+export const fetchEventMonth = async (
+  matchId: number,
+  from: string,
+  to: string,
+): Promise<EventMonthResponse> => {
+  const res = await axios.get<EventMonthResponse>(`/api/matches/${matchId}/events/calendar`, {
+    params: { from, to },
   });
   return res.data;
 };

--- a/front/src/components/common/BellBtn.tsx
+++ b/front/src/components/common/BellBtn.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { Bell, Loader2 } from 'lucide-react';
+import { Bell, Loader2, X } from 'lucide-react';
 import React, { useEffect, useRef, useState } from 'react';
 import { Sheet, SheetContent, SheetTitle, SheetTrigger } from '../ui/sheet';
 import {
@@ -14,6 +14,7 @@ import { useRouter } from 'next/navigation';
 import { useIntersectionObserver, useMediaQuery } from 'usehooks-ts';
 import { flatNotifications, formatTimeAgo } from '@/utils/notificationUtils';
 import CategoryIcons from '../notification/ui/CategoryIcons';
+import { deleteNotification } from '@/api/notification';
 
 export default function BellBtn() {
   const isMobile = useMediaQuery('(max-width: 640px)');
@@ -74,17 +75,28 @@ export default function BellBtn() {
       </button>
     );
   }
-  const clickHandler = (item: contentItemType): void => {
+  const clickHandler = async (item: contentItemType): Promise<void> => {
     setSelectedId(item.notificationId);
-    if (item.category === 'EVENT') {
-      router.push(`/schedule`);
+
+    let href = '/';
+    switch (item.category) {
+      case 'EVENT':
+        href = '/schedule';
+        break;
+      case 'QUESTION':
+        href = `/question/detail?id=${detail?.resourceId}`;
+        break;
+      case 'MATCH':
+        href = '/main';
+        break;
     }
-    if (item.category === 'QUESTION') {
-      router.push(`/question/detail?id=${detail?.resourceId}`);
+
+    try {
+      await router.prefetch(href);
+    } catch (e) {
+      console.error(e);
     }
-    if (item.category === 'MATCH') {
-      router.push(`/main`);
-    }
+    router.push(href);
   };
 
   return (
@@ -110,19 +122,23 @@ export default function BellBtn() {
             {items.map((item: contentItemType) => (
               <li
                 key={item.notificationId}
-                onClick={() => clickHandler(item)}
                 className={cn(
                   `mx-3 p-3 flex items-center gap-4 ${
                     item.read === false ? 'bg-unread' : 'bg-read border-read-border border'
-                  } w-[290px] h-25 rounded-sm cursor-pointer`,
+                  } w-[290px] h-25 rounded-sm`,
                 )}
               >
-                <div className="flex flex-col justify-center">
-                  <div className="flex gap-3">
+                <div className="flex justify-between w-full h-full items-center">
+                  <div
+                    className="flex gap-3 w-50 h-full py-3 cursor-pointer"
+                    onClick={() => clickHandler(item)}
+                  >
                     <CategoryIcons
                       category={item.category}
                       className={cn(
-                        `w-6 h-6 ${item.read === false ? '!text-primary' : '!text-text-unread'} `,
+                        `w-6 h-6 items-start ${
+                          item.read === false ? '!text-primary' : '!text-text-unread'
+                        } `,
                       )}
                     />
                     <div className="flex flex-col text-14 font-normal">
@@ -141,6 +157,12 @@ export default function BellBtn() {
 
                       <p className="text-text-unread">{formatTimeAgo(item.createdAt)}</p>
                     </div>
+                  </div>
+                  <div
+                    className="flex h-full w-10 items-center cursor-pointer"
+                    onClick={() => deleteNotification(item.notificationId)}
+                  >
+                    <X className="w-6 h-6" />
                   </div>
                 </div>
               </li>

--- a/front/src/components/common/Nav.tsx
+++ b/front/src/components/common/Nav.tsx
@@ -44,9 +44,10 @@ export default function Nav() {
       {/* 데스크탑 (상단 고정) */}
       <header className="hidden sm:flex fixed top-0 left-0 w-full h-[70px] items-center z-40 bg-transparent">
         <Link href="/main">
-          <span
+          <img
+            src="/logo.svg"
+            alt="큐메이트 로고"
             className="site-logo inline-block w-[109px] h-[35px] ml-7"
-            role="img"
             aria-label="큐메이트"
           />
         </Link>

--- a/front/src/components/notification/Notification.tsx
+++ b/front/src/components/notification/Notification.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { ChevronLeft, Loader2, Trash2 } from 'lucide-react';
+import { Loader2, X } from 'lucide-react';
 import React, { useEffect, useRef, useState } from 'react';
 
 import { useInfiniteNotifications, useNotificationDetail } from '@/hooks/useNotificationList';
@@ -10,6 +10,7 @@ import { useRouter } from 'next/navigation';
 import { useIntersectionObserver } from 'usehooks-ts';
 import { flatNotifications, formatTimeAgo } from '@/utils/notificationUtils';
 import CategoryIcons from './ui/CategoryIcons';
+import { deleteNotification } from '@/api/notification';
 
 export default function Notification() {
   const router = useRouter();
@@ -40,15 +41,34 @@ export default function Notification() {
     }
   }, [entry?.isIntersecting, hasNextPage, isFetchingNextPage, fetchNextPage]);
 
+  const clickHandler = async (item: contentItemType): Promise<void> => {
+    setSelectedId(item.notificationId);
+
+    let href = '/';
+    switch (item.category) {
+      case 'EVENT':
+        href = '/schedule';
+        break;
+      case 'QUESTION':
+        href = `/question/detail?id=${detail?.resourceId}`;
+        break;
+      case 'MATCH':
+        href = '/main';
+        break;
+    }
+
+    try {
+      await router.prefetch(href);
+    } catch (e) {
+      console.error(e);
+    }
+    router.push(href);
+  };
+
   return (
     <div className="w-full h-full flex flex-col justify-center items-center sm:pt-0 pt-[70px]">
       <div className="fixed top-0 left-0 right-0 flex items-center justify-between py-5 sm:hidden px-4">
-        <button
-          className="relative flex ml-7 w-fit h-full hover:opacity-80 rounded-md p-2 bell-btn justify-center items-center"
-          onClick={() => router.back()}
-        >
-          <ChevronLeft className="w-7 h-7" />
-        </button>
+        <div className="relative flex ml-7 w-fit h-full hover:opacity-80 rounded-md p-2 bell-btn justify-center items-center"></div>
         <span className="absolute left-1/2 -translate-x-1/2 font-Gumi text-20 text-theme-primary">
           알림
         </span>
@@ -56,7 +76,7 @@ export default function Notification() {
           className="relative flex mr-7 w-fit h-full hover:opacity-80 rounded-md p-2 bell-btn justify-center items-center"
           onClick={() => router.back()}
         >
-          <Trash2 className="w-7 h-7" />
+          <X className="w-7 h-7" />
         </button>
       </div>
       <div ref={scrollRef} className="w-full h-full overflow-y-auto bg-white">
@@ -91,7 +111,7 @@ export default function Notification() {
                 } w-full h-25 cursor-pointer`,
               )}
             >
-              <div className="flex flex-col justify-center">
+              <div className="flex flex-col justify-center w-full" onClick={() => clickHandler}>
                 <div className="flex gap-3">
                   <CategoryIcons
                     category={item.category}
@@ -114,6 +134,12 @@ export default function Notification() {
                     <p className="text-text-unread">{formatTimeAgo(item.createdAt)}</p>
                   </div>
                 </div>
+              </div>
+              <div
+                className="flex h-full w-20 items-center justify-center cursor-pointer"
+                onClick={() => deleteNotification(item.notificationId)}
+              >
+                <X className="w-6 h-6" />
               </div>
             </li>
           ))}

--- a/front/src/components/question/QuestionDetail.tsx
+++ b/front/src/components/question/QuestionDetail.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useSearchParams, useRouter, usePathname } from 'next/navigation';
+import { useSearchParams } from 'next/navigation';
 import {
   useQuestionDetail,
   useAnswerQuestion,
@@ -10,7 +10,6 @@ import {
 import AnswerView from './AnswerView';
 import Custom from './Custom';
 import AnswerForm from './ui/AnswerForm';
-import CloseButton from '../common/CloseButton';
 import { Answer } from '@/types/questionType';
 import { useFetchCustomQuestions } from '@/hooks/useCustom';
 import { useMatchIdStore } from '@/store/useMatchIdStore';
@@ -24,9 +23,6 @@ export default function QuestionDetail() {
   const questionInstanceId = idParam ? Number(idParam.replace('custom-', '')) : null;
   const matchId = useMatchIdStore((state) => state.matchId);
   const queryClient = useQueryClient();
-
-  const router = useRouter();
-  const pathname = usePathname();
 
   // 커스텀 질문 불러오기
   const { data } = useFetchCustomQuestions(matchId!);

--- a/front/src/components/question/ui/AnswerForm.tsx
+++ b/front/src/components/question/ui/AnswerForm.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { usePathname, useRouter } from 'next/navigation';
 import CloseButton from '@/components/common/CloseButton';
 import { Button } from '@/components/common/Button';
@@ -10,7 +10,6 @@ import Link from 'next/link';
 import TextTextarea, { TextTextareaRef } from './TextTextarea';
 import { useSelectedStore } from '@/store/useSelectedStore';
 import ConfirmModal from '@/components/common/ConfirmModal';
-import { set } from 'zod';
 import { ratingQuestion } from '@/api/questions';
 
 type AnswerFormProps = {

--- a/front/src/components/schedule/Schedule.tsx
+++ b/front/src/components/schedule/Schedule.tsx
@@ -11,7 +11,7 @@ export default function Schedule() {
   const setSelectedMenu = useSelectedStore((state) => state.setSelectedMenu);
   return (
     <div className="sm:pt-[35px] w-full h-full">
-      <div className="flex w-full h-[70px] items-center justify-between sm:hidden">
+      <div className="fixed top-0 left-0 right-0 flex items-center justify-between py-5 sm:hidden px-4">
         <Link href="/schedule/list" aria-label="일정 리스트로 이동">
           <CalendarDays className="text-theme-primary ml-7" />
         </Link>
@@ -30,7 +30,7 @@ export default function Schedule() {
           <ScheduleListWeb />
         </div>
 
-        <div className="flex-2 flex justify-center">
+        <div className="flex-2 flex justify-center pt-[70px] sm:pt-0">
           <ScheduleView />
         </div>
       </div>

--- a/front/src/components/schedule/ScheduleView.tsx
+++ b/front/src/components/schedule/ScheduleView.tsx
@@ -1,71 +1,93 @@
 'use client';
-import { useScheduleList } from '@/hooks/useSchedule';
+import { useEventDetail, useEventMonth, useScheduleList } from '@/hooks/useSchedule';
 import React, { useMemo, useState } from 'react';
 import MainCalendar from './calendar/MainCalendar';
 import EventList from './list/EventList';
-import { isEventOnDate, toKey } from '@/utils/date';
+import { getCalendarRange, isEventOnDate, toKey } from '@/utils/date';
 import AddBtn from './ui/AddBtn';
 import { useMatchIdStore } from '@/store/useMatchIdStore';
 import { ScheduleEvent } from '@/types/scheduleType';
 
 export default function ScheduleView() {
   const [selected, setSelected] = useState<Date | undefined>(new Date());
+  const [displayMonth, setDisplayMonth] = useState<Date>(new Date());
   const matchId = useMatchIdStore((state) => state.matchId);
 
   const monthRange = useMemo(() => {
-    const base = selected ?? new Date();
-
-    const start = new Date(base.getFullYear(), base.getMonth(), 1);
-    const end = new Date(base.getFullYear(), base.getMonth() + 1, 0);
+    const base = displayMonth;
+    const { start, end } = getCalendarRange(base);
 
     return {
       from: toKey(start),
       to: toKey(end),
     };
-  }, [selected]);
+  }, [displayMonth]);
 
-  const { data, isLoading, isError } = useScheduleList(matchId!, {
-    from: monthRange.from,
-    to: monthRange.to,
-  });
+  // const { data, isLoading, isError } = useScheduleList(matchId!, {
+  //   from: monthRange.from,
+  //   to: monthRange.to,
+  // });
+  const { data: monthEvent } = useEventMonth(matchId!, monthRange.from, monthRange.to);
+
+  const eventId: number | undefined = useMemo(() => {
+    //날짜 자르기 yyyy-mm-dd
+    const ymd = toKey(selected ?? new Date());
+    return monthEvent?.days.find((d) => d.eventAt === ymd)?.eventId;
+  }, [monthEvent, selected]);
+  const {
+    data: detail,
+    isLoading: isDetailLoading,
+    isError: isDetailError,
+  } = useEventDetail(matchId!, eventId!);
 
   const anniversarySet = useMemo(() => {
     const s = new Set<string>();
-    (data?.content ?? []).forEach((e) => {
-      if (e.isAnniversary) s.add(e.eventAt);
+    (monthEvent?.days ?? []).forEach((d) => {
+      if (d.anniversary) s.add(d.eventAt);
     });
     return s;
-  }, [data]);
+  }, [monthEvent]);
 
   const scheduleSet = useMemo(() => {
     const s = new Set<string>();
-    (data?.content ?? []).forEach((e) => {
-      if (!e.isAnniversary && !anniversarySet.has(e.eventAt)) s.add(e.eventAt);
+    (monthEvent?.days ?? []).forEach((d) => {
+      if (!d.anniversary) s.add(d.eventAt);
     });
     return s;
-  }, [data, anniversarySet]);
-
-  console.log(data);
+  }, [monthEvent]);
 
   const dayItems: ScheduleEvent[] = useMemo(() => {
-    const list = data?.content ?? [];
-    return list.filter((event) => isEventOnDate(event, selected ?? new Date()));
-  }, [data, selected]);
+    return detail ? [detail] : [];
+  }, [detail]);
+  const handleDateSelect = (date: Date | undefined) => {
+    if (!date) return;
+
+    setSelected(date);
+
+    if (
+      date.getMonth() !== displayMonth.getMonth() ||
+      date.getFullYear() !== displayMonth.getFullYear()
+    ) {
+      setDisplayMonth(new Date(date.getFullYear(), date.getMonth(), 1));
+    }
+  };
 
   return (
     <div className="w-full h-full flex justify-center md:rounded-lg md:min-w-[450px] md:max-w-[900px]">
       <div className="relative flex flex-col justify-center w-full h-full">
         <MainCalendar
           selected={selected}
-          onSelect={(date) => date && setSelected(date)}
+          onSelect={handleDateSelect}
           anniversarySet={anniversarySet}
           scheduleSet={scheduleSet}
+          displayMonth={displayMonth}
+          onDisplayMonthChange={(d) => setDisplayMonth(new Date(d.getFullYear(), d.getMonth(), 1))}
         />
         <EventList
           date={selected ?? new Date()}
           items={dayItems}
-          isLoading={isLoading}
-          isError={isError}
+          isLoading={isDetailLoading}
+          isError={isDetailError}
         />
         <AddBtn />
       </div>

--- a/front/src/components/schedule/calendar/MainCalendar.tsx
+++ b/front/src/components/schedule/calendar/MainCalendar.tsx
@@ -10,13 +10,24 @@ type Props = {
   onSelect: (date: Date | undefined) => void;
   anniversarySet: Set<string>;
   scheduleSet: Set<string>;
+  displayMonth: Date;
+  onDisplayMonthChange: (date: Date) => void;
 };
-export default function MainCalendar({ selected, onSelect, anniversarySet, scheduleSet }: Props) {
+export default function MainCalendar({
+  selected,
+  onSelect,
+  anniversarySet,
+  scheduleSet,
+  displayMonth,
+  onDisplayMonthChange,
+}: Props) {
   return (
     <div className="flex flex-1 justify-center w-full">
       <Calendar
         mode="single"
-        defaultMonth={selected}
+        // defaultMonth={selected}
+        month={displayMonth}
+        onMonthChange={onDisplayMonthChange}
         selected={selected}
         onSelect={onSelect}
         className="w-full md:rounded-t-lg theme-night:bg-black"

--- a/front/src/hooks/useNotificationList.ts
+++ b/front/src/hooks/useNotificationList.ts
@@ -1,10 +1,15 @@
-import { fetchNotificationDetail, fetchNotifications, fetchUnreadCount } from '@/api/notification';
+import {
+  deleteNotification,
+  fetchNotificationDetail,
+  fetchNotifications,
+  fetchUnreadCount,
+} from '@/api/notification';
 import {
   ListParams,
   notificationListResponseType,
   notificationResponseType,
 } from '@/types/notification';
-import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 //알림 리스트
 export const useNotifications = (params: ListParams) => {
@@ -39,7 +44,19 @@ export const useNotificationDetail = (notificationId?: number) => {
     staleTime: 1000 * 60 * 5,
   });
 };
+//알림 삭제
+export const useDeleteNotification = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (notificationId: number) => deleteNotification(notificationId),
+    onSuccess: () => {
+      // 무한스크롤목록 /안 읽은 카운트 최신화
 
+      queryClient.invalidateQueries({ queryKey: ['notificationsInfinite'] });
+      queryClient.invalidateQueries({ queryKey: ['unreadCount'] });
+    },
+  });
+};
 //읽지 않은 알림
 export const useUnreadCount = () => {
   return useQuery({

--- a/front/src/hooks/useSchedule.ts
+++ b/front/src/hooks/useSchedule.ts
@@ -8,7 +8,7 @@ import {
   fetchScheduleList,
   updateSchedule,
 } from '@/api/schedule';
-import { EventMonthResponse, ScheduleEvent, ScheduleResponse } from '@/types/scheduleType';
+import { EventMonthResponse, ScheduleEvent } from '@/types/scheduleType';
 import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 //스케줄 리스트 조회
@@ -84,8 +84,8 @@ export const useUpdateSchedule = (matchId: number, eventId: number) => {
   return useMutation({
     mutationFn: (body: {
       title: string;
-      description: string | null; // nullable
-      eventAt: string; // YYYY-MM-DD
+      description: string | null;
+      eventAt: string;
       repeatType: 'NONE' | 'WEEKLY' | 'MONTHLY' | 'YEARLY';
       alarmOption: 'NONE' | 'WEEK_BEFORE' | 'THREE_DAYS_BEFORE' | 'SAME_DAY';
     }) =>

--- a/front/src/hooks/useSchedule.ts
+++ b/front/src/hooks/useSchedule.ts
@@ -57,14 +57,13 @@ export const useDeleteSchedule = () => {
   });
 };
 
-export const useEventMonth = (year: number, month: number) => {
+export const useEventMonth = (matchId: number, from: string, to: string) => {
   return useQuery<EventMonthResponse>({
-    queryKey: ['calendarMonth', year, month],
-    queryFn: () => fetchEventMonth(year, month),
-
+    queryKey: ['calendarMonth', matchId, from, to],
+    queryFn: () => fetchEventMonth(matchId, from, to),
+    enabled: Boolean(matchId && from && to),
     placeholderData: keepPreviousData,
-    staleTime: 1000 * 60 * 10,
-    gcTime: 1000 * 60 * 60,
+    staleTime: 1000 * 60 * 5,
   });
 };
 export const useEventDetail = (matchId: number, eventId: number) => {
@@ -75,7 +74,6 @@ export const useEventDetail = (matchId: number, eventId: number) => {
     staleTime: 1000 * 30,
     gcTime: 1000 * 60 * 10,
     refetchOnWindowFocus: false,
-    placeholderData: keepPreviousData,
   });
 };
 

--- a/front/src/mocks/handlers/notifications.ts
+++ b/front/src/mocks/handlers/notifications.ts
@@ -28,6 +28,7 @@ export const notificationsHandler = [
       count: 2,
     });
   }),
+  //알림 리스트
   http.get('/api/notifications', async ({ request }) => {
     const url = new URL(request.url);
     const page = Number(url.searchParams.get('page') ?? '0');
@@ -60,62 +61,27 @@ export const notificationsHandler = [
       empty: content.length === 0,
     });
   }),
-  //알림 리스트 조회
-  // http.get('/api/notifications', async ({ params }) => {
-  //   return HttpResponse.json({
+  //알림 삭제
+  http.delete('/api/notifications/:notificationId(\\d+)', async ({ params }) => {
+    const notificationId = Number(params.notificationId);
 
-  //     content: [
-  //       {
-  //         notificationId: 1,
-  //         category: 'QUESTION',
-  //         code: 'QI_TODAY_READY',
-  //         listTitle: '오늘의 질문이 도착했어요!',
-  //         createdAt: '2025-10-04T07:00:16.313Z',
-  //         read: true,
-  //       },
-  //       {
-  //         notificationId: 2,
-  //         category: 'EVENT',
-  //         code: 'EVENT_SAME_DAY',
-  //         listTitle: '오늘은 기념일이에요 🎉',
-  //         createdAt: '2025-10-03T10:32:45.100Z',
-  //         read: false,
-  //       },
-  //       {
-  //         notificationId: 3,
-  //         category: 'MATCH',
-  //         code: 'MATCH_CONNECTED',
-  //         listTitle: '새로운 매칭이 연결되었어요.',
-  //         createdAt: '2025-10-02T22:11:00.000Z',
-  //         read: false,
-  //       },
-  //       {
-  //         notificationId: 4,
-  //         category: 'MATCH',
-  //         code: 'MATCH_CONNECTED',
-  //         listTitle: '새로운 매칭이 연결되었어요.',
-  //         createdAt: '2025-10-02T22:11:10.000Z',
-  //         read: false,
-  //       },
-  //       {
-  //         notificationId: 5,
-  //         category: 'MATCH',
-  //         code: 'MATCH_CONNECTED',
-  //         listTitle: '새로운 매칭이 연결되었어요.',
-  //         createdAt: '2025-10-02T22:11:20.000Z',
-  //         read: false,
-  //       },
-  //       {
-  //         notificationId: 6,
-  //         category: 'MATCH',
-  //         code: 'MATCH_CONNECTED',
-  //         listTitle: '새로운 매칭이 연결되었어요.',
-  //         createdAt: '2025-10-02T22:11:30.000Z',
-  //         read: false,
-  //       },
-  //     ],
-  //   });
-  // }),
+    if (!Number.isFinite(notificationId)) {
+      return HttpResponse.json(
+        { error: 'NOTIFICATION_NOT_FOUND', message: 'Notification not found' },
+        { status: 404 },
+      );
+    }
+
+    const exists = ALL.some((n) => n.notificationId === notificationId);
+    if (!exists) {
+      return HttpResponse.json(
+        { error: 'NOTIFICATION_NOT_FOUND', message: 'Notification not found' },
+        { status: 404 },
+      );
+    }
+
+    return new HttpResponse(null, { status: 204 });
+  }),
   //알림 상세 조회
   http.get('/api/notifications/:notificationId(\\d+)', async ({ params }) => {
     const { notificationId } = params;

--- a/front/src/mocks/handlers/schedule.ts
+++ b/front/src/mocks/handlers/schedule.ts
@@ -1,3 +1,4 @@
+import { EventMonthResponse } from '@/types/scheduleType';
 import { http, HttpResponse } from 'msw';
 
 interface ScheduleRequestBody {
@@ -43,6 +44,28 @@ const events = [
     createdAt: '2025-09-20T12:32:11',
     updatedAt: '2025-09-28T09:10:01',
   },
+  {
+    eventId: 4,
+    title: '기념일 저녁',
+    description: '19:00 예약',
+    eventAt: '2025-10-20',
+    repeatType: 'YEARLY',
+    alarmOption: 'SAME_DAY',
+    isAnniversary: true,
+    createdAt: '2025-09-20T12:32:11',
+    updatedAt: '2025-09-28T09:10:01',
+  },
+  {
+    eventId: 5,
+    title: '일정',
+    description: '19:00 예약',
+    eventAt: '2025-09-29',
+    repeatType: 'YEARLY',
+    alarmOption: 'SAME_DAY',
+    isAnniversary: false,
+    createdAt: '2025-09-20T12:32:11',
+    updatedAt: '2025-09-28T09:10:01',
+  },
 ];
 
 export const scheduleHandlers = [
@@ -65,6 +88,49 @@ export const scheduleHandlers = [
       },
       { status: 200 },
     );
+  }),
+  // 월별 조회
+
+  http.get('/api/matches/:matchId/events/calendar', ({ request, params }) => {
+    const url = new URL(request.url);
+    const from = url.searchParams.get('from');
+    const to = url.searchParams.get('to');
+
+    if (!from || !to) {
+      return HttpResponse.json({ error: 'from, to required' }, { status: 400 });
+    }
+
+    const fromDate = new Date(from);
+    const toDate = new Date(to);
+    const diffDays = Math.ceil((toDate.getTime() - fromDate.getTime()) / (1000 * 60 * 60 * 24));
+
+    if (diffDays > 60) {
+      return HttpResponse.json(
+        { error: '조회 기간은 최대 60일까지만 허용합니다.' },
+        { status: 400 },
+      );
+    }
+    const year = fromDate.getFullYear();
+    const month = fromDate.getMonth() + 1;
+    const allEvents = [
+      { eventId: 1, eventAt: '2025-10-25', anniversary: false },
+      { eventId: 2, eventAt: '2025-10-29', anniversary: true },
+      { eventId: 3, eventAt: '2025-10-20', anniversary: true },
+      { eventId: 4, eventAt: '2025-10-9', anniversary: true },
+      { eventId: 5, eventAt: '2025-09-25', anniversary: false },
+    ];
+
+    const filteredDays = allEvents.filter((day) => {
+      return day.eventAt >= from && day.eventAt <= to;
+    });
+
+    const mockData: EventMonthResponse = {
+      year,
+      month,
+      days: filteredDays,
+    };
+
+    return HttpResponse.json(mockData);
   }),
   // 일정 상세 조회
   http.get('/api/matches/:matchId/events/:eventId', ({ params }) => {
@@ -101,7 +167,7 @@ export const scheduleHandlers = [
   }),
 
   // 삭제
-  http.delete('/api/matches/:matchId/events/:eventId', async ({ params }) => {
+  http.delete('/api/matches/:matchId/events/:eventId(\\d+)', async ({ params }) => {
     const eventId = Number(params.eventId);
     const index = events.findIndex((e) => e.eventId === eventId);
 

--- a/front/src/types/scheduleType.ts
+++ b/front/src/types/scheduleType.ts
@@ -54,5 +54,5 @@ export type EventMonthResponse = {
 export type EventDay = {
   eventId: number;
   eventAt: string;
-  isAnniversary: boolean;
+  anniversary: boolean;
 };

--- a/front/src/utils/date.ts
+++ b/front/src/utils/date.ts
@@ -34,3 +34,23 @@ export const isEventOnDate = (event: ScheduleEvent, selected: Date): boolean => 
       return false;
   }
 };
+
+//일요일 기준 달력에 표시되는 날짜 구간
+export const getCalendarRange = (date: Date) => {
+  const firstDay = new Date(date.getFullYear(), date.getMonth(), 1);
+
+  const lastDay = new Date(date.getFullYear(), date.getMonth() + 1, 0);
+
+  const calendarStart = new Date(firstDay);
+  const firstDayOfWeek = firstDay.getDay();
+  calendarStart.setDate(firstDay.getDate() - firstDayOfWeek);
+
+  const calendarEnd = new Date(lastDay);
+  const lastDayOfWeek = lastDay.getDay();
+  calendarEnd.setDate(lastDay.getDate() + (6 - lastDayOfWeek));
+
+  return {
+    start: calendarStart,
+    end: calendarEnd,
+  };
+};


### PR DESCRIPTION
## 📝 작업 내용

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 업데이트
- [x] 기타 (설명)

## 🔍 변경 사항
#### 알림관련
- 알림 삭제 기능 추가
- 알림 모바일 상단바 수정 (알림리스트 뷰+캘린더 뷰)
- 불필요한 import 삭제
#### 캘린더 관련
- 이벤트 상세조회 hook에서 데이터 유지 제거
- 캘린더 타입 및 fetch함수 수정
- 캘린더 기념일 표기 dot 및 이벤트 리스트 호출 리펙토링 
    -> 월별조회 api추가 전 리스트로 기념일과 일정에 대한 구분을 월별조회 api가 추가 되어 수정
- 캘린더 조회 범위 수정
    -> 기존 해당 월의 이벤트만 조회하였으나 캘린더 표시 기준 전월과 다음달 함께 표기되도록 수정
- 날짜 클릭시 같은 월에 해당하는 이벤트는 나타나지만 캘린더뷰에서 함께 표기되는 다른 월의 날짜를 클릭 시 기존 표시 사라짐
    -> 다른 월 클릭시 월이 바뀌도록 수정

## 💬 기타 공유 사항
브랜치를 분리하여 작업했어야 했는데 수정하다 보니 브랜치 변경이 안되어있는지 확인을 못했습니다.

추가로 MSW목업 데이터 에서 404 에러가 많이 나와서 원인을 못찾다가
fetch함수와 hook작성을 잘못한 줄 알고 수정만하다 시간 소요가 많이 됬는데

원인을 알아보니
MSW는 핸들러 배열을 순서대로 매칭을 시도합니다
구체적인 경로(정적 세그먼트)는 동적 파라미터(:param)보다 반드시 먼저 정의해야 한다고 합니다.
api명세서에서 같은 엔드포인트
http.get('/api/matches/:matchId/events/:eventId', ...)
http.get('/api/matches/:matchId/events/calendar', ...)
를 예로들면 calendar를 인식못하고 eventId를 읽어서 에러가 발생합니다.

공유되면 좋을 것 같아서 작성합니다.