### PR TITLE
feat: QI 6시간 전 미답변 리마인더 구현 + 테스트 추가

### DIFF
--- a/back/src/main/java/com/qmate/domain/notification/repository/NotificationRepository.java
+++ b/back/src/main/java/com/qmate/domain/notification/repository/NotificationRepository.java
@@ -3,6 +3,7 @@ package com.qmate.domain.notification.repository;
 import com.qmate.domain.notification.entity.Notification;
 import com.qmate.domain.notification.entity.NotificationCategory;
 import com.qmate.domain.notification.entity.NotificationCode;
+import com.qmate.domain.notification.entity.NotificationResourceType;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -54,4 +55,11 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
          and n.readAt is null
       """)
   long countAuthorizedUnread(@Param("userId") Long userId);
+
+  boolean existsByUserIdAndCodeAndResourceTypeAndResourceId(
+      Long userId,
+      NotificationCode code,
+      NotificationResourceType resourceType,
+      Long resourceId
+  );
 }

--- a/back/src/main/java/com/qmate/domain/questioninstance/repository/QuestionInstanceRepository.java
+++ b/back/src/main/java/com/qmate/domain/questioninstance/repository/QuestionInstanceRepository.java
@@ -5,6 +5,7 @@ import com.qmate.domain.questioninstance.entity.QuestionInstance;
 import com.qmate.domain.questioninstance.entity.QuestionInstanceStatus;
 import jakarta.persistence.LockModeType;
 import jakarta.persistence.QueryHint;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -37,18 +38,18 @@ public interface QuestionInstanceRepository extends JpaRepository<QuestionInstan
   );
 
   @Query("""
-    select qi
-    from QuestionInstance qi
-    join fetch qi.match m
-    join fetch m.members mm
-    join fetch mm.user u
-    where qi.id = :qiId
-      and qi.match.id = (
-        select u.currentMatchId
-        from User u
-        where u.id = :userId
-      )
-    """)
+      select qi
+      from QuestionInstance qi
+      join fetch qi.match m
+      join fetch m.members mm
+      join fetch mm.user u
+      where qi.id = :qiId
+        and qi.match.id = (
+          select u.currentMatchId
+          from User u
+          where u.id = :userId
+        )
+      """)
   Optional<QuestionInstance> findAuthorizedByIdForUser(
       @Param("qiId") Long questionInstanceId,
       @Param("userId") Long userId
@@ -56,7 +57,8 @@ public interface QuestionInstanceRepository extends JpaRepository<QuestionInstan
 
   @Lock(LockModeType.PESSIMISTIC_WRITE)
   @Query("select qi from QuestionInstance qi where qi.id = :qiId")
-  @QueryHints(@QueryHint(name = "jakarta.persistence.lock.timeout", value = "1000")) // ms
+  @QueryHints(@QueryHint(name = "jakarta.persistence.lock.timeout", value = "1000"))
+    // ms
   Optional<QuestionInstance> findByIdForUpdate(Long qiId);
 
   boolean existsByCustomQuestion_Id(Long customQuestionId);
@@ -79,5 +81,37 @@ public interface QuestionInstanceRepository extends JpaRepository<QuestionInstan
       @Param("hour") int hour,
       @Param("active") MatchStatus active,
       @Param("pending") QuestionInstanceStatus pending
+  );
+
+  /**
+   * 6시간 전의 "같은 시(hour)" 안에서 0~50분 사이에 delivered된, 아직 PENDING 상태인 QI 를 대상으로
+   * - 매치가 ACTIVE 이고
+   * - 해당 QI 에 대해 아직 답변(Answer)이 없는 사용자만 을 반환한다. (중복/불필요 조인 최소화)
+   */
+  @Query(value = """
+      SELECT
+          qi.question_instance_id AS qiId,
+          m.match_id              AS matchId,
+          mm.user_id              AS userId,
+          u.push_enabled          AS pushEnabled
+      FROM question_instance qi
+      JOIN `match` m 
+        ON m.match_id = qi.match_id 
+       AND m.status   = 'ACTIVE'
+      JOIN match_member mm 
+        ON mm.match_id = m.match_id
+      LEFT JOIN answer a 
+        ON a.question_instance_id = qi.question_instance_id
+       AND a.user_id              = mm.user_id
+      JOIN `user` u 
+        ON u.user_id = mm.user_id
+      WHERE qi.status = 'PENDING'
+        AND qi.delivered_at >= :start
+        AND qi.delivered_at  < :end
+        AND a.answer_id IS NULL
+      """, nativeQuery = true)
+  List<ReminderTargetRow> findReminderTargetsBetween(
+      @Param("start") LocalDateTime start,
+      @Param("end") LocalDateTime end
   );
 }

