### PR TITLE
fix: 커스텀 질문 삭제 불가 이슈 수정 — 트랜잭션 readOnly 범위 조정

### DIFF
--- a/back/src/main/java/com/qmate/domain/question/service/CustomQuestionService.java
+++ b/back/src/main/java/com/qmate/domain/question/service/CustomQuestionService.java
@@ -20,7 +20,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class CustomQuestionService {
 
   private final CustomQuestionRepository customQuestionRepository;
@@ -95,6 +94,7 @@ public class CustomQuestionService {
    * @param id 조회할 커스텀 질문 ID
    * @return 커스텀 질문 정보
    */
+  @Transactional(readOnly = true)
   public CustomQuestionResponse getOne(Long userId, Long id) {
     CustomQuestion entity = customQuestionRepository.findByIdAndCreatedBy(id, userId)
         .orElseThrow(CustomQuestionNotFoundException::new);
@@ -113,6 +113,7 @@ public class CustomQuestionService {
    * @param pageable    페이징 정보
    * @return 필터링된 커스텀 질문 목록 (페이징)
    */
+  @Transactional(readOnly = true)
   public Page<CustomQuestionResponse> findPageByOwnerAndStatusFilter(Long ownerUserId, Long matchId, CustomQuestionStatusFilter status,
       Pageable pageable) {
     return customQuestionRepository.findPageByOwnerAndStatusFilter(ownerUserId, matchId, status, pageable);


### PR DESCRIPTION
## 배경
- **증상**: 커스텀 질문 `delete()`가 실행되지 않는(또는 실행된 것처럼 보이지 않는) 이슈가 발생.
- **원인**: 서비스 클래스 레벨에 `@Transactional(readOnly = true)`가 걸려 있어, 삭제 같은 쓰기 동작이 **읽기 전용 트랜잭션** 하에서 수행됨.

## 변경 사항
1. **클래스 레벨 `@Transactional(readOnly = true)` 제거**
2. **조회 메서드에만 `@Transactional(readOnly = true)` 개별 부여**
3. **삭제 메서드(`delete`)에는 트랜잭션 어노테이션을 달지 않음**
   - 목적: 쓰기 동작이 readOnly 트랜잭션의 영향을 받지 않도록 분리