### PR TITLE
feature: chagned naver social login logics

### DIFF
--- a/back/src/main/java/com/qmate/api/NaverAuthController.java
+++ b/back/src/main/java/com/qmate/api/NaverAuthController.java
@@ -1,0 +1,81 @@
+package com.qmate.api;
+
+import com.qmate.domain.auth.JwtService;
+import com.qmate.domain.auth.NaverOAuthService;
+import com.qmate.domain.auth.NaverOAuthService.NaverTokenResponse;
+import com.qmate.domain.auth.NaverOAuthService.NaverUserProfile;
+import com.qmate.domain.auth.SocialAccountService;
+import com.qmate.domain.auth.model.response.LoginResponse;
+import com.qmate.domain.user.User;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+public class NaverAuthController {
+
+  private final NaverOAuthService naverOAuthService;
+  private final SocialAccountService socialAccountService;
+  private final JwtService jwtService;
+
+  @PostMapping("/auth/naver/exchange")
+  public ResponseEntity<LoginResponse> exchange(@RequestBody NaverCodeExchangeRequest req) {
+    // 1) 토큰 교환
+    NaverTokenResponse tokenRes = naverOAuthService.exchange(req.code(), req.state(), req.redirectUri());
+
+    // 2) 프로필 조회
+    NaverUserProfile profile = naverOAuthService.fetchProfile(tokenRes.getAccess_token());
+
+    // 3) 사용자 upsert
+    String naverId  = profile.getId();               // 필수
+    String email    = profile.getEmail();            // null 가능
+    String nickname = (profile.getNickname() != null && !profile.getNickname().isBlank())
+        ? profile.getNickname()
+        : profile.getName();                         // 이름도 없으면 upsert에서 fallback
+    LocalDate birth = null;
+    // birthday: "MM-DD", birthyear: "YYYY" — 둘 다 있을 때만 LocalDate로 조합
+    if (profile.getBirthyear() != null && profile.getBirthday() != null && profile.getBirthday().length() == 5) {
+      try {
+        String yyyy = profile.getBirthyear();
+        String mm = profile.getBirthday().substring(0, 2);
+        String dd = profile.getBirthday().substring(3, 5);
+        birth = LocalDate.parse(yyyy + "-" + mm + "-" + dd);
+      } catch (Exception ignored) {}
+    }
+
+    User user = socialAccountService.upsertNaverUser(naverId, email, nickname, birth);
+
+    // 4) 앱 JWT 발급
+    var pair = jwtService.issue(user.getId(), user.getRole().name(), user.getEmail());
+
+    // 5) 응답
+    LoginResponse.UserSummary summary = LoginResponse.UserSummary.builder()
+        .userId(user.getId())
+        .email(user.getEmail())
+        .nickname(user.getNickname())
+        .birthDate(user.getBirthDate())
+        .role(user.getRole().name())
+        .currentMatchId(user.getCurrentMatchId())
+        .pushEnabled(user.isPushEnabled())
+        .build();
+
+    LoginResponse body = LoginResponse.builder()
+        .accessToken(pair.getAccessToken())
+        .refreshToken(pair.getRefreshToken())
+        .tokenType("Bearer")
+        .accessTokenExpiresIn(pair.getAccessTokenTtlSeconds())
+        .refreshTokenExpiresIn(pair.getRefreshTokenTtlSeconds())
+        .user(summary)
+        .build();
+
+    return ResponseEntity.ok(body);
+  }
+
+  public record NaverCodeExchangeRequest(
+      String code,
+      String state,
+      String redirectUri
+  ) {}
+}