--- a/back/src/main/java/com/qmate/domain/questioninstance/repository/ReminderTargetRow.java
+++ b/back/src/main/java/com/qmate/domain/questioninstance/repository/ReminderTargetRow.java
@@ -1,0 +1,12 @@
+package com.qmate.domain.questioninstance.repository;
+
+public interface ReminderTargetRow {
+
+  Long getQiId();
+
+  Long getMatchId();
+
+  Long getUserId();
+
+  Boolean getPushEnabled();
+}

--- a/back/src/main/java/com/qmate/domain/questioninstance/service/QuestionInstanceAlarmService.java
+++ b/back/src/main/java/com/qmate/domain/questioninstance/service/QuestionInstanceAlarmService.java
@@ -3,7 +3,6 @@ package com.qmate.domain.questioninstance.service;
 import com.qmate.common.push.PushSender;
 import com.qmate.domain.match.MatchMember;
 import com.qmate.domain.match.MatchStatus;
-import com.qmate.domain.match.repository.MatchMemberRepository;
 import com.qmate.domain.notification.entity.Notification;
 import com.qmate.domain.notification.entity.NotificationCategory;
 import com.qmate.domain.notification.entity.NotificationCode;
@@ -11,25 +10,29 @@ import com.qmate.domain.notification.entity.NotificationResourceType;
 import com.qmate.domain.notification.repository.NotificationRepository;
 import com.qmate.domain.questioninstance.entity.QuestionInstance;
 import com.qmate.domain.questioninstance.entity.QuestionInstanceStatus;
+import com.qmate.domain.questioninstance.repository.AnswerRepository;
 import com.qmate.domain.questioninstance.repository.QuestionInstanceRepository;
