### PR TITLE
feature/changed logics for google social login

### DIFF
--- a/back/build.gradle
+++ b/back/build.gradle
@@ -37,6 +37,11 @@ dependencies {
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
     annotationProcessor 'org.projectlombok:lombok'
 
+    //google oauth
+    implementation 'com.google.api-client:google-api-client:2.6.0'
+    implementation 'com.google.oauth-client:google-oauth-client-jetty:1.34.1'
+    implementation 'com.google.http-client:google-http-client-gson:1.43.3'
+//    implementation 'com.google.http-client:google-http-client-jackson2:1.43.3'
 
     // Querydsl
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'

--- a/back/src/main/java/com/qmate/api/GoogleAuthController.java
+++ b/back/src/main/java/com/qmate/api/GoogleAuthController.java
@@ -1,0 +1,75 @@
+package com.qmate.api;
+
+import com.qmate.domain.auth.GoogleOAuthService;
+import com.qmate.domain.auth.GoogleOAuthService.GoogleTokenResponse;
+import com.qmate.domain.auth.JwtService;
+import com.qmate.domain.auth.SocialAccountService;
+import com.qmate.domain.auth.model.response.LoginResponse;
+import com.qmate.domain.user.User;
+import com.qmate.domain.user.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.Duration;
+
+@RestController
+@RequiredArgsConstructor
+public class GoogleAuthController {
+
+  private final GoogleOAuthService googleOAuthService;
+  private final SocialAccountService socialAccountService;
+  private final JwtService jwtService;
+
+  @PostMapping("/auth/google/exchange")
+  public ResponseEntity<LoginResponse> exchange(@RequestBody GoogleCodeExchangeRequest req) {
+    // 1) 구글 토큰 교환
+    GoogleTokenResponse tokenRes = googleOAuthService.exchange(req.code(), req.redirectUri());
+
+    // 2) id_token 검증
+    var payload = googleOAuthService.verifyIdToken(tokenRes.getId_token());
+
+    // 3) 사용자 upsert
+    String sub   = payload.getSubject();
+    String email = (String) payload.get("email");
+    String name  = (String) payload.get("name");
+    User user = socialAccountService.upsertGoogleUser(sub, email, name);
+
+    // 4) 애플리케이션 토큰 발급
+    var pair = jwtService.issue(user.getId(), user.getRole().name(), user.getEmail());
+
+    // 5) LoginResponse 조립
+    LoginResponse.UserSummary summary = LoginResponse.UserSummary.builder()
+        .userId(user.getId())
+        .email(user.getEmail())
+        .nickname(user.getNickname())
+        .birthDate(user.getBirthDate())
+        .role(user.getRole().name())
+        .currentMatchId(user.getCurrentMatchId())
+        .pushEnabled(user.isPushEnabled())
+        .build();
+
+    LoginResponse body = LoginResponse.builder()
+        .accessToken(pair.getAccessToken())
+        .refreshToken(pair.getRefreshToken())
+        .tokenType("Bearer")
+        .accessTokenExpiresIn(pair.getAccessTokenTtlSeconds())   // 초 단위
+        .refreshTokenExpiresIn(pair.getRefreshTokenTtlSeconds()) // 초 단위
+        .user(
+            summary
+        )
+        .build();
+
+    return ResponseEntity.ok(body);
+  }
+
+  // === 요청 DTO ===
+  public record GoogleCodeExchangeRequest(
+      String code,
+      String redirectUri,
+      String state,
+      String nonce
+  ) {}
+}

--- a/back/src/main/java/com/qmate/config/GoogleVerifierConfig.java
+++ b/back/src/main/java/com/qmate/config/GoogleVerifierConfig.java
@@ -1,0 +1,27 @@
+package com.qmate.config;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.gson.GsonFactory;
+import java.util.Collections;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+//import com.google.api.client.json.jackson2.JacksonFactory;
+
+@Configuration
+public class GoogleVerifierConfig {
+
+  @Value("${app.oauth.google.client-id}")
+  private String clientId;
+
+  @Bean
+  public GoogleIdTokenVerifier googleIdTokenVerifier() {
+    return new GoogleIdTokenVerifier.Builder(
+        new NetHttpTransport(),
+        GsonFactory.getDefaultInstance()
+    )
+        .setAudience(Collections.singletonList(clientId))
+        .build();
+  }
+}

--- a/back/src/main/java/com/qmate/config/SecurityConfig.java
+++ b/back/src/main/java/com/qmate/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import com.qmate.security.oauth.OAuth2SuccessHandler;
 import com.qmate.exception.CommonErrorCode;
 import com.qmate.exception.ErrorCode;
 import com.qmate.exception.ErrorResponse;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -20,6 +21,9 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
 @EnableWebSecurity
@@ -70,7 +74,7 @@ public class SecurityConfig {
         )
         .authorizeHttpRequests(authz -> authz
             .requestMatchers("/auth/**", "/oauth2/**", "/login/**",
-                "/login/oauth2/**", "/oauth2/authorization/**", "/actuator/**", "/auth/exchange").permitAll()
+                "/login/oauth2/**", "/oauth2/authorization/**", "/actuator/**", "/auth/exchange", "/auth/google/exchange").permitAll()
 
             .requestMatchers(SWAGGER_WHITELIST).permitAll()
             .requestMatchers("/api/admin/**").hasRole("ADMIN")
@@ -84,5 +88,16 @@ public class SecurityConfig {
         .addFilterBefore(new JwtAuthenticationFilter(jwtService), UsernamePasswordAuthenticationFilter.class);  // JWT 필터 추가
 
     return http.build();
+  }
+  @Bean
+  public CorsConfigurationSource corsConfigurationSource() {
+    var cfg = new CorsConfiguration();
+    cfg.setAllowedOrigins(List.of("https://q-mate.vercel.app"));
+    cfg.setAllowedMethods(List.of("GET","POST","PUT","DELETE","OPTIONS"));
+    cfg.setAllowedHeaders(List.of("*"));
+    cfg.setAllowCredentials(true); //쿠키 주고받기
+    var src = new UrlBasedCorsConfigurationSource();
+    src.registerCorsConfiguration("/**", cfg);
+    return src;
   }
 }

