### PR TITLE
Feature/social login cookies google

### DIFF
--- a/back/src/main/java/com/qmate/api/AuthExchangeController.java
+++ b/back/src/main/java/com/qmate/api/AuthExchangeController.java
@@ -1,0 +1,59 @@
+package com.qmate.api;
+
+import com.qmate.domain.auth.JwtService;
+import com.qmate.domain.auth.model.response.LoginResponse;
+import com.qmate.domain.user.UserRepository;
+import com.qmate.security.UserPrincipal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthExchangeController {
+
+  private final JwtService jwtService;
+  private final UserRepository userRepository;
+
+  @PostMapping("/exchange")
+  public ResponseEntity<LoginResponse> exchange(
+      @CookieValue(name = "ACCESS_TOKEN", required = false) String accessCookie,
+      @AuthenticationPrincipal UserPrincipal principal
+  ) {
+    if (accessCookie == null || !jwtService.isValid(accessCookie)) {
+      return ResponseEntity.status(401).build(); // 액세스 토큰만 검사, 실패면 끝
+    }
+
+    // principal이 null이면 jwt 필터가 컨텍스트를 못 세팅한 케이스 → 401
+    if (principal == null)
+      return ResponseEntity.status(401).build();
+
+    var user = userRepository.findById(principal.userId()).orElseThrow();
+
+    long accessTtl = jwtService.getRemainingTtlSeconds(accessCookie);
+
+    var body = LoginResponse.builder()
+        .accessToken(accessCookie)
+        .refreshToken(null)
+        .tokenType("Bearer")
+        .accessTokenExpiresIn(accessTtl)
+        .refreshTokenExpiresIn(0)
+        .user(LoginResponse.UserSummary.builder()
+            .userId(user.getId())
+            .email(user.getEmail())
+            .nickname(user.getNickname())
+            .birthDate(user.getBirthDate())
+            .role(user.getRole().name())
+            .currentMatchId(user.getCurrentMatchId())
+            .pushEnabled(user.isPushEnabled())
+            .build())
+        .build();
+
+    return ResponseEntity.ok(body);
+  }
+}

--- a/back/src/main/java/com/qmate/api/AuthMeController.java
+++ b/back/src/main/java/com/qmate/api/AuthMeController.java
@@ -1,0 +1,19 @@
+package com.qmate.api;
+
+import com.qmate.security.UserPrincipal;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+public class AuthMeController {
+
+  public record MeResponse(Long userId, String email, String role) {}
+
+  @GetMapping("/me")//프로필만
+  public MeResponse me(@AuthenticationPrincipal UserPrincipal p) {
+    return new MeResponse(p.userId(), p.email(), p.role());
+  }
+}