--- a/back/src/main/java/com/qmate/config/SecurityConfig.java
+++ b/back/src/main/java/com/qmate/config/SecurityConfig.java
@@ -74,8 +74,8 @@ public class SecurityConfig {
         )
         .authorizeHttpRequests(authz -> authz
             .requestMatchers("/auth/**", "/oauth2/**", "/login/**",
-                "/login/oauth2/**", "/oauth2/authorization/**", "/actuator/**", "/auth/exchange", "/auth/google/exchange").permitAll()
-
+                "/login/oauth2/**", "/oauth2/authorization/**", "/actuator/**", "/auth/exchange",
+                "/auth/google/exchange", "/auth/naver/exchange").permitAll()
             .requestMatchers(SWAGGER_WHITELIST).permitAll()
             .requestMatchers("/api/admin/**").hasRole("ADMIN")
             .anyRequest().authenticated()  // 나머지 모든 요청은 인증 필요

--- a/back/src/main/java/com/qmate/domain/auth/NaverOAuthService.java
+++ b/back/src/main/java/com/qmate/domain/auth/NaverOAuthService.java
@@ -1,0 +1,110 @@
+package com.qmate.domain.auth;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@RequiredArgsConstructor
+public class NaverOAuthService {
+
+  @Value("${app.oauth.naver.client-id}")
+  private String clientId;
+
+  @Value("${app.oauth.naver.client-secret}")
+  private String clientSecret;
+
+  @Value("${app.oauth.naver.redirect-uri}")
+  private String configuredRedirectUri;
+
+  private final RestTemplate restTemplate = new RestTemplate();
+
+  /** code → token 교환 */
+  public NaverTokenResponse exchange(String code, String state, String redirectUri) {
+    if (!configuredRedirectUri.equals(redirectUri)) {
+      throw new IllegalArgumentException("redirect_uri mismatch");
+    }
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+    MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
+    form.add("grant_type", "authorization_code");
+    form.add("client_id", clientId);
+    form.add("client_secret", clientSecret);
+    form.add("code", code);
+    form.add("state", state != null ? state : "");
+
+    HttpEntity<MultiValueMap<String, String>> req = new HttpEntity<>(form, headers);
+
+    return restTemplate.postForObject(
+        "https://nid.naver.com/oauth2.0/token",
+        req,
+        NaverTokenResponse.class
+    );
+  }
+
+  /** access_token → 사용자 프로필 조회 */
+  public NaverUserProfile fetchProfile(String accessToken) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setBearerAuth(accessToken);
+
+    ResponseEntity<NaverUserInfoResponse> res = restTemplate.exchange(
+        "https://openapi.naver.com/v1/nid/me",
+        HttpMethod.GET,
+        new HttpEntity<>(headers),
+        NaverUserInfoResponse.class
+    );
+
+    if (!res.getStatusCode().is2xxSuccessful() || res.getBody() == null) {
+      throw new IllegalStateException("Failed to fetch Naver profile");
+    }
+    NaverUserInfoResponse body = res.getBody();
+    if (!"00".equals(body.getResultcode())) {
+      throw new IllegalStateException("Naver profile error: " + body.getMessage());
+    }
+
+    NaverUserProfile profile = body.getResponse();
+    if (profile.getEmail() == null || profile.getEmail().isBlank()) {
+      throw new IllegalStateException("Naver profile has no email (but email is required).");
+    }
+    return profile;
+  }
+
+  // ===== DTOs =====
+  @Getter @Setter
+  public static class NaverTokenResponse {
+    private String access_token;
+    private String refresh_token;
+    private String token_type;     // e.g., "bearer"
+    private String expires_in;     // seconds as string
+    private String error;
+    private String error_description;
+    private String id_token;       // (OIDC scope일 때만)
+  }
+
+  @Getter @Setter
+  public static class NaverUserInfoResponse {
+    private String resultcode; // "00" 이면 성공
+    private String message;
+    private NaverUserProfile response;
+  }
+
+  @Getter @Setter
+  public static class NaverUserProfile {
+    private String id;        // 고유 식별자 (필수)
+    private String email;     // 동의/인증 시
+    private String name;      // 동의 시
+    private String nickname;  // 동의 시
+    private String birthday;  // "MM-DD" (scope: birthday)
+    private String birthyear; // "YYYY" (scope: birthyear)
+    private String mobile;    // 동의 시
+    // 필요 시 필드 추가
+  }
+}

