### PR TITLE
feat: 로그인 로직 개선 (토큰 만료 시 로그아웃 처리 및 소셜 리다이렉트 방식 적용)

### DIFF
--- a/front/src/api/auth.ts
+++ b/front/src/api/auth.ts
@@ -14,8 +14,7 @@ export const logoutUser = async () => {
 
 //소셜 로그인
 export const socialLogin = async (provider: string) => {
-  const res = await instance.post(`/oauth2/authorization/${provider}`);
-  return res.data;
+  window.location.href = `/oauth2/authorization/${provider}`;
 };
 
 //추가 폼 정보 입력
@@ -26,6 +25,6 @@ export const updateSocialProfile = async ({
   nickname: string;
   birthDate: string;
 }) => {
-  const res = await instance.patch(`/users/me/profile`, { nickname, birthDate });
+  const res = await instance.patch(`api/users/me/profile`, { nickname, birthDate });
   return res.data;
 };

--- a/front/src/api/axiosInstance.ts
+++ b/front/src/api/axiosInstance.ts
@@ -9,7 +9,6 @@ export const instance = axios.create({
 
 instance.interceptors.request.use(
   (config) => {
-    console.log('accessToken:', useAuthStore.getState().accessToken);
     const token = useAuthStore.getState().accessToken;
     if (token) {
       config.headers.Authorization = `Bearer ${token}`;

--- a/front/src/app/login/success/page.tsx
+++ b/front/src/app/login/success/page.tsx
@@ -1,0 +1,6 @@
+import LoginSuccess from '@/components/login/LoginSuccess';
+import React from 'react';
+
+export default function page() {
+  return <LoginSuccess />;
+}

--- a/front/src/components/home/Home.tsx
+++ b/front/src/components/home/Home.tsx
@@ -5,39 +5,54 @@ import { useAuthStore } from '@/store/useAuthStore';
 import { useRouter } from 'next/navigation';
 import { useMatchIdStore } from '@/store/useMatchIdStore';
 import { useSelectedStore } from '@/store/useSelectedStore';
+import { useLogoutUser } from '@/hooks/useAuth';
+import { ErrorToast } from '../common/CustomToast';
+import Loader from '../common/Loader';
+import { useEffect, useState } from 'react';
 
 export default function Home() {
-  const accessToken = useAuthStore((state) => state.accessToken);
-  const accessTokenTime = Number(localStorage.getItem('accessTokenTime'));
   const router = useRouter();
+  const accessToken = useAuthStore((state) => state.accessToken);
   const resetMatchId = useMatchIdStore((state) => state.resetMatchId);
   const resetAccessToken = useAuthStore((state) => state.resetAccessToken);
   const setSelectedMenu = useSelectedStore((state) => state.setSelectedMenu);
+  const resetSelectedMenu = useSelectedStore((state) => state.resetSelectedMenu);
+  const { mutate: logoutMutate, isPending } = useLogoutUser();
+
+  const [accessTokenTime, setAccessTokenTime] = useState<number | null>(null);
+
+  useEffect(() => {
+    const savedTime = localStorage.getItem('accessTokenTime');
+    if (savedTime) setAccessTokenTime(Number(savedTime));
+  }, []);
+
   const checkLogin = () => {
-    if (accessToken && Date.now() < accessTokenTime) {
-      // 아직 유효하면 메인으로 이동
+    if (accessToken && accessTokenTime && Date.now() < accessTokenTime) {
       setSelectedMenu('home');
       router.replace('/main');
-    } else if ((accessToken && Date.now() >= accessTokenTime) || !accessTokenTime) {
-      // 만료된 토큰이면 전부 정리
-      //선택된 메뉴 리셋
-      setSelectedMenu('home');
-      // exp 리셋
-      localStorage.clear();
-      // 매치 아이디 리셋
-      resetMatchId();
-      // 토큰 리셋
-      resetAccessToken();
-      router.replace('/login');
+    } else {
+      logoutMutate(undefined, {
+        onSuccess: () => {
+          resetSelectedMenu();
+          localStorage.clear();
+          resetMatchId();
+          resetAccessToken();
+          router.replace('/login');
+        },
+        onError: () => {
+          ErrorToast('다시 시도해주세요.');
+        },
+      });
     }
   };
 
+  if (isPending) return <Loader />;
+
   return (
-    <div className="w-full h-full  flex flex-col items-center justify-center pt-[70px] sm:pt-[0px] sm:pb-[70px]">
+    <div className="w-full h-full flex flex-col items-center justify-center pt-[70px] sm:pt-[0px] sm:pb-[70px]">
       <div className="absolute inset-0 pointer-events-none z-0">
         <picture>
-          <source media="(max-width: 768px) " srcSet="/images/background_deco_M.png" />
-
+          <source media="(max-width: 768px)" srcSet="/images/background_deco_M.png" />
           <Image
             src="/images/background_deco_W.png"
             alt="배경 장식 이미지"
@@ -48,6 +63,7 @@ export default function Home() {
           />
         </picture>
       </div>
+
       <div className="flex flex-col gap-5 items-center justify-center">
         <Image src="/images/logo/day_logo.svg" alt="큐메이트" width={173} height={55} />
         <p className="font-Gumi text-24 cursor-none">함께 하루를 기록해봐요!</p>

--- a/front/src/components/login/Login.tsx
+++ b/front/src/components/login/Login.tsx
@@ -6,7 +6,7 @@ import TextInput from '../common/TextInput';
 import { Button } from '../common/Button';
 import Link from 'next/link';
 import Image from 'next/image';
-import { useLoginUser, useSocialLogin } from '@/hooks/useAuth';
+import { useLoginUser } from '@/hooks/useAuth'; // ✅ socialLogin 제거
 import { useRouter } from 'next/navigation';
 import NoticeModal from '../common/NoticeModal';
 import Loader from '../common/Loader';
@@ -15,6 +15,7 @@ import { useSyncPushOnLogin } from '@/hooks/useSyncPush';
 import { fetchPetInfo } from '@/api/pet';
 import { useAuthStore } from '@/store/useAuthStore';
 import { useSelectedStore } from '@/store/useSelectedStore';
+import { socialLogin } from '@/api/auth';
 
 const validateEmail = (v: string) => /\S+@\S+\.\S+/.test(v);
 const validatePassword = (v: string) =>
@@ -38,48 +39,13 @@ export default function Login() {
   const setAccessToken = useAuthStore((state) => state.setAccessToken);
   const setSelectedMenu = useSelectedStore((state) => state.setSelectedMenu);
   const { mutate: loginUserMutate, isPending: isLoginLoading } = useLoginUser();
-  const { mutate: socialLoginMutate, isPending: isSocialLoading } = useSocialLogin();
 
+  // 소셜 로그인 (리다이렉트 방식)
   const handleSocialLogin = (provider: string) => {
-    socialLoginMutate(provider, {
-      onSuccess: async (data) => {
-        try {
-          await syncPushOnLogin();
-        } catch (error) {
-          console.warn('[Push Sync Failed]', error);
-        }
-        if (data.user.currentMatchId) {
-          //매치 아이디 셋팅
-          setMatchId(data.user.currentMatchId);
-
-          // 서버에서 현재 exp 조회
-          const petInfo = await fetchPetInfo(data.user.currentMatchId);
-          //현재 exp 셋팅
-          localStorage.setItem('prevExp', String(petInfo.exp));
-          //accessToken 셋팅
-          setAccessToken(data.accessToken);
-          const accessTokenTime = Date.now() + data.accessTokenExpiresIn * 1000;
-          localStorage.setItem('accessTokenTime', String(accessTokenTime));
-
-          setSelectedMenu('home');
-          router.push('/main');
-        } else {
-          if (!data.accessToken) return;
-          //accessToken 셋팅
-          setAccessToken(data.accessToken);
-          //닉네임 생일 정보 있으면 저장하기
-          if (data.user?.nickname) sessionStorage.setItem('nickname', data.user.nickname);
-          if (data.user?.birthdate) sessionStorage.setItem('birthdate', data.user.birthdate);
-          router.push('/signup/onboarding');
-        }
-      },
-      onError: () => {
-        setLoginErrorType('social');
-        setOpen(true);
-      },
-    });
+    socialLogin(provider);
   };
 
+  // 일반 로그인
   const handleLogin = () => {
     loginUserMutate(
       { email, password },
@@ -90,21 +56,25 @@ export default function Login() {
           } catch (error) {
             console.warn('[Push Sync Failed]', error);
           }
+
           if (data.user.currentMatchId) {
-            //매치 아이디 셋팅
+            // 매치 아이디 셋팅
             setMatchId(data.user.currentMatchId);
+
             // 서버에서 현재 exp 조회
             const petInfo = await fetchPetInfo(data.user.currentMatchId);
-            //현재 exp 셋팅
+            // 현재 exp 셋팅
             localStorage.setItem('prevExp', String(petInfo.exp));
-            //accessToken 셋팅
+            // accessToken 셋팅
             setAccessToken(data.accessToken);
             const accessTokenTime = Date.now() + data.accessTokenExpiresIn * 1000;
             localStorage.setItem('accessTokenTime', String(accessTokenTime));
+
+            //메뉴 메인 선택
             setSelectedMenu('home');
             router.push('/main');
           } else {
-            //accessToken 셋팅
+            // accessToken 셋팅
             setAccessToken(data.accessToken);
             router.push('/invite');
           }
@@ -118,10 +88,9 @@ export default function Login() {
   };
 
   return (
-    <div className=" w-full h-full flex flex-col gap-3 items-center justify-center pt-[70px] sm:pt-[0px] sm:pb-[70px]">
-      {isLoginLoading || (isSocialLoading && <Loader />)}
+    <div className="w-full h-full flex flex-col gap-3 items-center justify-center pt-[70px] sm:pt-[0px] sm:pb-[70px]">
+      {isLoginLoading && <Loader />} {/* ✅ socialLoading 제거 */}
       <Image src="/images/logo/day_logo.svg" alt="큐메이트" width={173} height={55} />
-
       <form onSubmit={(e) => e.preventDefault()} className="flex flex-col gap-3">
         <TextInput
           label="이메일"
@@ -149,19 +118,16 @@ export default function Login() {
           로그인
         </Button>
       </form>
-
       <div className="my-6 flex items-center gap-3 w-[295px]">
         <div className="h-px flex-1 bg-dash" />
         <span className="px-2 text-font-16 text-text-secondary">또는</span>
         <div className="h-px flex-1 bg-dash" />
       </div>
-
       <Button variant="primaryOutline" className="w-[295px]" asChild>
         <Link href="/signup">회원가입</Link>
       </Button>
       <GoogleBtn onSocialLogin={handleSocialLogin} />
       <NaverBtn onSocialLogin={handleSocialLogin} />
-
       <NoticeModal
         open={open}
         setOpen={setOpen}

--- a/front/src/components/login/Login.tsx
+++ b/front/src/components/login/Login.tsx
@@ -6,7 +6,7 @@ import TextInput from '../common/TextInput';
 import { Button } from '../common/Button';
 import Link from 'next/link';
 import Image from 'next/image';
-import { useLoginUser } from '@/hooks/useAuth'; // ✅ socialLogin 제거
+import { useLoginUser } from '@/hooks/useAuth';
 import { useRouter } from 'next/navigation';
 import NoticeModal from '../common/NoticeModal';
 import Loader from '../common/Loader';

--- a/front/src/components/login/LoginSuccess.tsx
+++ b/front/src/components/login/LoginSuccess.tsx
@@ -1,0 +1,49 @@
+'use client';
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import axios from 'axios';
+import { useAuthStore } from '@/store/useAuthStore';
+import { useSelectedStore } from '@/store/useSelectedStore';
+import { useMatchIdStore } from '@/store/useMatchIdStore';
+import { fetchPetInfo } from '@/api/pet';
+import Loader from '../common/Loader';
+
+export default function LoginSuccess() {
+  const router = useRouter();
+  const setMatchId = useMatchIdStore((state) => state.setMatchId);
+  const setAccessToken = useAuthStore((state) => state.setAccessToken);
+  const setSelectedMenu = useSelectedStore((state) => state.setSelectedMenu);
+
+  useEffect(() => {
+    const checkLogin = async () => {
+      try {
+        const res = await axios.get('/api/me', { withCredentials: true });
+        const data = res.data;
+        if (data?.user?.currentMatchId) {
+          setMatchId(data.user.currentMatchId);
+          // 서버에서 현재 exp 조회
+          const petInfo = await fetchPetInfo(data.user.currentMatchId);
+          // 현재 exp 셋팅
+          localStorage.setItem('prevExp', String(petInfo.exp));
+          // accessToken 셋팅
+          setAccessToken(data.accessToken);
+          const accessTokenTime = Date.now() + data.accessTokenExpiresIn * 1000;
+          localStorage.setItem('accessTokenTime', String(accessTokenTime));
+          setSelectedMenu('home');
+          router.push('/main');
+        } else {
+          if (data.accessToken) setAccessToken(data.accessToken);
+          if (data.user.nickname) sessionStorage.setItem('nickname', data.user.nickname);
+          if (data.user.birthDate) sessionStorage.setItem('birthDate', data.user.birthDate);
+          router.push('/signup/onboarding');
+        }
+      } catch (err) {
+        router.push('/login');
+      }
+    };
+
+    checkLogin();
+  }, [router, setAccessToken, setMatchId, setSelectedMenu]);
+
+  return <Loader />;
+}

--- a/front/src/components/siginup/SocialOnboardingForm.tsx
+++ b/front/src/components/siginup/SocialOnboardingForm.tsx
@@ -20,7 +20,7 @@ export default function SocialOnboardingForm() {
   const [open, setOpen] = React.useState(false);
 
   const storedNickname = sessionStorage.getItem('nickname') || '';
-  const storedBirthDate = sessionStorage.getItem('birthdate') || '';
+  const storedBirthDate = sessionStorage.getItem('birthDate') || '';
 
   const [birthDate, setBirthDate] = React.useState<string | undefined>(
     storedBirthDate || undefined,

--- a/front/src/hooks/useAuth.ts
+++ b/front/src/hooks/useAuth.ts
@@ -16,13 +16,6 @@ export const useLogoutUser = () => {
   });
 };
 
-//소셜 로그인
-export const useSocialLogin = () => {
-  return useMutation({
-    mutationFn: (provider: string) => socialLogin(provider),
-  });
-};
-
 //소셜 로그인 추가 정보 폼
 export const useSocialProfile = () => {
   return useMutation({

--- a/front/src/lib/redirectHandler.ts
+++ b/front/src/lib/redirectHandler.ts
@@ -3,16 +3,26 @@ import { ErrorToast } from '@/components/common/CustomToast';
 import { useAuthStore } from '@/store/useAuthStore';
 import { useMatchIdStore } from '@/store/useMatchIdStore';
 import { useSelectedStore } from '@/store/useSelectedStore';
+import { logoutUser } from '@/api/auth';
 
-export const handleUnauthorized = () => {
+export const handleUnauthorized = async () => {
   const { resetAccessToken } = useAuthStore.getState();
   const { resetMatchId } = useMatchIdStore.getState();
   const { resetSelectedMenu } = useSelectedStore.getState();
 
   ErrorToast('로그인이 만료되어 다시 로그인 화면으로 이동합니다.');
+
+  try {
+    await logoutUser();
+  } catch (e) {
+    console.warn('로그아웃 요청 실패:', e);
+  }
+
   resetSelectedMenu();
-  localStorage.clear();
   resetMatchId();
   resetAccessToken();
+  localStorage.clear();
+  sessionStorage.clear();
+
   window.location.replace('/login');
 };


### PR DESCRIPTION
## 📝 작업 내용

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [x] 기타 (설명)

## 🔍 변경 사항
- 홈 진입 시 토큰 만료 시 로그아웃 처리 추가
- 소셜 로그인 로직을 리다이렉트 방식으로 수정

## 💬 기타 공유 사항
홈에서 상태 리셋을 수행했음에도, 로그인 화면에서 “토큰 만료로 로그인 불가” 오류가 발생하여 로그아웃 로직을 추가했습니다.
소셜 로그인은 기존에 POST 요청 방식이었으나, 실제 설계가 리다이렉트 방식이어서 해당 형태로 수정했습니다.
소셜 로그인 성공 시 /login/success로 리다이렉트되도록 수아님께 처리 예정입니다.
@leejicircle 