+import com.qmate.domain.questioninstance.repository.ReminderTargetRow;
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class QuestionInstanceAlarmService {
 
   private final QuestionInstanceRepository qiRepository;
   private final NotificationRepository notificationRepository;
+  private final AnswerRepository answerRepository;
   private final PushSender pushSender;
 
   /**
-   * 매 정각에 실행: 아직 delivered_at이 null인 PENDING QI를 발송/기록하고,
-   * 매치 멤버 2명에게 알림 생성 후, 알림설정에 따라 전송한다.
+   * 매 정각에 실행: 아직 delivered_at이 null인 PENDING QI를 발송/기록하고, 매치 멤버 2명에게 알림 생성 후, 알림설정에 따라 전송한다.
    */
   @Transactional
   public void dispatchTopOfHour(ZonedDateTime nowKst) {
@@ -61,6 +64,52 @@ public class QuestionInstanceAlarmService {
 
         if (mm.getUser().isPushEnabled()) {
           pushSender.send(notification);
+        }
+      }
+    }
+  }
+
+  @Transactional
+  public void remindAfterSixHours(ZonedDateTime nowKst) {
+    // 기준 시각: 정확히 6시간 전
+    LocalDateTime targetHourStart = nowKst.minusHours(6)
+        .withMinute(0).withSecond(0).withNano(0)
+        .toLocalDateTime();
+    LocalDateTime targetHourEnd = targetHourStart.plusMinutes(50);
+
+    // 6시간 전에 노출되었고 아직 PENDING인 QI들 (매치 & 멤버까지 페치된 상태)
+    List<ReminderTargetRow> targets =
+        qiRepository.findReminderTargetsBetween(targetHourStart, targetHourEnd);
+
+    for (ReminderTargetRow target : targets) {
+      boolean alreadyNotified = notificationRepository
+          .existsByUserIdAndCodeAndResourceTypeAndResourceId(
+              target.getUserId(),
+              NotificationCode.QI_REMINDER,
+              NotificationResourceType.QUESTION_INSTANCE,
+              target.getQiId()
+          );
+      if (alreadyNotified) {
+        continue;
+      }
+
+      Notification n = Notification.builder()
+          .userId(target.getUserId())
+          .matchId(target.getMatchId())
+          .category(NotificationCategory.QUESTION)
+          .code(NotificationCode.QI_REMINDER)
+          .pushTitle(NotificationCode.QI_REMINDER.getDescription())
+          .listTitle(NotificationCode.QI_REMINDER.getDescription())
+          .resourceType(NotificationResourceType.QUESTION_INSTANCE)
+          .resourceId(target.getQiId())
+          .build();
+
+      notificationRepository.save(n);
+      if (Boolean.TRUE.equals(target.getPushEnabled())) {
+        try {
+          pushSender.send(n);
+        } catch (Exception e) {
+          log.error("QI_REMINDER 푸시 전송 실패. userId={}, qiId={}", target.getUserId(), target.getQiId(), e);
         }
       }
     }

--- a/back/src/main/java/com/qmate/schedule/DailyQuestionScheduler.java
+++ b/back/src/main/java/com/qmate/schedule/DailyQuestionScheduler.java
@@ -28,6 +28,8 @@ public class DailyQuestionScheduler {
   // 매 정각 실행
   @Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul")
   public void runTopOfHour() {
-    alarmService.dispatchTopOfHour(ZonedDateTime.now(ZONE_KST));
+    ZonedDateTime now = ZonedDateTime.now(ZONE_KST);
+    alarmService.dispatchTopOfHour(now);     // 정각 QI 전달
+    alarmService.remindAfterSixHours(now);   // 6시간 전 미답변 리마인드
   }
 }

--- a/back/src/test/java/com/qmate/domain/quetioninstance/repository/QuestionInstanceRepositoryQueryTest.java
+++ b/back/src/test/java/com/qmate/domain/quetioninstance/repository/QuestionInstanceRepositoryQueryTest.java
@@ -1,0 +1,174 @@
+package com.qmate.domain.quetioninstance.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.qmate.config.JpaConfig;
+import com.qmate.config.QuerydslConfig;
+import com.qmate.domain.match.Match;
+import com.qmate.domain.match.MatchMember;
+import com.qmate.domain.match.MatchStatus;
+import com.qmate.domain.match.RelationType;
+import com.qmate.domain.question.entity.CustomQuestion;
+import com.qmate.domain.questioninstance.entity.QuestionInstance;
+import com.qmate.domain.questioninstance.entity.QuestionInstanceStatus;
+import com.qmate.domain.questioninstance.repository.QuestionInstanceRepository;
+import com.qmate.domain.questioninstance.repository.ReminderTargetRow;
+import com.qmate.domain.user.User;
+import com.qmate.domain.questioninstance.entity.Answer;
+import java.time.LocalDateTime;
+import java.time.Month;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+@DataJpaTest
+@Import({JpaConfig.class, QuerydslConfig.class})
+//@Tag("local")
+class QuestionInstanceRepositoryQueryTest {
+
+  @Autowired
+  private TestEntityManager tem;
+  @Autowired
+  private QuestionInstanceRepository repository;
+
+  private Match matchActive;
+
+  private User userPushOn;   // pushEnabled = true
+  private User userPushOff;  // pushEnabled = false
+
+  private CustomQuestion cqMatchAcive;
+
+  @BeforeEach
+  void setUp() {
+    // 매치 2개
+    matchActive = tem.persist(Match.builder()
+        .relationType(RelationType.COUPLE)
+        .status(MatchStatus.ACTIVE)
+        .startDate(LocalDateTime.now())
+        .createdAt(LocalDateTime.now())
+        .updatedAt(LocalDateTime.now())
+        .build());
+
+    // 유저 2명 (푸시 on/off)
+    userPushOn = tem.persist(User.builder()
+        .email("pushon@test.com")
+        .nickname("on")
+        .pushEnabled(true)
+        .currentMatchId(matchActive.getId())
+        .build());
+
+    userPushOff = tem.persist(User.builder()
+        .email("pushoff@test.com")
+        .nickname("off")
+        .pushEnabled(false)
+        .currentMatchId(matchActive.getId())
+        .build());
+
+    cqMatchAcive = tem.persist(CustomQuestion.builder()
+        .match(matchActive)
+        .createdBy(userPushOn.getId())
+        .text("CQ for Active")
+        .build());
+
+    // 매치 멤버 등록
+    tem.persist(MatchMember.builder().match(matchActive).user(userPushOn).build());
+    tem.persist(MatchMember.builder().match(matchActive).user(userPushOff).build());
+
+    tem.flush();
+    tem.clear();
+  }
+
+  @Nested
+  @DisplayName("findReminderTargetsBetween")
+  class FindReminderTargetsBetween {
+
+    @Test
+    @DisplayName("윈도우[11:00,11:50) & PENDING & ACTIVE 매치 & 미답변만 반환, pushEnabled 값까지 매핑")
+    void returnsOnlyUnansweredUsersWithinWindow() {
+      // given: 2025-01-10 11:00 ~ 11:50
+      LocalDateTime start = LocalDateTime.of(2025, Month.JANUARY, 10, 11, 0, 0);
+      LocalDateTime end = start.plusMinutes(50);
+
+      // QI #1: 대상 — PENDING, delivered=11:30, match=ACTIVE
+      QuestionInstance qiIn = tem.persist(QuestionInstance.builder()
+          .match(matchActive)
+          .customQuestion(cqMatchAcive)
+          .status(QuestionInstanceStatus.PENDING)
+          .deliveredAt(LocalDateTime.of(2025, 1, 10, 11, 30, 0))
+          .build());
+
+      // QI #2: 윈도우 밖 — 11:55
+      QuestionInstance qiOutOfWindow = tem.persist(QuestionInstance.builder()
+          .match(matchActive)
+          .customQuestion(cqMatchAcive)
+          .status(QuestionInstanceStatus.PENDING)
+          .deliveredAt(LocalDateTime.of(2025, 1, 10, 11, 55, 0))
+          .build());
+
+      // 같은 QI #1에 대해 userPushOff는 이미 답변 → 제외되어야 함
+      tem.persist(Answer.builder()
+          .questionInstance(qiIn)
+          .userId(userPushOff.getId())
+          .content("done") // 실제 필드명/필수 값에 맞게 수정
+          .submittedAt(LocalDateTime.now())
+          .build());
+
+      tem.flush();
+      tem.clear();
+
+      // when
+      List<ReminderTargetRow> rows = repository.findReminderTargetsBetween(start, end);
+
+      // then: QI #1 × userPushOn 만 반환 (미답변 + pushEnabled=true)
+      assertThat(rows)
+          .hasSize(1)
+          .allSatisfy(r -> {
+            assertThat(r.getQiId()).isEqualTo(qiIn.getId());
+            assertThat(r.getMatchId()).isEqualTo(matchActive.getId());
+            assertThat(r.getUserId()).isEqualTo(userPushOn.getId());
+            assertThat(r.getPushEnabled()).isTrue();
+          });
+    }
+
+    @Test
+    @DisplayName("PENDING 아님 / ACTIVE 아님 / 윈도우 밖 / 다른 매치 → 모두 제외")
+    void excludesNonPendingNonActiveOutOfWindowOtherMatch() {
+      LocalDateTime start = LocalDateTime.of(2025, Month.JANUARY, 10, 11, 0, 0);
+      LocalDateTime end = start.plusMinutes(50);
+
+      // (제외) COMPLETED 상태
+      tem.persist(QuestionInstance.builder()
+          .match(matchActive)
+          .customQuestion(cqMatchAcive)
+          .status(QuestionInstanceStatus.COMPLETED)
+          .deliveredAt(LocalDateTime.of(2025, 1, 10, 11, 10, 0))
+          .build());
+
+      // (제외) 윈도우 경계 end(11:50) — 반개구간 밖
+      tem.persist(QuestionInstance.builder()
+          .match(matchActive)
+          .customQuestion(cqMatchAcive)
+          .status(QuestionInstanceStatus.PENDING)
+          .deliveredAt(LocalDateTime.of(2025, 1, 10, 11, 50, 0))
+          .build());
+
+      tem.flush();
+      tem.clear();
+
+      List<ReminderTargetRow> rows = repository.findReminderTargetsBetween(start, end);
+
+      assertThat(rows).isEmpty();
+    }
+  }
+}

--- a/back/src/test/java/com/qmate/domain/quetioninstance/repository/QuestionInstanceRepositoryTest.java
+++ b/back/src/test/java/com/qmate/domain/quetioninstance/repository/QuestionInstanceRepositoryTest.java
@@ -29,7 +29,7 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles("test")
 @Import({JpaConfig.class, QuerydslConfig.class})
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-//@Tag("local")
+@Tag("local")
 class QuestionInstanceRepositoryTest {
 
   @Autowired

--- a/back/src/test/java/com/qmate/domain/quetioninstance/service/QuestionInstanceAlarmServiceTest.java
+++ b/back/src/test/java/com/qmate/domain/quetioninstance/service/QuestionInstanceAlarmServiceTest.java
@@ -9,6 +9,8 @@ import com.qmate.domain.notification.repository.NotificationRepository;
 import com.qmate.domain.questioninstance.entity.QuestionInstance;
 import com.qmate.domain.questioninstance.entity.QuestionInstanceStatus;
 import com.qmate.domain.questioninstance.repository.QuestionInstanceRepository;
+import com.qmate.domain.questioninstance.repository.ReminderTargetRow;
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -80,5 +82,102 @@ class QuestionInstanceAlarmServiceTest {
 
     // pushEnabled=true 인 user1 에 대해서만 실제 전송
     verify(pushSender, times(1)).send(any(Notification.class));
+  }
+
+  @Test
+  @DisplayName("리마인더: 6시간 전 같은 시(0~50) delivered & 미답변 대상 → 알림 생성, pushEnabled만 푸시")
+  void remindAfterSixHours_createNotiAndSendPushConditionally() {
+    // given
+    ZonedDateTime now = ZonedDateTime.of(2025, 1, 10, 17, 1, 0, 0, KST);
+    var expectedStart = now.minusHours(6).withMinute(0).withSecond(0).withNano(0).toLocalDateTime(); // 11:00
+    var expectedEnd = expectedStart.plusMinutes(50); // 11:50
+
+    // 리마인더 대상 프젝션 스텁
+    ReminderTargetRow rowPushOn = stubRow(1001L, 11L, 201L, true);
+    ReminderTargetRow rowPushOff = stubRow(1002L, 11L, 202L, false);
+
+    given(qiRepository.findReminderTargetsBetween(expectedStart, expectedEnd))
+        .willReturn(List.of(rowPushOn, rowPushOff));
+
+    // 중복 알림 없음
+    given(notificationRepository.existsByUserIdAndCodeAndResourceTypeAndResourceId(
+        anyLong(), any(), any(), anyLong())).willReturn(false);
+
+    // when
+    service.remindAfterSixHours(now);
+
+    // then
+    // 알림은 2건 모두 생성
+    ArgumentCaptor<Notification> notiCaptor = ArgumentCaptor.forClass(Notification.class);
+    verify(notificationRepository, times(2)).save(notiCaptor.capture());
+    assertThat(notiCaptor.getAllValues())
+        .extracting(Notification::getUserId)
+        .containsExactlyInAnyOrder(201L, 202L);
+
+    // pushEnabled=true 인 대상에게만 푸시 1회
+    verify(pushSender, times(1)).send(any(Notification.class));
+
+    // 시간창 파라미터 정확히 전달되었는지도 검증
+    verify(qiRepository).findReminderTargetsBetween(expectedStart, expectedEnd);
+  }
+
+  @Test
+  @DisplayName("리마인더: 동일 알림 존재 시 생성·전송 스킵")
+  void remindAfterSixHours_skipIfAlreadyNotified() {
+    // given
+    ZonedDateTime now = ZonedDateTime.of(2025, 1, 10, 17, 5, 0, 0, KST);
+    LocalDateTime start = now.minusHours(6).withMinute(0).withSecond(0).withNano(0).toLocalDateTime();
+    LocalDateTime end = start.plusMinutes(50);
+
+    ReminderTargetRow row = stubRow(1001L, 11L, 201L, true);
+    given(qiRepository.findReminderTargetsBetween(start, end))
+        .willReturn(List.of(row));
+
+    // 이미 같은 알림 있음
+    given(notificationRepository.existsByUserIdAndCodeAndResourceTypeAndResourceId(
+        eq(201L), any(), any(), eq(1001L))).willReturn(true);
+
+    // when
+    service.remindAfterSixHours(now);
+
+    // then
+    verify(notificationRepository, never()).save(any());
+    verify(pushSender, never()).send(any());
+  }
+
+  @Test
+  @DisplayName("리마인더: 푸시 전송 실패해도 예외 전파 없이 진행(알림 레코드는 유지)")
+  void remindAfterSixHours_pushFailureIsCaught() {
+    // given
+    ZonedDateTime now = ZonedDateTime.of(2025, 1, 10, 17, 10, 0, 0, KST);
+    LocalDateTime start = now.minusHours(6).withMinute(0).withSecond(0).withNano(0).toLocalDateTime();
+    LocalDateTime end = start.plusMinutes(50);
+
+    ReminderTargetRow row = stubRow(1001L, 11L, 201L, true);
+    given(qiRepository.findReminderTargetsBetween(start, end))
+        .willReturn(List.of(row));
+
+    given(notificationRepository.existsByUserIdAndCodeAndResourceTypeAndResourceId(anyLong(), any(), any(), anyLong()))
+        .willReturn(false);
+
+    // pushSender가 예외 던짐 → 테스트 대상 코드가 try-catch로 흡수해야 함
+    willThrow(new RuntimeException("push failed")).given(pushSender).send(any(Notification.class));
+
+    // when & then (예외 안터져야 함)
+    service.remindAfterSixHours(now);
+
+    // 알림은 저장되었고
+    verify(notificationRepository, times(1)).save(any(Notification.class));
+    // 푸시는 시도되었으나 실패 → 예외 전파 없음
+    verify(pushSender, times(1)).send(any(Notification.class));
+  }
+
+  private static ReminderTargetRow stubRow(Long qiId, Long matchId, Long userId, boolean pushEnabled) {
+    return new ReminderTargetRow() {
+      @Override public Long getQiId() { return qiId; }
+      @Override public Long getMatchId() { return matchId; }
+      @Override public Long getUserId() { return userId; }
+      @Override public Boolean getPushEnabled() { return pushEnabled; }
+    };
   }
 }


### PR DESCRIPTION
## 개요
- 6시간 전의 동일 시(hour) 창(0~50분)에 delivered된 **PENDING QI** 중에서, **아직 답변하지 않은 사용자**에게 **리마인더 알림을 생성**하고, 사용자 설정(`pushEnabled`)에 따라 **푸시 전송**까지 수행합니다.
- 정각 분배(Top-of-hour)와 함께 스케줄러에서 동작하도록 연결했습니다.
- 서비스/리포지토리 테스트를 포함합니다.

## 주요 변경 사항
- **Repository**: 시간 창 [start, end) 기반의 리마인더 대상 조회(미답변 사용자, ACTIVE 매치, PENDING QI, pushEnabled 조회 포함).
- **Service**: 리마인더 처리 메서드 추가
  - 알림은 항상 생성.
  - 푸시는 pushEnabled일 때만 시도하며, 전송 실패는 예외 흡수(로그 기록).
- **Scheduler**: 정각 잡에서 리마인더 호출 추가(정각 분배와 함께 실행).

## 테스트
- **Service (BDD Mockito)**
  - 알림 항상 생성 + pushEnabled에 따른 전송 분기 검증.
  - 동일 알림 존재 시 생성/전송 스킵 검증.
  - 푸시 전송 실패 시 예외 흡수 동작 검증.
- **Repository (TestEntityManager 기반)**
  - 시간 창 [start, end) + PENDING + 미답변 사용자만 반환 검증.
  - 윈도우 밖/상태 불일치 시 제외 검증.