--- a/back/src/main/java/com/qmate/config/JwtAuthenticationFilter.java
+++ b/back/src/main/java/com/qmate/config/JwtAuthenticationFilter.java
@@ -3,6 +3,7 @@ package com.qmate.config;
 import com.qmate.domain.auth.JwtService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -23,18 +24,34 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
   @Override
   protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
     throws ServletException, IOException {
-    String token = getJwtFromRequest(request);
-    if (token != null) {
-      Authentication auth = jwtService.getAuthentication(token); // 유효하지 않으면 null
-      if (auth != null) {
-        SecurityContextHolder.getContext().setAuthentication(auth);
+    if (SecurityContextHolder.getContext().getAuthentication() == null) {
+      String token = resolveToken(request);
+      if (token != null) {
+        try {
+          Authentication auth = jwtService.getAuthentication(token); // 유효하지 않으면 null
+          if (auth != null) {
+            SecurityContextHolder.getContext().setAuthentication(auth);
+          }
+        } catch (Exception e) {
+          log.debug("JWT parse/validate failed: {}", e.getMessage());
+        }
       }
     }
     chain.doFilter(request, response);
   }
 
-  private String getJwtFromRequest(HttpServletRequest request) {
-    String bearer = request.getHeader("Authorization");
-    return (bearer != null && bearer.startsWith("Bearer ")) ? bearer.substring(7) : null;
+  private String resolveToken(HttpServletRequest req) {
+    // 1) Authorization 헤더 Bearer ...
+    String h = req.getHeader("Authorization");
+    if (h != null && h.startsWith("Bearer ")) return h.substring(7);
+
+    // 2) 쿠키 ACCESS_TOKEN
+    Cookie[] cookies = req.getCookies();
+    if (cookies != null) {
+      for (Cookie c : cookies) {
+        if ("ACCESS_TOKEN".equals(c.getName())) return c.getValue();
+      }
+    }
+    return null;
   }
 }

--- a/back/src/main/java/com/qmate/config/SecurityConfig.java
+++ b/back/src/main/java/com/qmate/config/SecurityConfig.java
@@ -11,7 +11,6 @@ import com.qmate.exception.ErrorResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpStatus;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -20,7 +19,6 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
@@ -71,7 +69,7 @@ public class SecurityConfig {
             })
         )
         .authorizeHttpRequests(authz -> authz
-            .requestMatchers("/auth/**", "/oauth2/**",
+            .requestMatchers("/auth/**", "/oauth2/**", "/login/**",
                 "/login/oauth2/**", "/oauth2/authorization/**", "/actuator/**").permitAll()
 
             .requestMatchers(SWAGGER_WHITELIST).permitAll()

--- a/back/src/main/java/com/qmate/config/SecurityConfig.java
+++ b/back/src/main/java/com/qmate/config/SecurityConfig.java
@@ -70,7 +70,7 @@ public class SecurityConfig {
         )
         .authorizeHttpRequests(authz -> authz
             .requestMatchers("/auth/**", "/oauth2/**", "/login/**",
-                "/login/oauth2/**", "/oauth2/authorization/**", "/actuator/**").permitAll()
+                "/login/oauth2/**", "/oauth2/authorization/**", "/actuator/**", "/auth/exchange").permitAll()
 
             .requestMatchers(SWAGGER_WHITELIST).permitAll()
             .requestMatchers("/api/admin/**").hasRole("ADMIN")

--- a/back/src/main/java/com/qmate/domain/auth/AuthService.java
+++ b/back/src/main/java/com/qmate/domain/auth/AuthService.java
@@ -7,6 +7,7 @@ import com.qmate.exception.custom.auth.InvalidCredentialsException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
@@ -52,6 +53,18 @@ public class AuthService {
   }
 
   public void logout(HttpServletRequest req, HttpServletResponse res, Authentication auth) {
-    delegate.logout(req, res, auth);
+    delegate.logout(req, res, auth); //세션, 컨텍스트 정리
+    expireCookie(res, "ACCESS_TOKEN");// JWT 쿠키 만료
+  }
+
+  private void expireCookie(HttpServletResponse res, String name) {
+    ResponseCookie expired = ResponseCookie.from(name, "")
+        .httpOnly(true)
+        .secure(true)
+        .sameSite("None")
+        .path("/")
+        .maxAge(0)
+        .build();
+    res.addHeader("Set-Cookie", expired.toString());
   }
 }

--- a/back/src/main/java/com/qmate/domain/auth/JwtService.java
+++ b/back/src/main/java/com/qmate/domain/auth/JwtService.java
@@ -3,6 +3,7 @@ package com.qmate.domain.auth;
 import com.qmate.security.UserPrincipal;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
@@ -63,6 +64,61 @@ public class JwtService {
 
     return new TokenPair(access, refresh, accessTtlSeconds, refreshTtlSeconds);
   }
+
+  /** 유효한 JWT면 Claims 반환, 아니면 null */
+  public Claims parseClaimsOrNull(String token) {
+    try {
+      return Jwts.parserBuilder().setSigningKey(key()).build()
+          .parseClaimsJws(token).getBody();
+    } catch (JwtException | IllegalArgumentException e) {
+      return null;
+    }
+  }
+
+  /** 토큰이 유효한가? (서명/만료 포함) */
+  public boolean isValid(String token) {
+    return parseClaimsOrNull(token) != null;
+  }
+
+  /** typ 클레임이 access 인가? */
+  public boolean isAccessToken(String token) {
+    Claims c = parseClaimsOrNull(token);
+    return c != null && "access".equals(c.get("typ", String.class));
+  }
+
+  /** typ 클레임이 refresh 인가? */
+  public boolean isRefreshToken(String token) {
+    Claims c = parseClaimsOrNull(token);
+    return c != null && "refresh".equals(c.get("typ", String.class));
+  }
+
+  /** subject(userId) 반환 (없거나 유효하지 않으면 null) */
+  public Long getUserId(String token) {
+    Claims c = parseClaimsOrNull(token);
+    if (c == null) return null;
+    try { return Long.valueOf(c.getSubject()); } catch (Exception e) { return null; }
+  }
+
+  /** role 반환 (없거나 유효하지 않으면 null) */
+  public String getRole(String token) {
+    Claims c = parseClaimsOrNull(token);
+    return (c == null) ? null : c.get("role", String.class);
+  }
+
+  /** email 반환 (리프레시에는 없을 수 있음) */
+  public String getEmail(String token) {
+    Claims c = parseClaimsOrNull(token);
+    return (c == null) ? null : c.get("email", String.class);
+  }
+
+  /** 남은 TTL(초) — 만료되었으면 0 */
+  public long getRemainingTtlSeconds(String token) {
+    Claims c = parseClaimsOrNull(token);
+    if (c == null || c.getExpiration() == null) return 0L;
+    long remainingMs = c.getExpiration().getTime() - System.currentTimeMillis();
+    return Math.max(0L, remainingMs / 1000L);
+  }
+
 
   /** 토큰 검증 + Spring Security Authentication 생성 */
   public Authentication getAuthentication(String bearerToken) {

--- a/back/src/main/java/com/qmate/security/oauth/OAuth2SuccessHandler.java
+++ b/back/src/main/java/com/qmate/security/oauth/OAuth2SuccessHandler.java
@@ -12,7 +12,9 @@ import com.qmate.security.UserPrincipal;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.time.LocalDate;
+import java.time.Duration;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseCookie;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
@@ -34,6 +36,9 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
   private final ObjectMapper om;
   private final UserRepository userRepository;
 
+  @Value("${app.frontend.success-url}")
+  private String successUrl;
+
   @Override
   public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
       Authentication authentication) throws IOException {
@@ -43,50 +48,83 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
     if (p instanceof CustomOAuth2User ou) {//네이버
       user = userRepository.findById(ou.getUserId()).orElseThrow();
-    } else if (p instanceof OidcUser oidc) {//구글
+
+      var principal = new UserPrincipal(user.getId(), user.getEmail(), user.getRole().name());
+
+      var auth = new UsernamePasswordAuthenticationToken(
+          principal, null,
+          java.util.List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole().name()))
+      );
+      SecurityContextHolder.getContext().setAuthentication(auth);
+
+      var pair = jwtService.issue(user.getId(), user.getRole().name(), user.getEmail());
+
+      LoginResponse.UserSummary summary = LoginResponse.UserSummary.builder()
+          .userId(user.getId())
+          .email(user.getEmail())
+          .nickname(user.getNickname())
+          .birthDate(user.getBirthDate())
+          .role(user.getRole().name())
+          .currentMatchId(user.getCurrentMatchId())
+          .pushEnabled(user.isPushEnabled())
+          .build();
+
+      LoginResponse body = LoginResponse.builder()
+          .accessToken(pair.getAccessToken())
+          .refreshToken(pair.getRefreshToken())
+          .tokenType("Bearer")
+          .accessTokenExpiresIn(pair.getAccessTokenTtlSeconds())
+          .refreshTokenExpiresIn(pair.getRefreshTokenTtlSeconds())
+          .user(summary)
+          .build();
+
+      response.setStatus(HttpServletResponse.SC_OK);
+      response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+      response.getWriter().write(om.writeValueAsString(body));
+      response.getWriter().flush();
+      return;
+    } else if (p instanceof OidcUser oidc) {//GOOGLE: 쿠키 + 302 리다이렉트로 변경 ===
       String sub  = oidc.getSubject();
       String mail = oidc.getEmail();
       String name = (String) oidc.getClaims().getOrDefault("name", mail);
+
       user = socialAccountService.upsertSocialUser(SocialProvider.GOOGLE, sub, mail, name, null);
 
-      String birthdate = (String) oidc.getClaims().get("birthdate");
-      log.debug("GOOGLE birthdate claim = {}", birthdate);
-    } else {
+      // SecurityContext에 인증 주입
+      var principal = new UserPrincipal(user.getId(), user.getEmail(), user.getRole().name());
+      var auth = new UsernamePasswordAuthenticationToken(
+          principal, null,
+          java.util.List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole().name()))
+      );
+      SecurityContextHolder.getContext().setAuthentication(auth);
+
+      // JWT 발급
+      var pair = jwtService.issue(user.getId(), user.getRole().name(), user.getEmail());
+
+      // 쿠키 세팅: HttpOnly + Secure + SameSite=None + Path=/
+      addHttpOnlyCookie(response, "ACCESS_TOKEN", pair.getAccessToken(), 60 * 60 * 3);        // 3h
+      addHttpOnlyCookie(response, "REFRESH_TOKEN", pair.getRefreshToken(), 60 * 60 * 24 * 14); // 14d
+
+      // 프론트 성공 페이지로 302
+      response.setStatus(HttpServletResponse.SC_FOUND);
+      response.setHeader("Location", successUrl);
+      return;
+    }
+    else {
       throw new UnsupportedPrincipalTypeException();
     }