--- a/back/src/main/java/com/qmate/domain/auth/SocialAccountService.java
+++ b/back/src/main/java/com/qmate/domain/auth/SocialAccountService.java
@@ -40,6 +40,22 @@ public class SocialAccountService {
     );
   }
 
+  @Transactional
+  public User upsertNaverUser(String naverId, String email, String nickname, LocalDate birthDate) {
+    String normalizedEmail = (email != null) ? email.trim().toLowerCase() : null;
+    String safeNickname = (nickname != null && !nickname.isBlank())
+        ? nickname
+        : (normalizedEmail != null ? normalizedEmail : "user_naver_" + naverId);
+
+    return upsertSocialUser(
+        UserSocialAccount.SocialProvider.NAVER,
+        naverId,
+        normalizedEmail,
+        safeNickname,
+        birthDate
+    );
+  }
+
   /**
    * 소셜 로그인 정보로 사용자 upsert + 소셜계정 연결
    * 규칙:

--- a/back/src/main/resources/application-doc.yml
+++ b/back/src/main/resources/application-doc.yml
@@ -42,10 +42,13 @@ app:
   #    success-url: https://q-mate.vercel.app/login/success
   oauth:
     google:
-      client-id: dummy-client-id                 # ← 고정값
-      client-secret: dummy-client-secret         # ← 고정값
-      redirect-uri: https://example.com/callback # 아무 문자열 OK
-
+      client-id: dummy-client-id
+      client-secret: dummy-client-secret
+      redirect-uri: https://example.com/callback
+    naver:
+      client-id: dummy-client-id
+      client-secret: dummy-client-secret
+      redirect-uri: https://q-mate.vercel.app/login/oauth2/code/naver
 # 필요 시 springdoc 커스터마이즈(옵션)
 # springdoc:
 #   api-docs:

--- a/back/src/main/resources/application-prod.yml
+++ b/back/src/main/resources/application-prod.yml
@@ -82,9 +82,11 @@ app:
     google:
       client-id: ${OAUTH_GOOGLE_CLIENT_ID}
       client-secret: ${OAUTH_GOOGLE_CLIENT_SECRET}
-      # 프론트가 code를 받는 콜백 주소
       redirect-uri: https://q-mate.vercel.app/login/oauth2/code/google
-
+    naver:
+      client-id: ${OAUTH_NAVER_CLIENT_ID}
+      client-secret: ${OAUTH_NAVER_CLIENT_SECRET}
+      redirect-uri: https://q-mate.vercel.app/login/oauth2/code/naver
 server:
   port: 8080
   forward-headers-strategy: native


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

- 백 주도 네이버 로그인 플로우/엔드포인트 존재
- 프로트 주도 네이버 로그인 플로우/엔드포인트 부재.
- 서로 다른 도메인이어서 에러 발생

**TO-BE**
네이버 로그인도 구글과 동일 플로우로 지원

> 프론트가 https://q-mate.vercel.app/login/oauth2/code/naver에서 code/state 수령
> 백엔드 /auth/naver/exchange에 { code, state, redirectUri } POST
> 백엔드에서 토큰 교환 → openapi.naver.com/v1/nid/me 프로필 조회(이메일 필수 검증) → 사용자 upsert → JWT 발급 응답
> 시큐리티에 /auth/naver/exchange 허용 추가.
> application-local.yml에 app.oauth.naver 설정 추가(redirect-uri를 프론트 콜백으로 고정).
> 공통 upsert 로직에 NAVER 분기 추가.

주요 변경 파일

> com.qmate.api.NaverAuthController : /auth/naver/exchange 엔드포인트 신규
> com.qmate.domain.auth.NaverOAuthService : code→token, access_token→프로필 조회 + 이메일 필수 검증
> com.qmate.domain.auth.SocialAccountService : upsertNaverUser(...) 추가
> com.qmate.config.SecurityConfig : permitAll 경로에 /auth/naver/exchange 추가
> application-local.yml : app.oauth.naver.client-id|client-secret|redirect-uri 추가