### PR TITLE
test 소셜 로그인 구글 테스트

### DIFF
--- a/front/next.config.ts
+++ b/front/next.config.ts
@@ -16,15 +16,6 @@ const nextConfig: NextConfig = {
         source: '/api/:path*',
         destination: `${process.env.BACKEND_ORIGIN}/:path*`,
       },
-      // 소셜 로그인 관련
-      {
-        source: '/oauth2/:path*',
-        destination: `${process.env.BACKEND_ORIGIN}/oauth2/:path*`,
-      },
-      {
-        source: '/login/:path*',
-        destination: `${process.env.BACKEND_ORIGIN}/login/:path*`,
-      },
     ];
   },
 };

--- a/front/src/api/auth.ts
+++ b/front/src/api/auth.ts
@@ -14,8 +14,19 @@ export const logoutUser = async () => {
 
 //소셜 로그인
 export const socialLogin = (provider: string) => {
-  const url = `http://ec2-43-201-32-144.ap-northeast-2.compute.amazonaws.com:8080/oauth2/authorization/${provider}`;
-  window.location.href = url;
+  const frontendUrl = process.env.NEXT_PUBLIC_FRONTEND_ORIGIN;
+  const clientId = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID;
+  const redirectUri = `${frontendUrl}/login/oauth2/code/${provider}`;
+
+  const googleUrl =
+    `https://accounts.google.com/o/oauth2/v2/auth` +
+    `?client_id=${clientId}` +
+    `&redirect_uri=${encodeURIComponent(redirectUri)}` +
+    `&response_type=code` +
+    `&scope=email profile openid` +
+    `&access_type=offline`;
+
+  window.location.href = googleUrl;
 };
 
 //추가 폼 정보 입력

--- a/front/src/app/oauth2/code/google/page.tsx
+++ b/front/src/app/oauth2/code/google/page.tsx
@@ -1,0 +1,64 @@
+'use client';
+import { useEffect } from 'react';
+import { useSearchParams, useRouter } from 'next/navigation';
+import axios from 'axios';
+import { useAuthStore } from '@/store/useAuthStore';
+import { useMatchIdStore } from '@/store/useMatchIdStore';
+import { useSelectedStore } from '@/store/useSelectedStore';
+import { fetchPetInfo } from '@/api/pet';
+import Loader from '@/components/common/Loader';
+
+export default function GoogleCallback() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const setAccessToken = useAuthStore((state) => state.setAccessToken);
+  const setMatchId = useMatchIdStore((state) => state.setMatchId);
+  const setSelectedMenu = useSelectedStore((state) => state.setSelectedMenu);
+
+  useEffect(() => {
+    const code = searchParams.get('code');
+    if (!code) {
+      router.replace('/login');
+      return;
+    }
+
+    const exchangeCode = async () => {
+      try {
+        const res = await axios.post(
+          `${process.env.NEXT_PUBLIC_BACKEND_ORIGIN}/auth/exchange`,
+          { code },
+          { withCredentials: true },
+        );
+
+        const data = res.data;
+        if (!data || !data.accessToken || !data.user) throw new Error('잘못된 응답');
+
+        // 로그인 후 분기 처리
+        if (data.user.currentMatchId) {
+          setMatchId(data.user.currentMatchId);
+          const petInfo = await fetchPetInfo(data.user.currentMatchId);
+          localStorage.setItem('prevExp', String(petInfo.exp));
+          setAccessToken(data.accessToken);
+          localStorage.setItem(
+            'accessTokenTime',
+            String(Date.now() + data.accessTokenExpiresIn * 1000),
+          );
+          setSelectedMenu('home');
+          router.replace('/main');
+        } else {
+          setAccessToken(data.accessToken);
+          if (data.user.nickname) sessionStorage.setItem('nickname', data.user.nickname);
+          if (data.user.birthDate) sessionStorage.setItem('birthDate', data.user.birthDate);
+          router.replace('/signup/onboarding');
+        }
+      } catch (err) {
+        router.replace('/login');
+      }
+    };
+
+    exchangeCode();
+  }, [searchParams, router, setAccessToken, setMatchId, setSelectedMenu]);
+
+  return <Loader />;
+}


### PR DESCRIPTION
## 📝 작업 내용

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [x] 기타 (설명)

## 🔍 변경 사항

- socialLogin.ts: 로그인 시작 로직을 프론트 리다이렉트 기반으로 수정
- /login/oauth2/code/google/page.tsx: code 교환 및 로그인 후 라우팅 로직 추가
- next.config.ts: /login/:path* rewrite 제거, /api/:path* 프록시 유지
- .env.local: NEXT_PUBLIC_GOOGLE_CLIENT_ID, NEXT_PUBLIC_FRONTEND_ORIGIN 추가

## 💬 기타 공유 사항

백엔드 .env에 GOOGLE_CLIENT_SECRET 설정 필수
구글 콘솔 redirect URI는 프론트 주소(/login/oauth2/code/google) 기준으로 등록 필요
기존 팝업 로그인은 제거됨 → 전체 리다이렉트 방식으로 동작