+  }
 
-    var principal = new UserPrincipal(user.getId(), user.getEmail(), user.getRole().name());
-
-    var auth = new UsernamePasswordAuthenticationToken(
-        principal, null,
-        java.util.List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole().name()))
-    );
-    SecurityContextHolder.getContext().setAuthentication(auth);
-
-    var pair = jwtService.issue(user.getId(), user.getRole().name(), user.getEmail());
-
-    LoginResponse.UserSummary summary = LoginResponse.UserSummary.builder()
-        .userId(user.getId())
-        .email(user.getEmail())
-        .nickname(user.getNickname())
-        .birthDate(user.getBirthDate())
-        .role(user.getRole().name())
-        .currentMatchId(user.getCurrentMatchId())
-        .pushEnabled(user.isPushEnabled())
+  /** SameSite=None 을 위해 Spring의 ResponseCookie 사용 */
+  private void addHttpOnlyCookie(HttpServletResponse response, String name, String value, int maxAgeSec) {
+    ResponseCookie cookie = ResponseCookie.from(name, value)
+        .httpOnly(true)
+        .secure(true)          // 프론트가 HTTPS 이므로 필수
+        .sameSite("None")      // 크로스사이트/프록시 환경 호환
+        .path("/")
+        // .domain("")         // 지정하지 말 것(프록시/도메인 이슈 방지)
+        .maxAge(Duration.ofSeconds(maxAgeSec))
         .build();
-
-    LoginResponse body = LoginResponse.builder()
-        .accessToken(pair.getAccessToken())
-        .refreshToken(pair.getRefreshToken())
-        .tokenType("Bearer")
-        .accessTokenExpiresIn(pair.getAccessTokenTtlSeconds())
-        .refreshTokenExpiresIn(pair.getRefreshTokenTtlSeconds())
-        .user(summary)
-        .build();
-
-    response.setStatus(HttpServletResponse.SC_OK);
-    response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-    response.getWriter().write(om.writeValueAsString(body));
-    response.getWriter().flush();
+    response.addHeader("Set-Cookie", cookie.toString());
   }
 }

