### PR TITLE
feat: status 파라미터 미지정 시 EXPIRED 자동 제외

### DIFF
--- a/back/src/main/java/com/qmate/domain/questioninstance/repository/QuestionInstanceQueryRepositoryImpl.java
+++ b/back/src/main/java/com/qmate/domain/questioninstance/repository/QuestionInstanceQueryRepositoryImpl.java
@@ -1,15 +1,12 @@
 package com.qmate.domain.questioninstance.repository;
 
 
-import static com.qmate.domain.question.entity.QQuestion.question;
 import static com.qmate.domain.question.entity.QCustomQuestion.customQuestion;
-import static com.qmate.domain.question.entity.QQuestionCategory.questionCategory;
+import static com.qmate.domain.question.entity.QQuestion.question;
 import static com.qmate.domain.questioninstance.entity.QQuestionInstance.questionInstance;
-import static com.qmate.domain.match.QMatch.match;
 import static com.qmate.domain.user.QUser.user;
 
 import com.qmate.domain.questioninstance.entity.QuestionInstanceStatus;
-import com.qmate.domain.questioninstance.entity.QuestionInstance;
 import com.qmate.domain.questioninstance.model.response.QIListItem;
 import com.qmate.domain.questioninstance.model.response.QQIListItem;
 import com.qmate.exception.custom.questioninstance.QIInvalidSortKeyException;
@@ -99,7 +96,7 @@ public class QuestionInstanceQueryRepositoryImpl implements QuestionInstanceQuer
         .where(
             questionInstance.match.id.eq(matchId),
             requesterInMatch(requesterId),          // ← 추가: 권한 검증(현재 매치 일치)
-            statusEq(status),
+            statusFilter(status),
             deliveredFrom(from),
             deliveredTo(to)
         )
@@ -115,7 +112,7 @@ public class QuestionInstanceQueryRepositoryImpl implements QuestionInstanceQuer
         .where(
             questionInstance.match.id.eq(matchId),
             requesterInMatch(requesterId),          // ← 추가: content와 동일 조건
-            statusEq(status),
+            statusFilter(status),
             deliveredFrom(from),
             deliveredTo(to)
         )
@@ -125,16 +122,20 @@ public class QuestionInstanceQueryRepositoryImpl implements QuestionInstanceQuer
   }
 
   // ---- Predicates (nullable → 무시) ----
-  private BooleanExpression statusEq(QuestionInstanceStatus status) {
-    return status == null ? null : questionInstance.status.eq(status);
-  }
-
   private BooleanExpression deliveredFrom(LocalDateTime from) {
     return from == null ? null : questionInstance.deliveredAt.goe(from);
   }
 
   private BooleanExpression deliveredTo(LocalDateTime to) {
     return to == null ? null : questionInstance.deliveredAt.lt(to);
+  }
+
+  /** 상태 필터: null이면 EXPIRED 자동 제외, 지정되면 해당 상태만 */
+  private BooleanExpression statusFilter(QuestionInstanceStatus status) {
+    if (status == null) {
+      return questionInstance.status.ne(QuestionInstanceStatus.EXPIRED);
+    }
+    return questionInstance.status.eq(status);
   }
 
   /** 요청자의 currentMatchId가 대상 QI의 match.id와 같은지 검증 */


### PR DESCRIPTION
## 배경
질문 인스턴스 목록 조회 API에서 `status` 파라미터를 전달하지 않은 경우에도 만료된(EXPIRED) 항목이 포함되어 UX 저하가 있었습니다. 기본적으로는 사용자가 확인해야 할 유효 항목 중심으로 노출하고, 필요 시 명시적으로 `EXPIRED`를 요청하도록 방향을 조정했습니다.

## 변경 사항
- `statusEq(status)` → `statusFilter(status)`로 교체 (content/total 쿼리 모두)
- `statusFilter` 프레디킷 추가:
  - `status == null` → `question_instance.status != EXPIRED`
  - `status != null` → `question_instance.status == status` (기존 동작 유지)