--- a/back/src/main/java/com/qmate/domain/auth/AuthService.java
+++ b/back/src/main/java/com/qmate/domain/auth/AuthService.java
@@ -54,7 +54,7 @@ public class AuthService {
 
   public void logout(HttpServletRequest req, HttpServletResponse res, Authentication auth) {
     delegate.logout(req, res, auth); //세션, 컨텍스트 정리
-    expireCookie(res, "ACCESS_TOKEN");// JWT 쿠키 만료
+//    expireCookie(res, "ACCESS_TOKEN");// JWT 쿠키 만료
   }
 
   private void expireCookie(HttpServletResponse res, String name) {

--- a/back/src/main/java/com/qmate/domain/auth/GoogleOAuthService.java
+++ b/back/src/main/java/com/qmate/domain/auth/GoogleOAuthService.java
@@ -1,0 +1,82 @@
+package com.qmate.domain.auth;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.Collections;
+
+@Service
+@RequiredArgsConstructor
+public class GoogleOAuthService {
+
+  @Value("${app.oauth.google.client-id}")
+  private String clientId;
+
+  @Value("${app.oauth.google.client-secret}")
+  private String clientSecret;
+
+  @Value("${app.oauth.google.redirect-uri}")
+  private String configuredRedirectUri;
+
+  private final RestTemplate restTemplate = new RestTemplate();
+  private final GoogleIdTokenVerifier verifier; // Bean 주입(그대로 사용)
+
+  public GoogleTokenResponse exchange(String code, String redirectUri) {
+    if (!configuredRedirectUri.equals(redirectUri)) {
+      throw new IllegalArgumentException("redirect_uri mismatch");
+    }
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+    MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
+    form.add("code", code);
+    form.add("client_id", clientId);
+    form.add("client_secret", clientSecret);
+    form.add("redirect_uri", redirectUri);
+    form.add("grant_type", "authorization_code");
+
+    HttpEntity<MultiValueMap<String, String>> req = new HttpEntity<>(form, headers);
+
+    return restTemplate.postForObject(
+        "https://oauth2.googleapis.com/token",
+        req,
+        GoogleTokenResponse.class
+    );
+  }
+
+  public GoogleIdToken.Payload verifyIdToken(String idTokenString) {
+    try {
+      GoogleIdToken idToken = verifier.verify(idTokenString);
+      if (idToken == null) throw new IllegalStateException("Invalid id_token");
+      return idToken.getPayload();
+    } catch (GeneralSecurityException | IOException e) {
+      throw new IllegalStateException("id_token verify failed", e);
+    }
+  }
+
+  @Getter @Setter
+  public static class GoogleTokenResponse {
+    private String access_token;
+    private String id_token;
+    private String refresh_token;
+    private String token_type;
+    private Long   expires_in;
+    private String scope;
+  }
+}

--- a/back/src/main/java/com/qmate/domain/auth/SocialAccountService.java
+++ b/back/src/main/java/com/qmate/domain/auth/SocialAccountService.java
@@ -16,6 +16,30 @@ import org.springframework.transaction.annotation.Transactional;
 public class SocialAccountService {
   private final UserRepository userRepository;
   private final UserSocialAccountRepository socialRepository;
+
+  /**
+   * Google 로그인용 upsert (google sub 기반)
+   * @param googleSub        Google 고유 ID (sub)
+   * @param email            구글에서 받은 이메일 (null 가능성 고려)
+   * @param nickname         구글 display name (없으면 email/대체키 사용)
+   */
+  @Transactional
+  public User upsertGoogleUser(String googleSub, String email, String nickname) {
+    // 필요 시 이메일 정규화
+    String normalizedEmail = (email != null) ? email.trim().toLowerCase() : null;
+    String safeNickname = (nickname != null && !nickname.isBlank())
+        ? nickname
+        : (normalizedEmail != null ? normalizedEmail : "user_google_" + googleSub);
+
+    return upsertSocialUser(
+        SocialProvider.GOOGLE,
+        googleSub,
+        normalizedEmail,
+        safeNickname,
+        null
+    );
+  }
+
   /**
    * 소셜 로그인 정보로 사용자 upsert + 소셜계정 연결
    * 규칙:

--- a/back/src/main/resources/application-doc.yml
+++ b/back/src/main/resources/application-doc.yml
@@ -35,17 +35,16 @@ security:
 
 app:
   email-verification:
-    jwt-secret: ${APP_EMAIL_VERIFICATION_JWT_SECRET}
+    jwt-secret: dummy-doc-email-jwt
     ttl-minutes: ${APP_EMAIL_VERIFICATION_TTL_MINUTES:10}
   frontend:
     origin: https://q-mate.vercel.app
   #    success-url: https://q-mate.vercel.app/login/success
   oauth:
     google:
-      client-id: ${OAUTH_GOOGLE_CLIENT_ID}
-      client-secret: ${OAUTH_GOOGLE_CLIENT_SECRET}
-      # 프론트가 code를 받는 콜백 주소
-      redirect-uri: https://q-mate.vercel.app/login/oauth2/code/google
+      client-id: dummy-client-id                 # ← 고정값
+      client-secret: dummy-client-secret         # ← 고정값
+      redirect-uri: https://example.com/callback # 아무 문자열 OK
 
 # 필요 시 springdoc 커스터마이즈(옵션)
 # springdoc:

--- a/back/src/main/resources/application-doc.yml
+++ b/back/src/main/resources/application-doc.yml
@@ -33,6 +33,19 @@ security:
   jwt:
     secret: dummy-doc-secret-32bytes-minimum-xxxxxxxxxxxxxxxx
 
+app:
+  email-verification:
+    jwt-secret: ${APP_EMAIL_VERIFICATION_JWT_SECRET}
+    ttl-minutes: ${APP_EMAIL_VERIFICATION_TTL_MINUTES:10}
+  frontend:
+    origin: https://q-mate.vercel.app
+  #    success-url: https://q-mate.vercel.app/login/success
+  oauth:
+    google:
+      client-id: ${OAUTH_GOOGLE_CLIENT_ID}
+      client-secret: ${OAUTH_GOOGLE_CLIENT_SECRET}
+      # 프론트가 code를 받는 콜백 주소
+      redirect-uri: https://q-mate.vercel.app/login/oauth2/code/google
 
 # 필요 시 springdoc 커스터마이즈(옵션)
 # springdoc:

--- a/back/src/main/resources/application-prod.yml
+++ b/back/src/main/resources/application-prod.yml
@@ -76,7 +76,14 @@ app:
     jwt-secret: ${APP_EMAIL_VERIFICATION_JWT_SECRET}
     ttl-minutes: ${APP_EMAIL_VERIFICATION_TTL_MINUTES:10}
   frontend:
-    success-url: https://q-mate.vercel.app/login/success
+    origin: https://q-mate.vercel.app
+#    success-url: https://q-mate.vercel.app/login/success
+  oauth:
+    google:
+      client-id: ${OAUTH_GOOGLE_CLIENT_ID}
+      client-secret: ${OAUTH_GOOGLE_CLIENT_SECRET}
+      # 프론트가 code를 받는 콜백 주소
+      redirect-uri: https://q-mate.vercel.app/login/oauth2/code/google
 
 server:
   port: 8080


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

- 구글 소셜 로그인 기존 백엔드 주도로 하니, 프론트와 백의 도메인 차이로 인해 오류 발생

**TO-BE**

- 프론트 주도 구글 로그인으로 변경
- 프론트가 구글에서 받은 code를 서버로 전송 → POST /auth/google/exchange
- 서버에서 code → token 교환, id_token 검증, 유저 upsert, JWT(Access/Refresh) 발급 후 JSON 응답(LoginResponse)
- GoogleIdTokenVerifier의 JSON 파서 GsonFactory로 교체(Deprecated 경고 제거)
- redirect_uri 완전 일치 검증 추가(app.oauth.google.redirect-uri와 요청 본문 값 동일 시에만 처리)
- 이후 API는 Authorization: Bearer <accessToken> 방식으로 호출(쿠키 미사용)
- JwtAuthenticationFilter로 Bearer 토큰 인증 처리
- CORS: 배포 프론트 도메인 허용
- application.yml에 app.oauth.google.* 분리/정의

### 테스트
- 프론트와 코드 통합후 테스트 예정