--- a/back/src/main/java/com/qmate/security/oauth/OAuth2SuccessHandler.java
+++ b/back/src/main/java/com/qmate/security/oauth/OAuth2SuccessHandler.java
@@ -103,7 +103,7 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
       // 쿠키 세팅: HttpOnly + Secure + SameSite=None + Path=/
       addHttpOnlyCookie(response, "ACCESS_TOKEN", pair.getAccessToken(), 60 * 60 * 3);        // 3h
-      addHttpOnlyCookie(response, "REFRESH_TOKEN", pair.getRefreshToken(), 60 * 60 * 24 * 14); // 14d
+//      addHttpOnlyCookie(response, "REFRESH_TOKEN", pair.getRefreshToken(), 60 * 60 * 24 * 14); // 14d
 
       // 프론트 성공 페이지로 302
       response.setStatus(HttpServletResponse.SC_FOUND);

--- a/back/src/main/resources/application-prod.yml
+++ b/back/src/main/resources/application-prod.yml
@@ -75,9 +75,12 @@ app:
   email-verification:
     jwt-secret: ${APP_EMAIL_VERIFICATION_JWT_SECRET}
     ttl-minutes: ${APP_EMAIL_VERIFICATION_TTL_MINUTES:10}
+  frontend:
+    success-url: https://q-mate.vercel.app/login/success
 
 server:
   port: 8080
+  forward-headers-strategy: native
 
 management:
   endpoints:


### PR DESCRIPTION
### 변경사항 
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요. --> 
**AS-IS** 

- 구글 로그인 성공 시 응답 본문(JSON)으로 토큰을 반환
- 쿠키(HttpOnly) 기반 인증 미지원

**TO-BE** 

- 구글 로그인 성공 시 ACCESS_TOKEN, REFRESH_TOKEN을 HttpOnly + Secure + SameSite=None 쿠키로 발급
- OAuth2SuccessHandler에 쿠키 발급 및 302 리다이렉트 로직 추가
- JwtAuthenticationFilter에서 쿠키 기반 토큰 검증 지원 (resolveToken() 추가)
- 엔드포인트 추가

> GET /api/me : 현재 로그인 사용자 프로필만 반환(200/401 상태 확인용).
> POST /auth/exchange : 쿠키의 ACCESS_TOKEN 검증 후 일반 로그인과 동일 스키마(LoginResponse)로 반환(리프레시는 미사용, 0/NULL).

- logout()에서 expireCookie(ACCESS_TOKEN) 호출 추가( HttpOnly + Secure + SameSite=None + path=/ 로 발급 시와 동일 옵션으로 만료).
- JwtService 유틸에 parseClaimsOrNull, isValid, isAccessToken, isRefreshToken, getUserId, getRole, getEmail, getRemainingTtlSeconds 추가.
- "/auth/exchange"(및 /auth/**) permitAll에 포함.

- 운영 설정(환경 파일) 전제
> app.frontend.success-url 사용(예: https://q-mate.vercel.app/login/success).
> 프록시 환경 호환을 위한 server.forward-headers-strategy=native 적용 전제.

### 테스트 
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 -->
프론트 리라이트(/login/*) 적용 후 배포 환경 검증 예정
