### PR TITLE
feat 구글 로그인 로직 추가

### DIFF
--- a/front/src/api/axiosInstance.ts
+++ b/front/src/api/axiosInstance.ts
@@ -2,10 +2,9 @@ import axios from 'axios';
 import { useAuthStore } from '@/store/useAuthStore';
 import { handleUnauthorized } from '@/lib/redirectHandler';
 
-// 공용 axios 인스턴스 생성
 export const instance = axios.create({
-  baseURL: '/api',
-  withCredentials: false,
+  baseURL: process.env.NEXT_PUBLIC_BACKEND_ORIGIN,
+  withCredentials: false, // Bearer 전략이면 false 유지
 });
 
 // 요청 인터셉터
@@ -14,16 +13,18 @@ instance.interceptors.request.use(
     const token = useAuthStore.getState().accessToken;
     const requestUrl = config.url ?? '';
 
-    // 로그인 및 회원가입 요청에는 Authorization 헤더를 추가하지 않음
-    const isAuthRoute =
+    // 인증 제외 라우트 (토큰 필요 없음)
+    const isPublicRoute =
       requestUrl.includes('/auth/login') ||
       requestUrl.includes('/auth/register') ||
       requestUrl.includes('/auth/email-verifications') ||
+      requestUrl.includes('/auth/google/exchange') ||
       requestUrl.includes('/auth/email-verifications/resend') ||
       requestUrl.includes('/auth/email-verifications/verify') ||
       requestUrl.includes('/api/users/me/profile');
 
-    if (token && !isAuthRoute) {
+    // 토큰이 있고, 공개 라우트가 아니라면 Authorization 헤더 추가
+    if (token && !isPublicRoute) {
       config.headers.Authorization = `Bearer ${token}`;
     }
 
@@ -37,15 +38,14 @@ instance.interceptors.response.use(
   (res) => res,
   (error) => {
     const status = error.response?.status;
-    const requestUrl = error.config?.url;
+    const requestUrl = error.config?.url ?? '';
 
-    // 로그인 및 회원가입 요청에서 발생한 401은 무시
     const isAuthRoute =
       requestUrl.includes('/auth/login') ||
       requestUrl.includes('/auth/register') ||
       requestUrl.includes('/auth/email-verifications') ||
+      requestUrl.includes('/auth/google/exchange') ||
       requestUrl.includes('/auth/email-verifications/resend') ||
-      requestUrl.includes('/auth/email-verifications/verify') ||
       requestUrl.includes('/auth/email-verifications/verify');
 
     if (status === 401 && !isAuthRoute) {

--- a/front/src/app/login/oauth2/code/[provider]/page.tsx
+++ b/front/src/app/login/oauth2/code/[provider]/page.tsx
@@ -1,29 +1,70 @@
 'use client';
-import { useSearchParams } from 'next/navigation';
+import { ErrorToast } from '@/components/common/CustomToast';
+import Loader from '@/components/common/Loader';
 import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuthStore } from '@/store/useAuthStore';
+import { useMatchIdStore } from '@/store/useMatchIdStore';
+import { useSelectedStore } from '@/store/useSelectedStore';
+import { fetchPetInfo } from '@/api/pet';
 
 export default function GoogleCallback() {
-  const searchParams = useSearchParams();
-  const [params, setParams] = useState<string>('');
+  const [error, setError] = useState<string | null>(null);
+  const router = useRouter();
+
+  const setAccessToken = useAuthStore((s) => s.setAccessToken);
+  const setMatchId = useMatchIdStore((s) => s.setMatchId);
+  const setSelectedMenu = useSelectedStore((s) => s.setSelectedMenu);
 
   useEffect(() => {
-    // 현재 URL의 전체 쿼리 파라미터를 보기 좋게 문자열로 정리
-    const entries = Array.from(searchParams.entries());
-    if (entries.length > 0) {
-      const formatted = entries
-        .map(([key, value]) => `${key} = ${decodeURIComponent(value)}`)
-        .join('\n');
-      setParams(formatted);
-    } else {
-      setParams('❌ URL에 전달된 code/state 파라미터가 없습니다.');
+    const url = new URL(window.location.href);
+    const code = url.searchParams.get('code');
+    if (!code) {
+      setError('Google code 누락');
+      return;
     }
-  }, [searchParams]);
 
-  return (
-    <div style={{ padding: '2rem', whiteSpace: 'pre-wrap', fontFamily: 'monospace' }}>
-      <h2>🔍 Google OAuth 콜백 파라미터</h2>
-      <hr />
-      <p>{params}</p>
-    </div>
-  );
+    exchangeCode(code);
+  }, []);
+
+  const exchangeCode = async (code: string) => {
+    try {
+      const res = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_ORIGIN}/auth/google/exchange`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          code,
+          redirectUri: process.env.NEXT_PUBLIC_GOOGLE_REDIRECT_URI,
+        }),
+      });
+
+      if (!res.ok) throw new Error(`교환 실패: ${res.status}`);
+
+      const data = await res.json();
+      const { accessToken, accessTokenExpiresIn, user } = data;
+
+      if (!accessToken || !user) throw new Error('잘못된 응답');
+
+      setAccessToken(accessToken);
+      localStorage.setItem('accessTokenTime', String(Date.now() + accessTokenExpiresIn * 1000));
+
+      if (user.currentMatchId) {
+        setMatchId(user.currentMatchId);
+        const petInfo = await fetchPetInfo(user.currentMatchId);
+        localStorage.setItem('prevExp', String(petInfo.exp));
+        setSelectedMenu('home');
+        router.replace('/main');
+      } else {
+        if (user.nickname) sessionStorage.setItem('nickname', user.nickname);
+        if (user.birthDate) sessionStorage.setItem('birthDate', user.birthDate);
+        router.replace('/signup/onboarding');
+      }
+    } catch (e) {
+      const err = e as Error;
+      setError(err.message);
+    }
+  };
+
+  if (error) return ErrorToast(error);
+  return <Loader />;
 }

--- a/front/src/components/login/ui/NaverBtn.tsx
+++ b/front/src/components/login/ui/NaverBtn.tsx
@@ -11,7 +11,7 @@ export default function NaverBtn({ onSocialLogin }: NaverBtnProps) {
     <Button
       variant="icon"
       className="bg-naver w-[295px] hover:bg-naver/80 text-secondary"
-      onClick={() => onSocialLogin('google')}
+      onClick={() => onSocialLogin('naver')}
     >
       <Image src="/images/social/naverLogo.png" width={12} height={11} alt="네이버 로그인" />
       네이버 로그인

--- a/front/src/utils/googleAuth.ts
+++ b/front/src/utils/googleAuth.ts
@@ -1,0 +1,26 @@
+export function buildGoogleAuthUrl() {
+  const base = 'https://accounts.google.com/o/oauth2/v2/auth';
+  const params = new URLSearchParams({
+    client_id: process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID!,
+    response_type: 'code',
+    scope: 'openid email profile',
+    redirect_uri: process.env.NEXT_PUBLIC_GOOGLE_REDIRECT_URI!,
+    state: cryptoRandom(), // 선택: CSRF 방지(세션/스토리지에 저장)
+    nonce: cryptoRandom(), // 선택: id_token nonce 대조용
+  });
+  // state/nonce 저장
+  if (typeof window !== 'undefined') {
+    localStorage.setItem('google_state', params.get('state')!);
+    localStorage.setItem('google_nonce', params.get('nonce')!);
+  }
+  return `${base}?${params.toString()}`;
+}
+
+function cryptoRandom() {
+  if (typeof window === 'undefined') return '';
+  const buf = new Uint8Array(16);
+  window.crypto.getRandomValues(buf);
+  return Array.from(buf)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}


### PR DESCRIPTION
## 📝 작업 내용

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [ ] 기타 (설명)

## 🔍 변경 사항
- /login/oauth2/code/google 콜백 페이지 구현


## 💬 기타 공유 사항
- 프론트 주도 로그인 플로우로, redirect URI는 `https://q-mate.vercel.app/login/oauth2/code/google`로 설정됨
- `/auth/google/exchange` 호출 시 Authorization 헤더가 추가되지 않도록 axios 인터셉터 예외 경로에 포함시켜야 함
- 이후 401 응답 시 자동 로그아웃(`handleUnauthorized`) 로직과 연동 예정
@leejicircle 