### PR TITLE
chore:월변경 시 리스트 데이터 남아있는 현상 수정

### DIFF
--- a/front/src/components/schedule/ScheduleView.tsx
+++ b/front/src/components/schedule/ScheduleView.tsx
@@ -79,7 +79,11 @@ export default function ScheduleView() {
           anniversarySet={anniversarySet}
           scheduleSet={scheduleSet}
           displayMonth={displayMonth}
-          onDisplayMonthChange={(d) => setDisplayMonth(new Date(d.getFullYear(), d.getMonth(), 1))}
+          onDisplayMonthChange={(d) => {
+            const firstDay = new Date(d.getFullYear(), d.getMonth(), 1);
+            setDisplayMonth(firstDay);
+            setSelected(firstDay);
+          }}
         />
         <EventList
           date={selected ?? new Date()}


### PR DESCRIPTION
## 📝 작업 내용

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [x] 기타 (설명)

## 🔍 변경 사항
-달력 리스트에 이전 달 선택했던 날짜데이터가 유지되어 월 이동 시 해당 월의 1일이 선택 되어 있도록 수정